### PR TITLE
Fix stale cached app.js breaking modals; add first-run onboarding

### DIFF
--- a/src/api/routers/web.py
+++ b/src/api/routers/web.py
@@ -6,6 +6,22 @@ from fastapi.templating import Jinja2Templates
 BASE_DIR = Path(__file__).resolve().parent.parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
+
+def static_url(path: str) -> str:
+    """Static asset URL with a cache-busting version derived from the file's
+    mtime, so browsers pick up new assets after a deploy instead of serving
+    stale cached scripts (which can break the page, e.g. duplicate globals
+    from an old app.js alongside a new core.js)."""
+    file = BASE_DIR / "static" / path.lstrip("/")
+    try:
+        version = int(file.stat().st_mtime)
+    except OSError:
+        version = 0
+    return f"/static/{path.lstrip('/')}?v={version}"
+
+
+templates.env.globals["static_url"] = static_url
+
 web_router = APIRouter()
 
 

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -10,6 +10,7 @@ const PAGE_SIZE = 20;
 let currentFeed = null;
 let itemSkip = 0;
 let selectedTemplate = null;
+let onboardingContinue = false; // set when the user creates their very first feed
 
 // ---------- boot ----------
 document.addEventListener('DOMContentLoaded', async () => {
@@ -73,10 +74,7 @@ async function loadFeeds() {
   try {
     const feeds = await sdk.feedList();
     if (!feeds.length) {
-      render(grid, h('div', { class: 'col-span-full' },
-        emptyState('\u{1F4E1}', 'No feeds yet',
-          'Create your first feed to start aggregating content',
-          h('button', { class: 'btn btn-primary btn-sm', onclick: () => showModal('createFeedModal') }, '+ Create Feed'))));
+      render(grid, h('div', { class: 'col-span-full' }, onboardingWelcome()));
       return;
     }
     render(grid, feeds.map(feedCard));
@@ -84,6 +82,34 @@ async function loadFeeds() {
     render(grid, h('div', { class: 'col-span-full text-center py-16 text-base-content/50' }, 'Failed to load feeds'));
     toast(err.message, 'alert-error');
   }
+}
+
+// First-run onboarding shown in place of the feed grid when the user has no feeds.
+function onboardingWelcome() {
+  const step = (num, title, message, active) =>
+    h('li', { class: 'flex gap-4 items-start' },
+      h('div', {
+        class: `badge ${active ? 'badge-primary' : 'badge-ghost'} badge-lg font-bold flex-shrink-0`,
+      }, String(num)),
+      h('div', {},
+        h('div', { class: `font-semibold text-sm ${active ? '' : 'text-base-content/50'}` }, title),
+        h('div', { class: 'text-xs text-base-content/60 mt-0.5' }, message)));
+
+  return h('div', { class: 'card bg-base-200 border border-base-300 max-w-lg mx-auto mt-8' },
+    h('div', { class: 'card-body' },
+      h('p', { class: 'text-4xl mb-1' }, '\u{1F44B}'),
+      h('h2', { class: 'card-title' }, 'Welcome to Aggy!'),
+      h('p', { class: 'text-sm text-base-content/60 mb-4' },
+        'Aggy pulls articles from sources you choose into feeds, then learns what you like as you vote. Getting set up takes three quick steps:'),
+      h('ul', { class: 'flex flex-col gap-4 mb-5' },
+        step(1, 'Create a feed', 'A feed is a topic bucket, like "Technology" or "Sports".', true),
+        step(2, 'Add sources', 'Point the feed at websites via templates or RSS URLs.', false),
+        step(3, 'Read & vote', 'Articles roll in; upvote and downvote to tune your ranking.', false)),
+      h('div', { class: 'card-actions' },
+        h('button', {
+          class: 'btn btn-primary w-full',
+          onclick: () => { onboardingContinue = true; showModal('createFeedModal'); $('newFeedName').focus(); },
+        }, 'Create your first feed'))));
 }
 
 function feedCard(feed) {
@@ -163,6 +189,17 @@ async function showFeed(hash) {
 
   $('feedTitle').textContent = currentFeed.feed_name;
   $('feedBreadcrumb').textContent = currentFeed.feed_name;
+
+  // Continue first-run onboarding: land the user on the next step (adding
+  // a source) instead of an empty articles list.
+  if (onboardingContinue) {
+    onboardingContinue = false;
+    switchFeedTab('sources');
+    showModal('addSourceModal');
+    toast('Feed created! Now add a source — search a template or paste an RSS URL.', 'alert-info');
+    return;
+  }
+
   switchFeedTab('items');
   loadFeedItems();
 }

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -164,5 +164,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/app.js"></script>
+<script src="{{ static_url('js/app.js') }}"></script>
 {% endblock %}

--- a/src/api/templates/base.html
+++ b/src/api/templates/base.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}Aggy{% endblock %}</title>
   <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="/static/css/tailwind.css">
-  <link rel="stylesheet" href="/static/css/style.css">
+  <link rel="stylesheet" href="{{ static_url('css/tailwind.css') }}">
+  <link rel="stylesheet" href="{{ static_url('css/style.css') }}">
 </head>
 <body class="min-h-screen bg-base-300">
   {% block body %}{% endblock %}
   <div class="toast toast-end z-50" id="toasts"></div>
-  <script src="/static/js/core.js"></script>
-  <script src="/static/js/sdk.js"></script>
+  <script src="{{ static_url('js/core.js') }}"></script>
+  <script src="{{ static_url('js/sdk.js') }}"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/src/api/templates/login.html
+++ b/src/api/templates/login.html
@@ -53,5 +53,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/login.js"></script>
+<script src="{{ static_url('js/login.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## What

**Fixes the `Uncaught SyntaxError: Identifier 'showModal' has already been declared` error** that made "+ Add Feed" (and every other button) dead for users.

Root cause: the current source has only one `showModal` declaration (in `core.js`). The error comes from the browser serving a **stale cached `app.js`** from before the #88 UI rewrite — that old monolithic `app.js` declared `function showModal(...)` at top level. Loading new `core.js` + old cached `app.js` collides, the SyntaxError aborts the whole script, and no handlers get bound.

Fix: static asset URLs (`core.js`, `sdk.js`, `app.js`, `login.js`, CSS) are now rendered through a `static_url()` Jinja helper that appends an mtime-based `?v=` cache-buster, so every deploy forces browsers to fetch fresh assets.

## Guided onboarding for new users

- Users with no feeds now see a welcome card on the dashboard explaining the flow (1. create a feed → 2. add sources → 3. read & vote) with a single "Create your first feed" call to action, instead of a bare empty state.
- After creating that first feed, they land directly on the **Sources** tab with the **Add Source** modal already open and a hint toast — the next required step, rather than an empty articles list.

## Testing

- `node --check` on modified JS
- Rendered all three templates through Jinja to confirm the `?v=` cache-buster appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MVC9nfvdA16DpaTQffAFn

---
_Generated by [Claude Code](https://claude.ai/code/session_018MVC9nfvdA16DpaTQffAFn)_