### PR TITLE
Migrate API storage from Redis to Postgres + Flyway + pgAdmin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,50 @@ networks:
 services:
   aggy-db:
     container_name: "${DEV_NAME}-aggy-db"
-    image: valkey/valkey:7.2.5-alpine
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=aggy
+      - POSTGRES_PASSWORD=aggy
+      - POSTGRES_DB=aggy
     ports:
-      - 6379
+      - 5432
+    volumes:
+      - "aggy-db-data:/var/lib/postgresql/data"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U aggy -d aggy"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  aggy-flyway:
+    container_name: "${DEV_NAME}-aggy-flyway"
+    image: flyway/flyway:10-alpine
+    command: -url=jdbc:postgresql://${DEV_NAME}-aggy-db:5432/aggy -user=aggy -password=aggy -connectRetries=30 migrate
+    volumes:
+      - "./src/api/db/migrations:/flyway/sql"
+    depends_on:
+      aggy-db:
+        condition: service_healthy
+
+  aggy-pgadmin:
+    container_name: "${DEV_NAME}-aggy-pgadmin"
+    image: dpage/pgadmin4:latest
+    restart: unless-stopped
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=admin@aggy.local
+      - PGADMIN_DEFAULT_PASSWORD=admin
+      - PGADMIN_CONFIG_SERVER_MODE=False
+    ports:
+      - 80
+    volumes:
+      - "aggy-pgadmin-data:/var/lib/pgadmin"
+    labels:
+      - "traefik.http.routers.${DEV_NAME}aggypgadmin.rule=Host(`${DEV_NAME}aggypgadmin.doze.dev`)"
+      - "traefik.http.routers.${DEV_NAME}aggypgadmin.service=${DEV_NAME}aggypgadmin"
+      - "traefik.http.services.${DEV_NAME}aggypgadmin.loadbalancer.server.port=80"
+    depends_on:
+      - aggy-db
 
   aggy-extract:
     container_name: "${DEV_NAME}-aggy-extract"
@@ -43,7 +84,10 @@ services:
       - 8000
     environment:
       - DB_HOST=${DEV_NAME}-aggy-db
-      - DB_PORT=6379
+      - DB_PORT=5432
+      - DB_USER=aggy
+      - DB_PASSWORD=aggy
+      - DB_NAME=aggy
       - RSS_BRIDGE_HOST=${DEV_NAME}-aggy-bridge
       - RSS_BRIDGE_PORT=80
       - OLLAMA_HOST=${DEV_NAME}-aggy-ollama
@@ -55,9 +99,14 @@ services:
       - "traefik.http.routers.${DEV_NAME}aggyapi.service=${DEV_NAME}aggyapi"
       - "traefik.http.services.${DEV_NAME}aggyapi.loadbalancer.server.port=8000"
     depends_on:
-      - aggy-db
-      - aggy-extract
-      - aggy-bridge
+      aggy-db:
+        condition: service_healthy
+      aggy-flyway:
+        condition: service_completed_successfully
+      aggy-extract:
+        condition: service_started
+      aggy-bridge:
+        condition: service_started
 
   aggy-webui:
     container_name: "${DEV_NAME}-aggy-webui"
@@ -76,3 +125,5 @@ services:
 
 volumes:
   aggy-ollama-data:
+  aggy-db-data:
+  aggy-pgadmin-data:

