### PR TITLE
Publish a Flyway migrations image so deployments don't need a repo checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,13 @@ jobs:
       packages: write
     strategy:
       matrix:
-        service: ['api', 'bridge']
+        include:
+          - service: api
+            context: ./src/api
+          - service: bridge
+            context: ./src/bridge
+          - service: migrations
+            context: ./src/api/db/migrations
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -63,8 +69,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: ./src/${{ matrix.service }}
-          file: ./src/${{ matrix.service }}/dockerfile
+          context: ${{ matrix.context }}
+          file: ${{ matrix.context }}/dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,8 @@ services:
       retries: 10
 
   aggy-flyway:
-    image: flyway/flyway:10-alpine
+    image: ghcr.io/mullinmax/aggy/aggy-migrations:latest
     command: -url=jdbc:postgresql://aggy-db:5432/aggy -user=aggy -password=aggy -connectRetries=30 migrate
-    volumes:
-      - "./src/api/db/migrations:/flyway/sql"
     depends_on:
       aggy-db:
         condition: service_healthy

--- a/src/api/db/migrations/dockerfile
+++ b/src/api/db/migrations/dockerfile
@@ -1,0 +1,3 @@
+FROM flyway/flyway:10-alpine
+
+COPY V*.sql /flyway/sql/


### PR DESCRIPTION
## Problem

The deploy `docker-compose.yml` uses prebuilt GHCR images for everything, but the `aggy-flyway` service bind-mounted `./src/api/db/migrations` from the host. Deploying the compose file without a full repo checkout mounted an empty directory, so Flyway "succeeded" with zero migrations and the API failed at runtime with `psycopg2.errors.UndefinedTable: relation "users" does not exist` (signup returned 500).

## Changes

- Added `src/api/db/migrations/dockerfile`: `flyway/flyway:10-alpine` with the `V*.sql` migrations copied into `/flyway/sql/`.
- `release.yml`: builds/pushes `aggy-migrations` alongside `aggy-api` and `aggy-bridge` (matrix switched to `include:` with per-service contexts).
- `docker-compose.yml`: `aggy-flyway` now uses `ghcr.io/mullinmax/aggy/aggy-migrations:latest` and the bind mount is removed.

The dev/test compose files under `src/api/` still bind-mount the local migrations, which is right for development.

## Notes

- Migrations image tags follow the same scheme as the other images (`main`, `dev`, `rc-*`, semver, `latest` on release), so the compose file works once a release is cut; until then use the `main`/`dev` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3fTqR2ARSY8ik4ng6kcGq

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3fTqR2ARSY8ik4ng6kcGq)_