### PR TITLE
Add favicon and refactor static asset URLs to use url_for

### DIFF
--- a/src/api/routers/web.py
+++ b/src/api/routers/web.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, FileResponse
 from fastapi.templating import Jinja2Templates
 
-templates = Jinja2Templates(directory=str(Path(__file__).resolve().parent.parent / "templates"))
+BASE_DIR = Path(__file__).resolve().parent.parent
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
 web_router = APIRouter()
 
@@ -16,3 +17,8 @@ async def login_page(request: Request):
 @web_router.get("/app", response_class=HTMLResponse, include_in_schema=False)
 async def app_page(request: Request):
     return templates.TemplateResponse(request=request, name="app.html")
+
+
+@web_router.get("/favicon.ico", include_in_schema=False)
+async def favicon():
+    return FileResponse(BASE_DIR / "static" / "favicon.svg", media_type="image/svg+xml")

--- a/src/api/static/favicon.svg
+++ b/src/api/static/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#605DFF"/>
+  <text x="50%" y="54%" text-anchor="middle" dominant-baseline="middle"
+        font-family="system-ui, -apple-system, Segoe UI, Helvetica, Arial, sans-serif"
+        font-weight="900" font-size="42" fill="#ffffff">A</text>
+</svg>

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -168,5 +168,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/app.js"></script>
+<script src="{{ url_for('static', path='js/app.js') }}"></script>
 {% endblock %}

--- a/src/api/templates/base.html
+++ b/src/api/templates/base.html
@@ -4,14 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}Aggy{% endblock %}</title>
+  <link rel="icon" href="{{ url_for('static', path='favicon.svg') }}" type="image/svg+xml">
   <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.14/dist/full.min.css" rel="stylesheet" type="text/css" />
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="/static/css/style.css">
+  <link rel="stylesheet" href="{{ url_for('static', path='css/style.css') }}">
 </head>
 <body class="min-h-screen bg-base-300">
   {% block body %}{% endblock %}
   <div class="toast toast-end z-50" id="toasts"></div>
-  <script src="/static/js/sdk.js"></script>
+  <script src="{{ url_for('static', path='js/sdk.js') }}"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
This PR adds a favicon to the application and improves static asset URL handling by using Jinja2's `url_for` function instead of hardcoded paths.

## Key Changes
- **Added favicon support**: Created a new SVG favicon (`favicon.svg`) with a purple background and white "A" letter, and added a dedicated route (`/favicon.ico`) to serve it
- **Refactored static asset URLs**: Updated all static asset references in templates to use `{{ url_for('static', path='...') }}` instead of hardcoded `/static/...` paths for better maintainability and flexibility
- **Code organization**: Extracted `BASE_DIR` as a constant in the web router for cleaner code and reusability
- **Updated imports**: Added `FileResponse` to handle favicon serving

## Implementation Details
- The favicon is served as SVG with proper media type (`image/svg+xml`)
- All template files (`base.html`, `app.html`) now use the `url_for` helper for CSS, JavaScript, and favicon references
- The favicon route is excluded from OpenAPI schema documentation (`include_in_schema=False`)

https://claude.ai/code/session_01EqPDdyuSAqBLFCFjdju3ck