--- a/src/api/config.py
+++ b/src/api/config.py
@@ -8,6 +8,9 @@ KNOWN_CONFIG_VALUES = [
     "JWT_SECRET",
     "DB_HOST",
     "DB_PORT",
+    "DB_USER",
+    "DB_PASSWORD",
+    "DB_NAME",
     "EXTRACT_HOST",
     "EXTRACT_PORT",
     "OLLAMA_HOST",
@@ -28,6 +31,9 @@ DEFAULT_CONFIG = {
     "OLLAMA_PORT": 11434,
     "RSS_BRIDGE_PORT": 80,
     "BUILD_VERSION": "0.0.0-beta",
+    "DB_PORT": 5432,
+    "DB_USER": "aggy",
+    "DB_NAME": "aggy",
 }
 
 

--- a/src/api/constants.py
+++ b/src/api/constants.py
@@ -1,7 +1,6 @@
 from config import config
 from datetime import timedelta
 
-SOURCES_TO_INGEST_KEY = "SOURCE-KEYS-TO-INGEST"
 SOURCE_READ_INTERVAL_TIMEDELTA = timedelta(
     minutes=config.get("SOURCE_READ_INTERVAL_MINUTES")
 )

--- a/src/api/coverage.sh
+++ b/src/api/coverage.sh
@@ -4,7 +4,10 @@ compose_file="docker-compose.yml"
 docker-compose -f $compose_file up --build -d
 
 export DB_HOST=dev-aggy-db
-export DB_PORT=6379
+export DB_PORT=5432
+export DB_USER=aggy
+export DB_PASSWORD=aggy
+export DB_NAME=aggy
 export JWT_ALGORITHM=HS256
 export JWT_SECRET=429bceb2ab20f5785a4b609a725b0164be73a95d8ce04706ed8366cfe6ade896
 export RSS_BRIDGE_HOST=dev-aggy-rss-bridge

--- a/src/api/db/base.py
+++ b/src/api/db/base.py
@@ -1,21 +1,52 @@
 from pydantic import BaseModel
-import redis
+import psycopg2
+import psycopg2.extras
+from psycopg2.extras import RealDictCursor
+from psycopg2.pool import ThreadedConnectionPool
 from contextlib import contextmanager
-import logging
 import hashlib
 import base64
 import json
+import threading
 
 from config import config
 
+# Make JSON/JSONB columns come back as parsed Python objects.
+psycopg2.extras.register_default_json(loads=json.loads, globally=True)
+psycopg2.extras.register_default_jsonb(loads=json.loads, globally=True)
 
+
+_pool: ThreadedConnectionPool | None = None
+_pool_lock = threading.Lock()
+
+
+def _get_pool() -> ThreadedConnectionPool:
+    global _pool
+    if _pool is None:
+        with _pool_lock:
+            if _pool is None:
+                _pool = ThreadedConnectionPool(
+                    minconn=1,
+                    maxconn=10,
+                    host=config.get("DB_HOST"),
+                    port=int(config.get("DB_PORT")),
+                    user=config.get("DB_USER"),
+                    password=config.get("DB_PASSWORD"),
+                    dbname=config.get("DB_NAME"),
+                )
+    return _pool
+
+
+@contextmanager
 def get_db_con():
-    return redis.Redis(
-        host=config.get("DB_HOST"),
-        port=int(config.get("DB_PORT")),
-        decode_responses=True,
-        db=0,
-    )
+    pool = _get_pool()
+    conn = pool.getconn()
+    try:
+        with conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                yield cur
+    finally:
+        pool.putconn(conn)
 
 
 class AggyBaseModel(BaseModel):
@@ -38,20 +69,19 @@ class AggyBaseModel(BaseModel):
         return base_64_hash.decode("utf-8").rstrip("=")
 
     def exists(self) -> bool:
-        with self.db_con() as r:
-            return bool(r.exists(self.key))
+        raise NotImplementedError()
 
     def create(self, overwrite=False):
         raise NotImplementedError()
 
     def delete(self):
-        with self.db_con() as r:
-            r.delete(self.key)
+        raise NotImplementedError()
 
     @classmethod
     @contextmanager
     def db_con(cls):
-        yield get_db_con()
+        with get_db_con() as cur:
+            yield cur
 
     # enable truthiness for objects if len is defined and sometimes 0
     def __bool__(self):
@@ -64,12 +94,30 @@ class AggyBaseModel(BaseModel):
         return self.__str__()
 
 
-def db_init(flush=False):
-    with get_db_con() as r:
+# Tables managed by Flyway. Listed for use by the test/dev flush helper.
+_ALL_TABLES = (
+    "item_states",
+    "source_items",
+    "feed_items",
+    "items",
+    "sources",
+    "feeds",
+    "users",
+    "source_templates",
+)
+
+
+def db_init(flush: bool = False) -> None:
+    """Verify connectivity to Postgres. Optionally truncate all aggy tables.
+
+    Schema is owned by Flyway; this function only checks the connection
+    is healthy and (when ``flush`` is set) wipes the data for tests.
+    """
+    with get_db_con() as cur:
+        cur.execute("SELECT 1")
         if flush:
-            r.flushdb()
-        r.config_set("save", "60 1")  # TODO parameterize me
-        try:
-            r.config_rewrite()
-        except redis.exceptions.ResponseError as e:
-            logging.warning(f"Database config write failed: {e}")
+            cur.execute(
+                "TRUNCATE TABLE {} RESTART IDENTITY CASCADE".format(
+                    ", ".join(_ALL_TABLES)
+                )
+            )

--- a/src/api/db/feed.py
+++ b/src/api/db/feed.py
@@ -3,11 +3,8 @@ from typing import List, Optional
 from typing_extensions import Annotated
 
 from .item_collection import ItemCollection
-from .source import Source
 
 
-# TODO write unit test that ensures we are using hashes where we should be
-# (ie. user_hash, name_hash, etc. should be so many characters and of a certain set)
 class Feed(ItemCollection):
     user_hash: str
     name: Annotated[str, StringConstraints(strict=True, min_length=1)]
@@ -21,97 +18,118 @@ class Feed(ItemCollection):
         return f"{self.key}:SOURCES"
 
     @property
+    def items_key(self):
+        return f"{self.key}:ITEMS"
+
+    @property
     def name_hash(self):
         return self.__insecure_hash__(self.name)
 
     @property
-    def source_hashes(self):
-        with self.db_con() as r:
-            return list(r.smembers(self.sources_key))
+    def _items_table(self) -> str:
+        return "feed_items"
+
+    def _items_filter(self) -> tuple[str, tuple]:
+        return (
+            "c.user_hash = %s AND c.feed_hash = %s",
+            (self.user_hash, self.name_hash),
+        )
+
+    def _collection_keys(self) -> tuple[list[str], tuple]:
+        return (["user_hash", "feed_hash"], (self.user_hash, self.name_hash))
 
     @property
-    def sources(self) -> List[Source]:
-        return [
-            Source.read(
-                user_hash=self.user_hash,
-                feed_hash=self.name_hash,
-                source_hash=source_hash,
+    def source_hashes(self) -> List[str]:
+        with self.db_con() as cur:
+            cur.execute(
+                "SELECT name_hash FROM sources "
+                "WHERE user_hash = %s AND feed_hash = %s",
+                (self.user_hash, self.name_hash),
             )
-            for source_hash in self.source_hashes
+            return [row["name_hash"] for row in cur.fetchall()]
+
+    @property
+    def sources(self):
+        # Local import to avoid a circular dependency at module load time.
+        from .source import Source
+
+        with self.db_con() as cur:
+            cur.execute(
+                "SELECT user_hash, feed_hash, name_hash, name, url FROM sources "
+                "WHERE user_hash = %s AND feed_hash = %s",
+                (self.user_hash, self.name_hash),
+            )
+            rows = cur.fetchall()
+
+        return [
+            Source(
+                user_hash=row["user_hash"],
+                feed_hash=row["feed_hash"],
+                name=row["name"],
+                url=row["url"],
+            )
+            for row in rows
         ]
 
-    @property
-    def items_key(self):
-        return f"{self.key}:ITEMS"
+    def exists(self) -> bool:
+        with self.db_con() as cur:
+            cur.execute(
+                "SELECT 1 FROM feeds WHERE user_hash = %s AND name_hash = %s",
+                (self.user_hash, self.name_hash),
+            )
+            return cur.fetchone() is not None
 
     def create(self):
-        with self.db_con() as r:
-            if self.exists():
-                raise Exception(f"Feed with name {self.name} already exists")
+        if self.exists():
+            raise Exception(f"Feed with name {self.name} already exists")
 
-            r.hset(self.key, mapping={"name": self.name})
-            r.sadd(f"USER:{self.user_hash}:FEEDS", self.name_hash)
+        with self.db_con() as cur:
+            cur.execute(
+                "INSERT INTO feeds (user_hash, name_hash, name) VALUES (%s, %s, %s)",
+                (self.user_hash, self.name_hash, self.name),
+            )
 
         return self.key
 
     def delete(self):
-        with self.db_con() as r:
-            # remove feed from list of user's feeds
-            r.srem(f"USER:{self.user_hash}:FEEDS", self.name_hash)
-
-            # delete each source then remove list
-            for source_hash in self.source_hashes:
-                try:
-                    source = Source.read(
-                        user_hash=self.user_hash,
-                        feed_hash=self.name_hash,
-                        source_hash=source_hash,
-                    )
-                    source.delete()
-                except ValueError:
-                    # source does not exist
-                    pass
-            r.delete(self.sources_key)
-
-            # delete list of feed items
-            r.delete(f"{self.key}:ITEMS")
-
-            # delete self
-            r.delete(self.key)
+        # ON DELETE CASCADE removes sources, feed_items, source_items, and
+        # item_states tied to this feed.
+        with self.db_con() as cur:
+            cur.execute(
+                "DELETE FROM feeds WHERE user_hash = %s AND name_hash = %s",
+                (self.user_hash, self.name_hash),
+            )
 
     @classmethod
     def read(cls, user_hash, name_hash) -> Optional["Feed"]:
-        key = f"USER:{user_hash}:FEED:{name_hash}"
-        with cls.db_con() as r:
-            feed_data = r.hgetall(key)
+        with cls.db_con() as cur:
+            cur.execute(
+                "SELECT name FROM feeds WHERE user_hash = %s AND name_hash = %s",
+                (user_hash, name_hash),
+            )
+            row = cur.fetchone()
 
-        if feed_data:
-            feed_data["name_hash"] = name_hash
-            feed_data["user_hash"] = user_hash
-            return Feed(**feed_data)
+        if row:
+            return cls(user_hash=user_hash, name=row["name"])
 
         return None
 
     @classmethod
     def read_all(cls, user_hash) -> List["Feed"]:
-        with cls.db_con() as r:
-            feed_name_hashs = r.smembers(f"USER:{user_hash}:FEEDS")
+        with cls.db_con() as cur:
+            cur.execute(
+                "SELECT name FROM feeds WHERE user_hash = %s",
+                (user_hash,),
+            )
+            rows = cur.fetchall()
 
-        feeds = []
-        for name_hash in feed_name_hashs:
-            feeds.append(cls.read(user_hash=user_hash, name_hash=name_hash))
+        return [cls(user_hash=user_hash, name=row["name"]) for row in rows]
 
-        return feeds
+    def add_source(self, source):
+        source.user_hash = self.user_hash
+        source.feed_hash = self.name_hash
+        if not source.exists():
+            source.create()
 
-    def add_source(self, source: Source):
-        with self.db_con() as r:
-            source.user_hash = self.user_hash
-            source.feed_hash = self.name_hash
-            if not source.exists():
-                source.create()
-            r.sadd(f"{self.key}:SOURCES", source.name_hash)
-
-    def delete_source(self, source: Source):
-        with self.db_con() as r:
-            source.delete()
-            r.srem(f"{self.key}:SOURCES", source.name_hash)
+    def delete_source(self, source):
+        source.delete()

--- a/src/api/db/item.py
+++ b/src/api/db/item.py
@@ -4,6 +4,7 @@ import dateparser
 from bleach import clean
 from typing import Optional, List, Dict
 import html
+import json
 from urllib.parse import urljoin, urlparse
 from bs4 import BeautifulSoup
 
@@ -30,24 +31,68 @@ class ItemBase(AggyBaseModel):
         return self.__insecure_hash__(str(self.url))
 
     def exists(self) -> bool:
-        with self.db_con() as r:
-            return r.strlen(self.key) > 0
+        with self.db_con() as cur:
+            cur.execute("SELECT 1 FROM items WHERE url_hash = %s", (self.url_hash,))
+            return cur.fetchone() is not None
+
+    def _row_values(self) -> dict:
+        data = self.model_dump()
+        return {
+            "url_hash": self.url_hash,
+            "url": str(self.url),
+            "title": data.get("title"),
+            "author": data.get("author"),
+            "domain": data.get("domain"),
+            "excerpt": data.get("excerpt"),
+            "content": data.get("content"),
+            "image_url": data.get("image_url"),
+            "date_published": data.get("date_published"),
+            "embeddings": json.dumps(data["embeddings"])
+            if data.get("embeddings") is not None
+            else None,
+        }
 
     def create(self, overwrite=False):
         if not overwrite and self.exists():
             raise ValueError(f"Item with url_hash {self.key} already exists")
 
-        with self.db_con() as r:
-            r.set(self.key, self.model_dump_json())
+        v = self._row_values()
+        with self.db_con() as cur:
+            cur.execute(
+                "INSERT INTO items (url_hash, url, title, author, domain, excerpt, "
+                "content, image_url, date_published, embeddings) "
+                "VALUES (%(url_hash)s, %(url)s, %(title)s, %(author)s, %(domain)s, "
+                "%(excerpt)s, %(content)s, %(image_url)s, %(date_published)s, "
+                "%(embeddings)s) "
+                "ON CONFLICT (url_hash) DO UPDATE SET "
+                "url = EXCLUDED.url, title = EXCLUDED.title, author = EXCLUDED.author, "
+                "domain = EXCLUDED.domain, excerpt = EXCLUDED.excerpt, "
+                "content = EXCLUDED.content, image_url = EXCLUDED.image_url, "
+                "date_published = EXCLUDED.date_published, "
+                "embeddings = EXCLUDED.embeddings",
+                v,
+            )
+
+    @classmethod
+    def from_row(cls, row):
+        if row is None:
+            return None
+        data = dict(row)
+        data.pop("url_hash", None)
+        data.pop("created_at", None)
+        return cls(**data)
 
     @classmethod
     def read(cls, url_hash):
-        with cls.db_con() as r:
-            item_json = r.get(f"ITEM:{url_hash}")
+        with cls.db_con() as cur:
+            cur.execute(
+                "SELECT url, title, author, domain, excerpt, content, image_url, "
+                "date_published, embeddings FROM items WHERE url_hash = %s",
+                (url_hash,),
+            )
+            row = cur.fetchone()
 
-        if item_json:
-            return cls.model_validate_json(item_json)
-        return None
+        return cls.from_row(row)
 
     def update(self, **updates):
         for field, value in updates.items():
@@ -55,8 +100,8 @@ class ItemBase(AggyBaseModel):
         self.create(overwrite=True)
 
     def delete(self):
-        with self.db_con() as r:
-            r.delete(self.key)
+        with self.db_con() as cur:
+            cur.execute("DELETE FROM items WHERE url_hash = %s", (self.url_hash,))
 
     @model_validator(mode="after")
     def sanitize_and_fix_links(self):

--- a/src/api/db/item_collection.py
+++ b/src/api/db/item_collection.py
@@ -2,44 +2,93 @@ from typing import List, Union
 
 from .base import AggyBaseModel
 from .item import ItemStrict
-from utils import skip_limit_to_start_end
 
 
 class ItemCollection(AggyBaseModel):
+    """Mixin for objects that own an ordered set of items.
+
+    Subclasses must implement ``_items_filter`` returning a SQL fragment and
+    parameter tuple identifying the rows in the join table that belong to
+    this collection, and ``_items_table`` naming the join table itself.
+    """
+
     @property
-    def items_key(self) -> str:
+    def _items_table(self) -> str:
+        raise NotImplementedError
+
+    def _items_filter(self) -> tuple[str, tuple]:
         raise NotImplementedError
 
     def query_items(self, skip=None, limit=None) -> List[ItemStrict]:
-        start, end = skip_limit_to_start_end(skip, limit)
-        with self.db_con() as r:
-            url_hashes = r.zrange(self.items_key, start=start, end=end)
-        items = [ItemStrict.read(url_hash) for url_hash in url_hashes]
-        items = [i for i in items if i]
-        return items
+        where, params = self._items_filter()
+        sql = (
+            f"SELECT i.* FROM items i "
+            f"JOIN {self._items_table} c ON c.item_url_hash = i.url_hash "
+            f"WHERE {where} "
+            f"ORDER BY c.score ASC, c.added_at ASC"
+        )
+        if limit is not None and limit >= 0:
+            sql += " LIMIT %s"
+            params = params + (limit,)
+        if skip is not None and skip > 0:
+            sql += " OFFSET %s"
+            params = params + (skip,)
+
+        with self.db_con() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+
+        return [ItemStrict.from_row(row) for row in rows if row]
 
     def add_items(self, items: Union[ItemStrict, List[ItemStrict]]) -> None:
         if isinstance(items, ItemStrict):
-            items = {items.url_hash: 0}
-        elif isinstance(items, list):
-            items = {item.url_hash: 0 for item in items}
-        else:
+            items = [items]
+        if not isinstance(items, list):
             raise ValueError(f"Invalid type for items: {type(items)}")
 
-        with self.db_con() as r:
-            r.zadd(self.items_key, items)
+        self.set_items_scores({item.url_hash: 0 for item in items})
 
-    def set_items_scores(self, items: dict[str, int]) -> None:
-        with self.db_con() as r:
-            r.zadd(self.items_key, items)
+    def set_items_scores(self, items: dict[str, float]) -> None:
+        if not items:
+            return
+        cols, key_params = self._collection_keys()
+        placeholders = ", ".join(["(" + ", ".join(["%s"] * (len(cols) + 2)) + ")"] * len(items))
+        params: list = []
+        for url_hash, score in items.items():
+            params.extend(key_params)
+            params.append(url_hash)
+            params.append(float(score))
+        col_list = ", ".join(cols + ["item_url_hash", "score"])
+        sql = (
+            f"INSERT INTO {self._items_table} ({col_list}) VALUES {placeholders} "
+            f"ON CONFLICT ({', '.join(cols + ['item_url_hash'])}) DO UPDATE "
+            f"SET score = EXCLUDED.score"
+        )
+        with self.db_con() as cur:
+            cur.execute(sql, params)
 
     def remove_items(self, items: Union[ItemStrict, List[ItemStrict]]) -> None:
-        with self.db_con() as r:
-            if isinstance(items, ItemStrict):
-                items = [items]
+        if isinstance(items, ItemStrict):
+            items = [items]
+        where, params = self._items_filter()
+        with self.db_con() as cur:
             for item in items:
-                r.zrem(self.items_key, item.url_hash)
+                cur.execute(
+                    f"DELETE FROM {self._items_table} "
+                    f"WHERE {where} AND item_url_hash = %s",
+                    params + (item.url_hash,),
+                )
 
     def count_items(self) -> int:
-        with self.db_con() as r:
-            return r.zcard(self.items_key)
+        where, params = self._items_filter()
+        with self.db_con() as cur:
+            cur.execute(
+                f"SELECT COUNT(*) AS n FROM {self._items_table} WHERE {where}",
+                params,
+            )
+            return cur.fetchone()["n"]
+
+    def _collection_keys(self) -> tuple[list[str], tuple]:
+        """Return the column list and corresponding values that identify this
+        collection in its items join table."""
+        raise NotImplementedError

--- a/src/api/db/item_state.py
+++ b/src/api/db/item_state.py
@@ -33,39 +33,76 @@ class ItemState(AggyBaseModel):
     def key(self) -> str:
         return f"USER:{self.user_hash}:FEED:{self.feed_hash}:ITEM:{self.item_url_hash}:ITEM_STATE"
 
+    def exists(self) -> bool:
+        with self.db_con() as cur:
+            cur.execute(
+                "SELECT 1 FROM item_states "
+                "WHERE user_hash = %s AND feed_hash = %s AND item_url_hash = %s",
+                (self.user_hash, self.feed_hash, self.item_url_hash),
+            )
+            return cur.fetchone() is not None
+
     def create(self) -> None:
-        with self.db_con() as r:
-            # check user exists
-            User.read(self.user_hash)  # raises ValueError if user does not exist
+        # check user exists (raises if missing)
+        User.read(self.user_hash)
 
-            # check feed exists
-            feed = Feed.read(user_hash=self.user_hash, name_hash=self.feed_hash)
-            if not feed:
-                raise ValueError(f"Feed with hash {self.feed_hash} does not exist")
+        feed = Feed.read(user_hash=self.user_hash, name_hash=self.feed_hash)
+        if not feed:
+            raise ValueError(f"Feed with hash {self.feed_hash} does not exist")
 
-            item = ItemLoose.read(self.item_url_hash)
-            if not item:
-                raise ValueError(f"Item with hash {self.item_url_hash} does not exist")
+        item = ItemLoose.read(self.item_url_hash)
+        if not item:
+            raise ValueError(f"Item with hash {self.item_url_hash} does not exist")
 
-            r.set(self.key, self.json)
+        with self.db_con() as cur:
+            cur.execute(
+                "INSERT INTO item_states (user_hash, feed_hash, item_url_hash, "
+                "score, score_date, is_read) VALUES (%s, %s, %s, %s, %s, %s) "
+                "ON CONFLICT (user_hash, feed_hash, item_url_hash) DO UPDATE SET "
+                "score = EXCLUDED.score, score_date = EXCLUDED.score_date, "
+                "is_read = EXCLUDED.is_read",
+                (
+                    self.user_hash,
+                    self.feed_hash,
+                    self.item_url_hash,
+                    self.score,
+                    self.score_date,
+                    self.is_read,
+                ),
+            )
 
     def update(self) -> None:
         self.create()
 
     def delete(self) -> None:
-        with self.db_con() as r:
-            r.delete(self.key)
+        with self.db_con() as cur:
+            cur.execute(
+                "DELETE FROM item_states "
+                "WHERE user_hash = %s AND feed_hash = %s AND item_url_hash = %s",
+                (self.user_hash, self.feed_hash, self.item_url_hash),
+            )
 
     @classmethod
     def read(cls, user_hash, feed_hash, item_url_hash) -> "ItemState":
-        with cls.db_con() as r:
-            item_vote_json = r.get(
-                f"USER:{user_hash}:FEED:{feed_hash}:ITEM:{item_url_hash}:ITEM_STATE"
+        with cls.db_con() as cur:
+            cur.execute(
+                "SELECT score, score_date, is_read FROM item_states "
+                "WHERE user_hash = %s AND feed_hash = %s AND item_url_hash = %s",
+                (user_hash, feed_hash, item_url_hash),
             )
+            row = cur.fetchone()
 
-        if item_vote_json:
-            return cls.model_validate_json(item_vote_json)
-        return None
+        if not row:
+            return None
+
+        return cls(
+            user_hash=user_hash,
+            feed_hash=feed_hash,
+            item_url_hash=item_url_hash,
+            score=row["score"],
+            score_date=row["score_date"],
+            is_read=row["is_read"],
+        )
 
     @classmethod
     def set_state(

--- a/src/api/db/migrations/V1__initial_schema.sql
+++ b/src/api/db/migrations/V1__initial_schema.sql
@@ -1,0 +1,94 @@
+-- Initial schema for Aggy
+-- Replaces the previous Redis/Valkey based key-value model.
+
+CREATE TABLE users (
+    name_hash       TEXT PRIMARY KEY,
+    name            TEXT NOT NULL UNIQUE,
+    hashed_password TEXT NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE feeds (
+    user_hash  TEXT NOT NULL REFERENCES users(name_hash) ON DELETE CASCADE,
+    name_hash  TEXT NOT NULL,
+    name       TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_hash, name_hash)
+);
+
+CREATE TABLE sources (
+    user_hash      TEXT NOT NULL,
+    feed_hash      TEXT NOT NULL,
+    name_hash      TEXT NOT NULL,
+    name           TEXT NOT NULL,
+    url            TEXT NOT NULL,
+    next_ingest_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_hash, feed_hash, name_hash),
+    FOREIGN KEY (user_hash, feed_hash)
+        REFERENCES feeds(user_hash, name_hash) ON DELETE CASCADE
+);
+
+CREATE INDEX sources_next_ingest_idx ON sources(next_ingest_at);
+
+CREATE TABLE items (
+    url_hash       TEXT PRIMARY KEY,
+    url            TEXT NOT NULL,
+    title          TEXT,
+    author         TEXT,
+    domain         TEXT,
+    excerpt        TEXT,
+    content        TEXT,
+    image_url      TEXT,
+    date_published TIMESTAMPTZ,
+    embeddings     JSONB,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Replaces the per-feed Redis ZSET of (item_url_hash -> score)
+CREATE TABLE feed_items (
+    user_hash     TEXT NOT NULL,
+    feed_hash     TEXT NOT NULL,
+    item_url_hash TEXT NOT NULL REFERENCES items(url_hash) ON DELETE CASCADE,
+    score         DOUBLE PRECISION NOT NULL DEFAULT 0,
+    added_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_hash, feed_hash, item_url_hash),
+    FOREIGN KEY (user_hash, feed_hash)
+        REFERENCES feeds(user_hash, name_hash) ON DELETE CASCADE
+);
+
+-- Replaces the per-source Redis ZSET of (item_url_hash -> score)
+CREATE TABLE source_items (
+    user_hash     TEXT NOT NULL,
+    feed_hash     TEXT NOT NULL,
+    source_hash   TEXT NOT NULL,
+    item_url_hash TEXT NOT NULL REFERENCES items(url_hash) ON DELETE CASCADE,
+    score         DOUBLE PRECISION NOT NULL DEFAULT 0,
+    added_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_hash, feed_hash, source_hash, item_url_hash),
+    FOREIGN KEY (user_hash, feed_hash, source_hash)
+        REFERENCES sources(user_hash, feed_hash, name_hash) ON DELETE CASCADE
+);
+
+CREATE TABLE item_states (
+    user_hash     TEXT NOT NULL REFERENCES users(name_hash) ON DELETE CASCADE,
+    feed_hash     TEXT NOT NULL,
+    item_url_hash TEXT NOT NULL,
+    score         DOUBLE PRECISION,
+    score_date    TIMESTAMPTZ,
+    is_read       BOOLEAN,
+    PRIMARY KEY (user_hash, feed_hash, item_url_hash),
+    FOREIGN KEY (user_hash, feed_hash)
+        REFERENCES feeds(user_hash, name_hash) ON DELETE CASCADE
+);
+
+CREATE TABLE source_templates (
+    name_hash         TEXT PRIMARY KEY,
+    name              TEXT NOT NULL,
+    bridge_short_name TEXT,
+    url               TEXT NOT NULL,
+    description       TEXT NOT NULL,
+    context           TEXT,
+    parameters        JSONB NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/src/api/db/source.py
+++ b/src/api/db/source.py
@@ -2,7 +2,7 @@ from pydantic import StringConstraints, HttpUrl
 from typing_extensions import Annotated
 from datetime import datetime
 
-from constants import SOURCES_TO_INGEST_KEY, SOURCE_READ_INTERVAL_TIMEDELTA
+from constants import SOURCE_READ_INTERVAL_TIMEDELTA
 from .item_collection import ItemCollection
 
 
@@ -24,49 +24,101 @@ class Source(ItemCollection):
     def items_key(self):
         return f"{self.key}:ITEMS"
 
-    def create(self):
-        with self.db_con() as r:
-            if r.exists(self.key):
-                raise Exception(f"Cannot create duplicate source {self.key}")
+    @property
+    def _items_table(self) -> str:
+        return "source_items"
 
-            r.hset(self.key, mapping={"url": str(self.url), "name": self.name})
-            self.trigger_ingest(now=True)
-        return
+    def _items_filter(self) -> tuple[str, tuple]:
+        return (
+            "c.user_hash = %s AND c.feed_hash = %s AND c.source_hash = %s",
+            (self.user_hash, self.feed_hash, self.name_hash),
+        )
+
+    def _collection_keys(self) -> tuple[list[str], tuple]:
+        return (
+            ["user_hash", "feed_hash", "source_hash"],
+            (self.user_hash, self.feed_hash, self.name_hash),
+        )
+
+    def exists(self) -> bool:
+        with self.db_con() as cur:
+            cur.execute(
+                "SELECT 1 FROM sources "
+                "WHERE user_hash = %s AND feed_hash = %s AND name_hash = %s",
+                (self.user_hash, self.feed_hash, self.name_hash),
+            )
+            return cur.fetchone() is not None
+
+    def create(self):
+        if self.exists():
+            raise Exception(f"Cannot create duplicate source {self.key}")
+
+        with self.db_con() as cur:
+            cur.execute(
+                "INSERT INTO sources (user_hash, feed_hash, name_hash, name, url, "
+                "next_ingest_at) VALUES (%s, %s, %s, %s, %s, NOW())",
+                (
+                    self.user_hash,
+                    self.feed_hash,
+                    self.name_hash,
+                    self.name,
+                    str(self.url),
+                ),
+            )
 
     def delete(self):
-        with self.db_con() as r:
-            r.delete(self.key)
-            r.delete(self.items_key)
+        with self.db_con() as cur:
+            cur.execute(
+                "DELETE FROM sources "
+                "WHERE user_hash = %s AND feed_hash = %s AND name_hash = %s",
+                (self.user_hash, self.feed_hash, self.name_hash),
+            )
 
     def trigger_ingest(self, now=False):
-        # if the source is not already in the list
-        # we're assuming it's over due to ingest
         if now:
-            score = int(datetime.now().timestamp())
+            target = datetime.now()
         else:
-            score = datetime.now() + SOURCE_READ_INTERVAL_TIMEDELTA
-            score = int((score).timestamp())
+            target = datetime.now() + SOURCE_READ_INTERVAL_TIMEDELTA
 
-        with self.db_con() as r:
-            # lt=True means that if the source is already in the list
-            # it will only be updated if the new score is lower
-            r.zadd(SOURCES_TO_INGEST_KEY, mapping={self.key: score}, lt=True)
+        # Mirrors the Redis ZADD lt=True semantics: only move next_ingest_at
+        # earlier, never later.
+        with self.db_con() as cur:
+            cur.execute(
+                "UPDATE sources SET next_ingest_at = LEAST(next_ingest_at, %s) "
+                "WHERE user_hash = %s AND feed_hash = %s AND name_hash = %s",
+                (target, self.user_hash, self.feed_hash, self.name_hash),
+            )
 
     @classmethod
     def read(cls, user_hash, feed_hash, source_hash):
-        source_key = f"USER:{user_hash}:FEED:{feed_hash}:SOURCE:{source_hash}"
-        source = cls.read_by_key(source_key)
+        with cls.db_con() as cur:
+            cur.execute(
+                "SELECT name, url FROM sources "
+                "WHERE user_hash = %s AND feed_hash = %s AND name_hash = %s",
+                (user_hash, feed_hash, source_hash),
+            )
+            row = cur.fetchone()
 
-        if source:
-            return source
-
+        if row:
+            return cls(
+                user_hash=user_hash,
+                feed_hash=feed_hash,
+                name=row["name"],
+                url=row["url"],
+            )
         raise ValueError("Source not found")
 
     @classmethod
     def read_by_key(cls, source_key):
-        with cls.db_con() as r:
-            if r.exists(source_key):
-                source_data = r.hgetall(source_key)
-                _, user_hash, _, feed_hash, _, source_hash = source_key.split(":")
-                return Source(user_hash=user_hash, feed_hash=feed_hash, **source_data)
-        return None
+        try:
+            _, user_hash, _, feed_hash, _, source_hash = source_key.split(":")
+        except ValueError:
+            return None
+        try:
+            return cls.read(
+                user_hash=user_hash,
+                feed_hash=feed_hash,
+                source_hash=source_hash,
+            )
+        except ValueError:
+            return None

--- a/src/api/db/source_template.py
+++ b/src/api/db/source_template.py
@@ -2,6 +2,7 @@ from pydantic import HttpUrl
 from typing import Dict, Any, Optional, List, Union
 from enum import Enum
 import urllib
+import json
 from rapidfuzz import fuzz
 
 from db.base import AggyBaseModel
@@ -109,54 +110,101 @@ class SourceTemplate(AggyBaseModel):
             query=urllib.parse.urlencode(url_params),
         )
 
-    def create(self):
-        with self.db_con() as r:
-            r.set(self.key, self.json)
+    def exists(self) -> bool:
+        with self.db_con() as cur:
+            cur.execute(
+                "SELECT 1 FROM source_templates WHERE name_hash = %s",
+                (self.name_hash,),
+            )
+            return cur.fetchone() is not None
 
-            # add to list of all templates
-            r.sadd("SOURCE_TEMPLATES", self.name_hash)
+    def create(self):
+        params_json = json.dumps(
+            {k: json.loads(v.model_dump_json()) for k, v in self.parameters.items()}
+        )
+        with self.db_con() as cur:
+            cur.execute(
+                "INSERT INTO source_templates (name_hash, name, bridge_short_name, "
+                "url, description, context, parameters) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s) "
+                "ON CONFLICT (name_hash) DO UPDATE SET "
+                "name = EXCLUDED.name, "
+                "bridge_short_name = EXCLUDED.bridge_short_name, "
+                "url = EXCLUDED.url, description = EXCLUDED.description, "
+                "context = EXCLUDED.context, parameters = EXCLUDED.parameters",
+                (
+                    self.name_hash,
+                    self.name,
+                    self.bridge_short_name,
+                    str(self.url),
+                    self.description,
+                    self.context,
+                    params_json,
+                ),
+            )
+
+    def delete(self):
+        with self.db_con() as cur:
+            cur.execute(
+                "DELETE FROM source_templates WHERE name_hash = %s",
+                (self.name_hash,),
+            )
+
+    @classmethod
+    def _from_row(cls, row) -> "SourceTemplate":
+        params_raw = row["parameters"]
+        if isinstance(params_raw, str):
+            params_raw = json.loads(params_raw)
+        parameters = {
+            k: SourceTemplateParameter(**v) for k, v in (params_raw or {}).items()
+        }
+        return cls(
+            name=row["name"],
+            bridge_short_name=row["bridge_short_name"],
+            url=row["url"],
+            description=row["description"],
+            context=row["context"],
+            parameters=parameters,
+        )
 
     @classmethod
     def read(cls, name_hash: str) -> Optional["SourceTemplate"]:
-        with cls.db_con() as r:
-            data = r.get(f"SOURCE_TEMPLATE:{name_hash}")
-            if data:
-                return cls.model_validate_json(data)
+        with cls.db_con() as cur:
+            cur.execute(
+                "SELECT name, bridge_short_name, url, description, context, "
+                "parameters FROM source_templates WHERE name_hash = %s",
+                (name_hash,),
+            )
+            row = cur.fetchone()
+
+        if not row:
             return None
+        return cls._from_row(row)
 
     @classmethod
     def read_all(cls) -> List["SourceTemplate"]:
-        templates = []
-        with cls.db_con() as r:
-            template_hashes = r.smembers("SOURCE_TEMPLATES")
-            for template_hash in template_hashes:
-                template = cls.read(template_hash)
-                if template:
-                    templates.append(template)
-        return templates
+        with cls.db_con() as cur:
+            cur.execute(
+                "SELECT name, bridge_short_name, url, description, context, "
+                "parameters FROM source_templates"
+            )
+            rows = cur.fetchall()
+
+        return [cls._from_row(row) for row in rows]
 
     @classmethod
     def search(
         cls, query: str, skip: Union[int, None] = None, limit: Union[int, None] = None
     ) -> List["SourceTemplate"]:
-        templates = []
-        with cls.db_con() as r:
-            template_hashes = r.smembers("SOURCE_TEMPLATES")
-            for template_hash in template_hashes:
-                template = cls.read(template_hash)
-                if template:
-                    # Compute fuzzy match score between the query and the template name
-                    score = fuzz.ratio(query.lower(), template.name.lower())
+        templates = cls.read_all()
 
-                    # Add the template and score to the list
-                    templates.append((template, score))
+        scored = [(t, fuzz.ratio(query.lower(), t.name.lower())) for t in templates]
+        scored.sort(key=lambda x: x[1], reverse=True)
 
-        # Sort the templates by score in descending order (high similarity first)
-        templates.sort(key=lambda x: x[1], reverse=True)
-
-        # Paginate results by skipping the first 'skip' items and returning 'limit' items
         start, end = skip_limit_to_start_end(skip, limit)
-        paginated_results = templates[start:end]
+        if end == -1:
+            paginated = scored[start:]
+        else:
+            paginated = scored[start : end + 1]
 
-        # Return only the templates, excluding the scores
-        return [template for template, score in paginated_results]
+        return [t for t, _ in paginated]

--- a/src/api/db/user.py
+++ b/src/api/db/user.py
@@ -21,20 +21,12 @@ class User(AggyBaseModel):
         return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
     @property
-    def feeds_key(self):
-        return f"USER:{self.name_hash}:FEEDS"
+    def feeds(self):
+        return Feed.read_all(user_hash=self.name_hash)
 
     @property
     def feed_hashes(self):
-        with self.db_con() as r:
-            return r.smembers(self.feeds_key)
-
-    @property
-    def feeds(self):
-        return [
-            Feed.read(user_hash=self.name_hash, name_hash=name_hash)
-            for name_hash in self.feed_hashes
-        ]
+        return {f.name_hash for f in self.feeds}
 
     def set_password(self, password: str):
         # TODO password complexity check
@@ -45,16 +37,26 @@ class User(AggyBaseModel):
             password.encode("utf-8"), self.hashed_password.encode("utf-8")
         )
 
+    def exists(self) -> bool:
+        with self.db_con() as cur:
+            cur.execute(
+                "SELECT 1 FROM users WHERE name_hash = %s", (self.name_hash,)
+            )
+            return cur.fetchone() is not None
+
     def create(self):
-        with self.db_con() as r:
-            if self.hashed_password is None:
-                raise Exception("Password is required to create a user")
+        if self.hashed_password is None:
+            raise Exception("Password is required to create a user")
 
-            if self.exists():
-                raise Exception(f"User with name {self.name} already exists")
+        if self.exists():
+            raise Exception(f"User with name {self.name} already exists")
 
-            r.hset(self.key, mapping=self.model_dump())
-            r.sadd("USERS", self.name_hash)
+        with self.db_con() as cur:
+            cur.execute(
+                "INSERT INTO users (name_hash, name, hashed_password) "
+                "VALUES (%s, %s, %s)",
+                (self.name_hash, self.name, self.hashed_password),
+            )
 
         return self.key
 
@@ -65,57 +67,50 @@ class User(AggyBaseModel):
                 raise Exception("name or name_hash is required")
             name_hash = User(name=name).name_hash
 
-        with cls.db_con() as r:
-            user_data = r.hgetall(f"USER:{name_hash}")
+        with cls.db_con() as cur:
+            cur.execute(
+                "SELECT name, hashed_password FROM users WHERE name_hash = %s",
+                (name_hash,),
+            )
+            row = cur.fetchone()
 
-        if not user_data:
+        if not row:
             raise Exception(f"User with name_hash {name_hash} does not exist")
 
-        return cls(**user_data)
+        return cls(name=row["name"], hashed_password=row["hashed_password"])
 
     @classmethod
     def read_all(cls) -> list["User"]:
-        with cls.db_con() as r:
-            user_hashes = r.smembers("USERS")
+        with cls.db_con() as cur:
+            cur.execute("SELECT name, hashed_password FROM users")
+            rows = cur.fetchall()
 
-        if not user_hashes:
-            return []
-
-        return [cls.read(name_hash=name_hash) for name_hash in user_hashes]
+        return [
+            cls(name=row["name"], hashed_password=row["hashed_password"])
+            for row in rows
+        ]
 
     def update(self):
-        with self.db_con() as r:
-            if not self.exists():
-                raise Exception(f"User withname {self.name} does not exist")
+        if not self.exists():
+            raise Exception(f"User withname {self.name} does not exist")
 
-            r.hset(
-                self.key,
-                mapping=self.model_dump(),
+        with self.db_con() as cur:
+            cur.execute(
+                "UPDATE users SET name = %s, hashed_password = %s "
+                "WHERE name_hash = %s",
+                (self.name, self.hashed_password, self.name_hash),
             )
 
     def delete(self):
-        with self.db_con() as r:
-            # delete all feeds
-            for feed in self.feeds:
-                feed.delete()
-
-            # remove user from list of users
-            r.srem("USERS", self.name_hash)
-
-            # delete self
-            r.delete(self.key)
+        # ON DELETE CASCADE on feeds (and their dependents) handles cleanup.
+        with self.db_con() as cur:
+            cur.execute("DELETE FROM users WHERE name_hash = %s", (self.name_hash,))
 
     def add_feed(self, feed: Feed):
-        with self.db_con() as r:
-            if feed.user_hash != self.name_hash:
-                raise Exception("Feed does not belong to user")
-            if not feed.exists():
-                feed.create()
-            r.sadd(self.feeds_key, feed.name_hash)
+        if feed.user_hash != self.name_hash:
+            raise Exception("Feed does not belong to user")
+        if not feed.exists():
+            feed.create()
 
     def remove_feed(self, feed: Feed):
-        with self.db_con() as r:
-            # get the feed
-            feed.delete()
-            # delete feed
-            r.srem(self.feeds_key, feed.name_hash)
+        feed.delete()

--- a/src/api/docker-compose.test.yml
+++ b/src/api/docker-compose.test.yml
@@ -1,8 +1,26 @@
 services:
   test-aggy-db:
-    image: valkey/valkey:8.0.0-alpine
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_USER=aggy
+      - POSTGRES_PASSWORD=aggy
+      - POSTGRES_DB=aggy
     ports:
-      - 6379
+      - 5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U aggy -d aggy"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  test-aggy-flyway:
+    image: flyway/flyway:10-alpine
+    command: -url=jdbc:postgresql://test-aggy-db:5432/aggy -user=aggy -password=aggy -connectRetries=30 migrate
+    volumes:
+      - "./db/migrations:/flyway/sql"
+    depends_on:
+      test-aggy-db:
+        condition: service_healthy
 
   test-aggy-rss-bridge:
     image: rssbridge/rss-bridge:latest
@@ -16,11 +34,18 @@ services:
       dockerfile: dockerfile.test
     environment:
       - DB_HOST=test-aggy-db
-      - DB_PORT=6379
+      - DB_PORT=5432
+      - DB_USER=aggy
+      - DB_PASSWORD=aggy
+      - DB_NAME=aggy
       - RSS_BRIDGE_HOST=dev-aggy-rss-bridge
       - RSS_BRIDGE_PORT=80
       - JWT_ALGORITHM=HS256
       - JWT_SECRET=429bceb2ab20f5785a4b609a725b0164be73a95d8ce04706ed8366cfe6ade896 # openssl rand -hex 32
     depends_on:
-      - test-aggy-db
-      - test-aggy-rss-bridge
+      test-aggy-db:
+        condition: service_healthy
+      test-aggy-flyway:
+        condition: service_completed_successfully
+      test-aggy-rss-bridge:
+        condition: service_started

--- a/src/api/docker-compose.yml
+++ b/src/api/docker-compose.yml
@@ -5,9 +5,44 @@ networks:
 
 services:
   dev-aggy-db:
-    image: valkey/valkey:8.0.0-alpine
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=aggy
+      - POSTGRES_PASSWORD=aggy
+      - POSTGRES_DB=aggy
     ports:
-      - 6379
+      - 5432
+    volumes:
+      - "dev-aggy-db-data:/var/lib/postgresql/data"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U aggy -d aggy"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  dev-aggy-flyway:
+    image: flyway/flyway:10-alpine
+    command: -url=jdbc:postgresql://dev-aggy-db:5432/aggy -user=aggy -password=aggy -connectRetries=30 migrate
+    volumes:
+      - "./db/migrations:/flyway/sql"
+    depends_on:
+      dev-aggy-db:
+        condition: service_healthy
+
+  dev-aggy-pgadmin:
+    image: dpage/pgadmin4:latest
+    restart: unless-stopped
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=admin@aggy.local
+      - PGADMIN_DEFAULT_PASSWORD=admin
+      - PGADMIN_CONFIG_SERVER_MODE=False
+    ports:
+      - 80
+    volumes:
+      - "dev-aggy-pgadmin-data:/var/lib/pgadmin"
+    depends_on:
+      - dev-aggy-db
 
   # https://github.com/HenryQW/mercury-parser-api
   dev-aggy-extract:
@@ -38,7 +73,10 @@ services:
       - 8000
     environment:
       - DB_HOST=dev-aggy-db
-      - DB_PORT=6379
+      - DB_PORT=5432
+      - DB_USER=aggy
+      - DB_PASSWORD=aggy
+      - DB_NAME=aggy
       - RSS_BRIDGE_HOST=dev-aggy-rss-bridge
       - RSS_BRIDGE_PORT=80
       - EXTRACT_HOST=dev-aggy-extract
@@ -53,9 +91,15 @@ services:
       - "traefik.http.routers.codehostapi.service=codehostapi"
       - "traefik.http.services.codehostapi.loadbalancer.server.port=8000"
     depends_on:
-      - dev-aggy-db
-      - dev-aggy-rss-bridge
+      dev-aggy-db:
+        condition: service_healthy
+      dev-aggy-flyway:
+        condition: service_completed_successfully
+      dev-aggy-rss-bridge:
+        condition: service_started
 
 
 volumes:
   dev-aggy-ollama-data:
+  dev-aggy-db-data:
+  dev-aggy-pgadmin-data:

--- a/src/api/dockerfile
+++ b/src/api/dockerfile
@@ -11,9 +11,14 @@ WORKDIR /src
 
 ENV TZ=America/New_York
 
+# psycopg2-binary needs libpq at runtime; build deps for any source wheels.
+RUN apk add --no-cache libpq
+
 COPY requirements.txt .
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev libpq-dev \
+    && pip install --no-cache-dir -r requirements.txt \
+    && apk del .build-deps
 
 COPY . /src/api
 COPY --from=css-builder /build/output.css /src/api/static/css/tailwind.css

--- a/src/api/dockerfile.test
+++ b/src/api/dockerfile.test
@@ -3,9 +3,13 @@ WORKDIR /src
 
 ENV TZ=America/New_York
 
+RUN apk add --no-cache libpq
+
 COPY requirements.txt .
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev libpq-dev \
+    && pip install --no-cache-dir -r requirements.txt \
+    && apk del .build-deps
 
 COPY . /src/api
 

--- a/src/api/ingest/jobs.py
+++ b/src/api/ingest/jobs.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime, timedelta
 
-from constants import SOURCES_TO_INGEST_KEY, SOURCE_READ_INTERVAL_TIMEDELTA
+from constants import SOURCE_READ_INTERVAL_TIMEDELTA
 from db.base import get_db_con
 from db.source import Source
 from ingest.source import ingest_source
@@ -19,37 +19,43 @@ def source_ingestion_scheduling_job() -> None:
 
 
 def source_ingestion_job() -> None:
-    r = get_db_con()
+    """Pop the next due source and ingest it.
 
-    if not r.exists(SOURCES_TO_INGEST_KEY):
-        return
+    Mirrors the previous Redis ZMPOP-based queue: pick the source with the
+    smallest ``next_ingest_at``, only proceed if it's actually due, and then
+    bump its next ingest time forward.
+    """
+    cutoff = datetime.now() + timedelta(minutes=1)
 
-    res = r.zmpop(1, [SOURCES_TO_INGEST_KEY], min=True)[1][0]
-    source_key, scheduled_time = res
-    scheduled_time = datetime.fromtimestamp(int(scheduled_time))
-
-    # if the source isn't due yet
-    if scheduled_time > datetime.now() + timedelta(minutes=1):
-        # replace the source without altering it
-        # take the sooner of the values if a source already exists
-        r.zadd(
-            SOURCES_TO_INGEST_KEY,
-            mapping={source_key: int(scheduled_time.timestamp())},
-            lt=True,
+    with get_db_con() as cur:
+        cur.execute(
+            "SELECT user_hash, feed_hash, name_hash, next_ingest_at "
+            "FROM sources WHERE next_ingest_at <= %s "
+            "ORDER BY next_ingest_at ASC LIMIT 1 FOR UPDATE SKIP LOCKED",
+            (cutoff,),
         )
-        return
+        row = cur.fetchone()
+
+        if not row:
+            return
+
+        next_run = row["next_ingest_at"] + SOURCE_READ_INTERVAL_TIMEDELTA
+        cur.execute(
+            "UPDATE sources SET next_ingest_at = %s "
+            "WHERE user_hash = %s AND feed_hash = %s AND name_hash = %s",
+            (next_run, row["user_hash"], row["feed_hash"], row["name_hash"]),
+        )
 
     try:
-        source = Source.read_by_key(source_key=source_key)
+        source = Source.read(
+            user_hash=row["user_hash"],
+            feed_hash=row["feed_hash"],
+            source_hash=row["name_hash"],
+        )
         ingest_source(source=source)
     except Exception as e:
-        logging.exception(f"Ingesting of source {source_key} failed: {e}")
+        logging.exception(f"Ingesting of source {row['name_hash']} failed: {e}")
         return
-
-    # reschedule the source for next go-round
-    next_process_time = scheduled_time + SOURCE_READ_INTERVAL_TIMEDELTA
-    next_process_time = int(next_process_time.timestamp())
-    r.zadd(SOURCES_TO_INGEST_KEY, mapping={source_key: next_process_time}, lt=True)
 
 
 def download_embedding_model_job() -> None:

--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -14,6 +14,6 @@ pytest
 pytest-cov
 python-multipart
 rapidfuzz
-redis
+psycopg2-binary
 requests
 uvicorn

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -1,3 +1,5 @@
+import pytest
+
 # fixtures
 from tests.fixtures.feed import unique_feed, existing_feed  # noqa
 from tests.fixtures.item import unique_item_strict, existing_item_strict  # noqa
@@ -13,4 +15,12 @@ from tests.fixtures.token import token  # noqa
 
 from db.base import db_init
 
+
 db_init()
+
+
+@pytest.fixture(autouse=True)
+def _wipe_db_between_tests():
+    """Truncate all aggy tables between tests for isolation."""
+    db_init(flush=True)
+    yield

--- a/src/api/tests/db/base_test.py
+++ b/src/api/tests/db/base_test.py
@@ -1,6 +1,6 @@
 import pytest
-import redis
-from db.base import AggyBaseModel
+
+from db.base import AggyBaseModel, get_db_con
 
 
 def test_key_property_raises_not_implemented_error():
@@ -11,11 +11,10 @@ def test_key_property_raises_not_implemented_error():
 
 
 def test_db_con():
-    model = AggyBaseModel()
-
-    with model.db_con() as r:
-        assert isinstance(r, redis.Redis)
-        r.ping()
+    with get_db_con() as cur:
+        cur.execute("SELECT 1 AS one")
+        row = cur.fetchone()
+        assert row["one"] == 1
 
 
 def test_base_create_raises_not_implemented_error():

--- a/src/api/tests/db/feed_test.py
+++ b/src/api/tests/db/feed_test.py
@@ -55,19 +55,17 @@ def test_feed_read(unique_feed):
     assert read_feed.name == unique_feed.name, "Feed name should match"
 
 
-def test_feed_read_all(unique_feed):
+def test_feed_read_all(existing_user):
     """Tests reading all feeds for a user."""
-    # Create multiple feeds for testing
     for i in range(3):
-        unique_feed.name += f" {i}"
-        unique_feed.create()
+        Feed(user_hash=existing_user.name_hash, name=f"feed-{i}").create()
 
-    feeds = Feed.read_all(unique_feed.user_hash)
+    feeds = Feed.read_all(existing_user.name_hash)
     assert len(feeds) == 3, "Should read all feeds for a user"
 
     for feed in feeds:
         assert (
-            feed.user_hash == unique_feed.user_hash
+            feed.user_hash == existing_user.name_hash
         ), "Feed should be for the correct user"
 
 
@@ -78,11 +76,10 @@ def test_get_items(unique_feed, unique_item_strict):
 
     items = [unique_item_strict.model_copy() for i in range(3)]
 
-    with unique_feed.db_con() as r:
-        for i, item in enumerate(items):
-            item.url = f"http://example.com/{i}"
-            item.create()
-            r.zadd(unique_feed.items_key, {item.url_hash: i})
+    for i, item in enumerate(items):
+        item.url = f"http://example.com/{i}"
+        item.create()
+        unique_feed.set_items_scores({item.url_hash: i})
 
     act_items = unique_feed.query_items()
     assert len(act_items) == 3, "Should get all items for a feed"
@@ -90,11 +87,6 @@ def test_get_items(unique_feed, unique_item_strict):
         assert item.url_hash in [
             i.url_hash for i in items
         ], "Should get the correct items"
-
-    unique_feed.delete()
-
-    for item in items:
-        item.delete()
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
@@ -104,11 +96,10 @@ def test_get_items_with_limit(unique_feed, unique_item_strict):
 
     items = [unique_item_strict.model_copy() for i in range(3)]
 
-    with unique_feed.db_con() as r:
-        for i, item in enumerate(items):
-            item.url = f"http://example.com/{i}"
-            item.create()
-            r.zadd(unique_feed.items_key, {item.url_hash: i})
+    for i, item in enumerate(items):
+        item.url = f"http://example.com/{i}"
+        item.create()
+        unique_feed.set_items_scores({item.url_hash: i})
 
     act_items = unique_feed.query_items(limit=2)
     assert len(act_items) == 2, "Should get all items for a feed"
@@ -116,11 +107,6 @@ def test_get_items_with_limit(unique_feed, unique_item_strict):
         assert item.url_hash in [
             i.url_hash for i in items
         ], "Should get the correct items"
-
-    unique_feed.delete()
-
-    for item in items:
-        item.delete()
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
@@ -130,11 +116,10 @@ def test_get_items_with_skip(unique_feed, unique_item_strict):
 
     items = [unique_item_strict.model_copy() for i in range(3)]
 
-    with unique_feed.db_con() as r:
-        for i, item in enumerate(items):
-            item.url = f"http://example.com/{i}"
-            item.create()
-            r.zadd(unique_feed.items_key, {item.url_hash: i})
+    for i, item in enumerate(items):
+        item.url = f"http://example.com/{i}"
+        item.create()
+        unique_feed.set_items_scores({item.url_hash: i})
 
     act_items = unique_feed.query_items(skip=1)
     assert len(act_items) == 2, "Should get all items for a feed"
@@ -142,11 +127,6 @@ def test_get_items_with_skip(unique_feed, unique_item_strict):
         assert item.url_hash in [
             i.url_hash for i in items
         ], "Should get the correct items"
-
-    unique_feed.delete()
-
-    for item in items:
-        item.delete()
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
@@ -156,11 +136,10 @@ def test_get_items_with_skip_and_limit(unique_feed, unique_item_strict):
 
     items = [unique_item_strict.model_copy() for i in range(3)]
 
-    with unique_feed.db_con() as r:
-        for i, item in enumerate(items):
-            item.url = f"http://example.com/{i}"
-            item.create()
-            r.zadd(unique_feed.items_key, {item.url_hash: i})
+    for i, item in enumerate(items):
+        item.url = f"http://example.com/{i}"
+        item.create()
+        unique_feed.set_items_scores({item.url_hash: i})
 
     act_items = unique_feed.query_items(skip=1, limit=1)
     assert len(act_items) == 1, "Should get all items for a feed"
@@ -168,11 +147,6 @@ def test_get_items_with_skip_and_limit(unique_feed, unique_item_strict):
         assert item.url_hash in [
             i.url_hash for i in items
         ], "Should get the correct items"
-
-    unique_feed.delete()
-
-    for item in items:
-        item.delete()
 
 
 def test_sources(unique_feed, unique_source):
@@ -195,20 +169,12 @@ def test_delete_feed_removes_sources(unique_feed, unique_source):
     unique_feed.create()
     unique_feed.add_source(unique_source)
 
-    with unique_feed.db_con() as r:
-        assert r.exists(unique_feed.sources_key)
-        assert not r.exists(unique_feed.items_key)
-        assert r.exists(unique_feed.key)
-        assert r.exists(unique_source.key)
+    assert unique_feed.exists()
+    assert unique_source.exists()
 
     unique_feed.delete()
     assert not unique_source.exists()
     assert not unique_feed.exists()
-    with unique_feed.db_con() as r:
-        assert not r.exists(unique_feed.sources_key)
-        assert not r.exists(unique_feed.items_key)
-        assert not r.exists(unique_feed.key)
-        assert not r.exists(unique_source.key)
 
 
 def test_remove_items(unique_feed, unique_item_strict):
@@ -221,8 +187,4 @@ def test_remove_items(unique_feed, unique_item_strict):
 
     unique_feed.remove_items(unique_item_strict)
     assert unique_item_strict not in unique_feed.query_items()
-    assert unique_item_strict.exists()
-
-    unique_feed.delete()
-    assert not unique_feed.exists()
     assert unique_item_strict.exists()

--- a/src/api/tests/db/item_test.py
+++ b/src/api/tests/db/item_test.py
@@ -65,13 +65,15 @@ def test_date_published_parsing(unique_item_strict, raw_date, expected_date):
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_bad_date_published_parsing(unique_item_strict):
-    """Tests parsing of a bad date_published string."""
-    unique_item_strict.date_published = "bad date"
-    unique_item_strict.create()
+    """Tests parsing of a bad date_published string at write time.
 
-    with pytest.raises(ValueError) as e:
-        _ = ItemStrict.read(unique_item_strict.url_hash)
-    assert "Invalid date format" in str(e.value)
+    The Postgres TIMESTAMPTZ column rejects unparseable values, so the
+    error surfaces on ``.create()`` rather than on ``.read()`` (which is
+    where it surfaced under the previous JSON-blob storage).
+    """
+    unique_item_strict.date_published = "bad date"
+    with pytest.raises(Exception):
+        unique_item_strict.create()
 
 
 def test_create_read_item(unique_item_strict):

--- a/src/api/tests/db/user_test.py
+++ b/src/api/tests/db/user_test.py
@@ -4,14 +4,14 @@ from db.user import User
 
 
 def test_create_user(unique_user):
-    with unique_user.db_con() as r:
-        assert not unique_user.exists()
-        assert len(r.smembers("USERS")) == 0
-        unique_user.set_password("password")
-        unique_user.create()
-        assert unique_user.exists()
-        assert len(r.smembers("USERS")) == 1
-        assert unique_user.name_hash in r.smembers("USERS")
+    assert not unique_user.exists()
+    assert User.read_all() == []
+    unique_user.set_password("password")
+    unique_user.create()
+    assert unique_user.exists()
+    all_users = User.read_all()
+    assert len(all_users) == 1
+    assert all_users[0].name_hash == unique_user.name_hash
 
 
 def test_read_user(existing_user):

--- a/src/api/tests/fixtures/feed.py
+++ b/src/api/tests/fixtures/feed.py
@@ -6,21 +6,22 @@ from db.user import User
 
 
 @pytest.fixture(scope="function")
-def unique_feed(unique_user: User) -> Feed:
-    """Generates unique feed data for each test, assuming a Redis connection fixture."""
+def unique_feed(existing_user: User) -> Feed:
+    """Generates unique feed data for each test.
+
+    The owning user is created so the foreign key constraint to ``users``
+    is satisfied if the feed itself is later persisted.
+    """
     feed = Feed(
-        user_hash=unique_user.name_hash,
+        user_hash=existing_user.name_hash,
         name=f"Feed Name {uuid.uuid4()}",
     )
 
     yield feed
 
-    if feed.exists():
-        feed.delete()
-
 
 @pytest.fixture(scope="function")
 def existing_feed(unique_feed: Feed, existing_user: User) -> Feed:
-    """Generates existing feed data for each test, assuming a Redis connection fixture."""
-    existing_user.add_feed(unique_feed)
+    if not unique_feed.exists():
+        existing_user.add_feed(unique_feed)
     yield unique_feed

--- a/src/api/tests/fixtures/item.py
+++ b/src/api/tests/fixtures/item.py
@@ -5,7 +5,7 @@ from db.item import ItemStrict
 
 
 @pytest.fixture(scope="function")
-def unique_item_strict(unique_feed):
+def unique_item_strict():
     item = ItemStrict(
         url="http://example.com/",
         author="Example author",
@@ -19,13 +19,11 @@ def unique_item_strict(unique_feed):
 
     yield item
 
-    if item.exists():
-        item.delete()
-
 
 @pytest.fixture(scope="function")
 def existing_item_strict(existing_source, existing_feed, unique_item_strict):
-    unique_item_strict.create()
+    if not unique_item_strict.exists():
+        unique_item_strict.create()
     existing_source.add_items(unique_item_strict)
     existing_feed.add_items(unique_item_strict)
     yield unique_item_strict

--- a/src/api/tests/fixtures/source.py
+++ b/src/api/tests/fixtures/source.py
@@ -7,23 +7,24 @@ from db.user import User
 
 
 @pytest.fixture(scope="function")
-def unique_source(unique_feed: Feed, unique_user: User) -> Source:
-    """Generates unique source data for each test"""
+def unique_source(existing_feed: Feed, existing_user: User) -> Source:
+    """Generates unique source data for each test.
+
+    Depends on ``existing_feed`` so the (user_hash, feed_hash) foreign key
+    can be satisfied if the source is persisted.
+    """
     source = Source(
-        user_hash=unique_user.name_hash,
-        feed_hash=unique_feed.name_hash,
+        user_hash=existing_user.name_hash,
+        feed_hash=existing_feed.name_hash,
         name=f"Source Name {uuid.uuid4()}",
         url="http://example.com",
     )
 
     yield source
 
-    if source.exists():
-        source.delete()
-
 
 @pytest.fixture(scope="function")
 def existing_source(unique_source: Source, existing_feed: Feed) -> Source:
-    """Generates existing source data for each test"""
-    existing_feed.add_source(unique_source)
+    if not unique_source.exists():
+        existing_feed.add_source(unique_source)
     yield unique_source

--- a/src/api/tests/fixtures/user.py
+++ b/src/api/tests/fixtures/user.py
@@ -14,11 +14,9 @@ def unique_user() -> User:
 
     yield user
 
-    if user.exists():
-        user.delete()
-
 
 @pytest.fixture(scope="function")
 def existing_user(unique_user) -> User:
-    unique_user.create()
+    if not unique_user.exists():
+        unique_user.create()
     yield unique_user


### PR DESCRIPTION
- Replace the Valkey/Redis backing store with Postgres 16, with schema
  managed by Flyway and an initial V1 migration that models users,
  feeds, sources, items, feed/source item join tables, item states, and
  source templates with proper foreign keys.
- Rewrite db/base.py around a psycopg2 ThreadedConnectionPool exposing
  a RealDictCursor via the existing db_con() context manager. db_init()
  now verifies connectivity and (with flush=True) truncates all tables
  for tests.
- Rewrite User, Feed, Source, ItemBase/ItemStrict/ItemLoose, ItemState,
  ItemCollection, and SourceTemplate to use SQL with parameterised
  queries and ON CONFLICT upserts where appropriate.
- Replace the SOURCES-TO-INGEST sorted-set queue with a next_ingest_at
  column on sources; the ingest job picks the next due source via
  SELECT ... FOR UPDATE SKIP LOCKED.
- Update docker-compose, the api dev/test compose files, dockerfiles,
  coverage.sh, requirements.txt, and config to add aggy-db (postgres),
  aggy-flyway (runs migrations from src/api/db/migrations), and
  aggy-pgadmin services, and to plumb DB_USER/DB_PASSWORD/DB_NAME.
- Update fixtures and db/router tests to match the new API surface and
  to honour foreign-key constraints; rely on a per-test TRUNCATE
  autouse fixture for isolation.