### PR TITLE
better parameter and return standardization

### DIFF
--- a/src/api/route_models/category.py
+++ b/src/api/route_models/category.py
@@ -4,15 +4,18 @@ from db.category import Category
 
 
 class CategoryResponse(BaseRouteModel):
-    name: str
-    name_hash: str
+    category_name: str
+    category_name_hash: str
 
     model_config = {
         "json_schema_extra": {
-            "example": {"name": "Technology", "name_hash": "982d98h98hf1uhfdi1sdhu"}
+            "example": {
+                "category_name": "Technology",
+                "category_name_hash": "982d98h98hf1uhfdi1sdhu",
+            }
         }
     }
 
     @classmethod
     def from_db_model(cls, db_model: Category):
-        return cls(name=db_model.name, name_hash=db_model.name_hash)
+        return cls(category_name=db_model.name, category_name_hash=db_model.name_hash)

--- a/src/api/route_models/feed.py
+++ b/src/api/route_models/feed.py
@@ -5,16 +5,16 @@ from .base import BaseRouteModel
 
 
 class FeedResponse(BaseRouteModel):
-    name: str
-    name_hash: str
+    feed_name: str
+    feed_name_hash: str
     feed_url: HttpUrl
     feed_category: str
 
     @classmethod
     def from_db_model(cls, db_model: Feed):
         return cls(
-            name=db_model.name,
-            name_hash=db_model.name_hash,
+            feed_name=db_model.name,
+            feed_name_hash=db_model.name_hash,
             feed_url=db_model.url,
             feed_category=db_model.category_hash,
         )

--- a/src/api/route_models/item.py
+++ b/src/api/route_models/item.py
@@ -8,24 +8,39 @@ from db.item import ItemLoose
 
 
 class ItemResponse(BaseRouteModel):
-    url: HttpUrl
-    author: Optional[str] = None
-    date_published: Optional[datetime] = None
-    image_url: Optional[str] = None
-    title: Optional[str] = None
-    domain: Optional[str] = None
-    excerpt: Optional[str] = None
-    content: Optional[str] = None
+    item_url: HttpUrl
+    item_author: Optional[str] = None
+    item_date_published: Optional[datetime] = None
+    item_image_url: Optional[str] = None
+    item_title: Optional[str] = None
+    item_domain: Optional[str] = None
+    item_excerpt: Optional[str] = None
+    item_content: Optional[str] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "item_url": "https://example.com",
+                "item_author": "John Doe",
+                "item_date_published": "2021-01-01T00:00:00",
+                "item_image_url": "https://example.com/image.jpg",
+                "item_title": "Example Title",
+                "item_domain": "example.com",
+                "item_excerpt": "This is an example excerpt.",
+                "item_content": "This is an example content. it's longer than the excerpt most of the time.",
+            }
+        }
+    }
 
     @classmethod
     def from_db_model(cls, db_model: ItemLoose):
         return cls(
-            url=db_model.url,
-            author=db_model.author,
-            date_published=db_model.date_published,
-            image_url=db_model.image_url,
-            title=db_model.title,
-            domain=db_model.domain,
-            excerpt=db_model.excerpt,
-            content=db_model.content,
+            item_url=db_model.url,
+            item_item_author=db_model.author,
+            item_date_published=db_model.date_published,
+            item_image_url=db_model.image_url,
+            item_title=db_model.title,
+            item_domain=db_model.domain,
+            item_excerpt=db_model.excerpt,
+            item_content=db_model.content,
         )

--- a/src/api/routers/category.py
+++ b/src/api/routers/category.py
@@ -27,8 +27,10 @@ def get_category_by_name_hash(user_hash: str, name_hash: str) -> Category:
 @category_router.post(
     "/create", summary="Create a category", response_model=CategoryResponse
 )
-def create_category(name: str, user: User = Depends(authenticate)) -> CategoryResponse:
-    category = Category(user_hash=user.name_hash, name=name)
+def create_category(
+    category_name: str, user: User = Depends(authenticate)
+) -> CategoryResponse:
+    category = Category(user_hash=user.name_hash, name=category_name)
     category.create()
     return CategoryResponse.from_db_model(category)
 

--- a/src/api/tests/routers/category_test.py
+++ b/src/api/tests/routers/category_test.py
@@ -5,7 +5,7 @@ from pydantic import HttpUrl
 def test_create_category(client, unique_category, existing_user, token):
     args = build_api_request_args(
         path="/category/create",
-        params={"name": unique_category.name},
+        params={"category_name": unique_category.name},
         token=token,
     )
 
@@ -13,8 +13,8 @@ def test_create_category(client, unique_category, existing_user, token):
 
     assert response.status_code == 200
     assert response.json() == {
-        "name": unique_category.name,
-        "name_hash": unique_category.name_hash,
+        "category_name": unique_category.name,
+        "category_name_hash": unique_category.name_hash,
     }
 
 
@@ -67,8 +67,8 @@ def test_get_category(client, existing_user, existing_category, token):
 
     assert response.status_code == 200
     assert response.json() == {
-        "name": existing_category.name,
-        "name_hash": existing_category.name_hash,
+        "category_name": existing_category.name,
+        "category_name_hash": existing_category.name_hash,
     }
 
 
@@ -96,8 +96,8 @@ def test_list_categories(client, existing_user, existing_category, token):
     assert response.status_code == 200
     assert response.json() == [
         {
-            "name": existing_category.name,
-            "name_hash": existing_category.name_hash,
+            "category_name": existing_category.name,
+            "category_name_hash": existing_category.name_hash,
         }
     ]
 
@@ -137,8 +137,8 @@ def test_feeds(client, existing_user, existing_category, existing_feed, token):
     assert response.status_code == 200
     assert response.json() == [
         {
-            "name": existing_feed.name,
-            "name_hash": existing_feed.name_hash,
+            "feed_name": existing_feed.name,
+            "feed_name_hash": existing_feed.name_hash,
             "feed_url": str(existing_feed.url),
             "feed_category": existing_feed.category_hash,
         }
@@ -158,7 +158,7 @@ def test_get_all_items(
 
     assert response.status_code == 200
     assert len(response.json()) == 1
-    assert response.json()[0]["url"] == str(existing_item_strict.url)
+    assert response.json()[0]["item_url"] == str(existing_item_strict.url)
 
 
 def test_get_some_items(
@@ -186,5 +186,5 @@ def test_get_some_items(
 
     assert response.status_code == 200
     assert len(response.json()) == 2
-    assert response.json()[0]["url"] == "http://example.com/2/"
-    assert response.json()[1]["url"] == "http://example.com/3/"
+    assert response.json()[0]["item_url"] == "http://example.com/2/"
+    assert response.json()[1]["item_url"] == "http://example.com/3/"

--- a/src/api/tests/routers/feed_test.py
+++ b/src/api/tests/routers/feed_test.py
@@ -78,8 +78,8 @@ def test_feed_with_items(
 
     assert response.status_code == 200
     item_json = response.json()[0]
-    assert item_json["title"] == existing_item_strict.title
-    assert item_json["url"] == str(existing_item_strict.url)
+    assert item_json["item_title"] == existing_item_strict.title
+    assert item_json["item_url"] == str(existing_item_strict.url)
 
 
 def test_delete_feed(client, existing_user, existing_category, existing_feed, token):


### PR DESCRIPTION
closes: #34 

more uniformly adds objectType_field for names of return types and arguments to API calls. This should reduce re-naming within front end(s) and be clear what is what.