### PR TITLE
Add source editing UI, fix duplicate-name sources, improve reddit previews

### DIFF
--- a/src/api/db/feed.py
+++ b/src/api/db/feed.py
@@ -76,7 +76,7 @@ class Feed(ItemCollection):
         with self.db_con() as cur:
             cur.execute(
                 "SELECT s.name, s.url, s.name_hash, s.feed_hash, s.last_ingested_at, "
-                "s.last_ingest_error, "
+                "s.last_ingest_error, s.template_name_hash, s.template_parameters, "
                 "(SELECT COUNT(*) FROM source_items si "
                 " WHERE si.user_hash = s.user_hash AND si.feed_hash = s.feed_hash "
                 " AND si.source_hash = s.name_hash) AS item_count "

--- a/src/api/db/migrations/V5__source_template_params.sql
+++ b/src/api/db/migrations/V5__source_template_params.sql
@@ -1,0 +1,23 @@
+-- Remember which template (and which parameter values) a source was created
+-- from, so the UI can offer editing a source's parameters after creation.
+ALTER TABLE sources
+    ADD COLUMN template_name_hash TEXT,
+    ADD COLUMN template_parameters JSONB;
+
+-- Renaming a source changes its name_hash (the hash is derived from the
+-- name), so the source_items FK must follow the new key.
+DO $$
+DECLARE con TEXT;
+BEGIN
+    SELECT conname INTO con
+    FROM pg_constraint
+    WHERE conrelid = 'source_items'::regclass
+      AND contype = 'f'
+      AND confrelid = 'sources'::regclass;
+    EXECUTE format('ALTER TABLE source_items DROP CONSTRAINT %I', con);
+END $$;
+
+ALTER TABLE source_items
+    ADD FOREIGN KEY (user_hash, feed_hash, source_hash)
+        REFERENCES sources(user_hash, feed_hash, name_hash)
+        ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/api/db/source.py
+++ b/src/api/db/source.py
@@ -1,3 +1,6 @@
+import json
+from typing import Dict, Optional
+
 from pydantic import StringConstraints, HttpUrl
 from typing_extensions import Annotated
 
@@ -10,6 +13,10 @@ class Source(ItemCollection):
     feed_hash: str
     name: Annotated[str, StringConstraints(strict=True, min_length=1)]
     url: HttpUrl
+    # Set when the source was created from a template, so its parameters can
+    # be edited later.
+    template_name_hash: Optional[str] = None
+    template_parameters: Optional[Dict[str, str]] = None
 
     @property
     def name_hash(self):
@@ -55,15 +62,48 @@ class Source(ItemCollection):
         with self.db_con() as cur:
             cur.execute(
                 "INSERT INTO sources (user_hash, feed_hash, name_hash, name, url, "
-                "next_ingest_at) VALUES (%s, %s, %s, %s, %s, NOW())",
+                "template_name_hash, template_parameters, next_ingest_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s, NOW())",
                 (
                     self.user_hash,
                     self.feed_hash,
                     self.name_hash,
                     self.name,
                     str(self.url),
+                    self.template_name_hash,
+                    json.dumps(self.template_parameters)
+                    if self.template_parameters is not None
+                    else None,
                 ),
             )
+
+    def update(self, name: str, url: str, template_parameters=None):
+        """Update this source in place. Renaming changes name_hash; the
+        source_items FK cascades so existing items stay attached. Resets
+        next_ingest_at so the (possibly new) URL is fetched promptly."""
+        new_name_hash = self.__insecure_hash__(name)
+        with self.db_con() as cur:
+            cur.execute(
+                "UPDATE sources SET name = %s, name_hash = %s, url = %s, "
+                "template_parameters = COALESCE(%s, template_parameters), "
+                "next_ingest_at = NOW() "
+                "WHERE user_hash = %s AND feed_hash = %s AND name_hash = %s",
+                (
+                    name,
+                    new_name_hash,
+                    str(url),
+                    json.dumps(template_parameters)
+                    if template_parameters is not None
+                    else None,
+                    self.user_hash,
+                    self.feed_hash,
+                    self.name_hash,
+                ),
+            )
+        self.name = name
+        self.url = url
+        if template_parameters is not None:
+            self.template_parameters = template_parameters
 
     def delete(self):
         with self.db_con() as cur:
@@ -126,7 +166,8 @@ class Source(ItemCollection):
     def read(cls, user_hash, feed_hash, source_hash):
         with cls.db_con() as cur:
             cur.execute(
-                "SELECT name, url FROM sources "
+                "SELECT name, url, template_name_hash, template_parameters "
+                "FROM sources "
                 "WHERE user_hash = %s AND feed_hash = %s AND name_hash = %s",
                 (user_hash, feed_hash, source_hash),
             )
@@ -138,6 +179,8 @@ class Source(ItemCollection):
                 feed_hash=feed_hash,
                 name=row["name"],
                 url=row["url"],
+                template_name_hash=row["template_name_hash"],
+                template_parameters=row["template_parameters"],
             )
         raise ValueError("Source not found")
 

--- a/src/api/ingest/item/rss.py
+++ b/src/api/ingest/item/rss.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 import feedparser
 
 from db.item import ItemLoose
@@ -10,12 +12,16 @@ def ingest_rss_item(entry: feedparser.FeedParserDict) -> ItemLoose:
     except Exception:
         entry_content = None
 
+    link = entry.get("link")
+    # domain is the site's hostname, not the full article URL
+    domain = urlparse(link).netloc if link else None
+
     return ItemLoose(
-        url=entry.get("link"),
+        url=link,
         title=entry.get("title"),
         content=entry_content,
         author=entry.get("author"),
         date_published=entry.get("published"),
-        domain=entry.get("link"),
+        domain=domain or None,
         excerpt=entry_content,
     )

--- a/src/api/route_models/source.py
+++ b/src/api/route_models/source.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from typing import Dict, Optional
 
 from pydantic import HttpUrl
 
@@ -15,6 +15,8 @@ class SourceRouteModel(BaseRouteModel):
     source_item_count: int = 0
     source_last_ingested_at: Optional[datetime] = None
     source_last_ingest_error: Optional[str] = None
+    source_template_name_hash: Optional[str] = None
+    source_template_parameters: Optional[Dict[str, str]] = None
 
     @classmethod
     def from_db_model(cls, db_model: Source):
@@ -23,6 +25,8 @@ class SourceRouteModel(BaseRouteModel):
             source_name_hash=db_model.name_hash,
             source_url=db_model.url,
             source_feed=db_model.feed_hash,
+            source_template_name_hash=db_model.template_name_hash,
+            source_template_parameters=db_model.template_parameters,
         )
 
     @classmethod
@@ -35,4 +39,6 @@ class SourceRouteModel(BaseRouteModel):
             source_item_count=row["item_count"],
             source_last_ingested_at=row["last_ingested_at"],
             source_last_ingest_error=row["last_ingest_error"],
+            source_template_name_hash=row.get("template_name_hash"),
+            source_template_parameters=row.get("template_parameters"),
         )

--- a/src/api/route_models/source_update.py
+++ b/src/api/route_models/source_update.py
@@ -1,0 +1,26 @@
+from typing import Dict, Optional
+
+from .base import BaseRouteModel
+
+
+class SourceUpdate(BaseRouteModel):
+    feed_name_hash: str
+    source_name_hash: str
+    source_name: str
+    # Manual sources: a new feed URL. Ignored for template sources.
+    source_url: Optional[str] = None
+    # Template sources: new parameter values; the URL is rebuilt from the
+    # source's template.
+    parameters: Optional[Dict[str, str]] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "feed_name_hash": "feed_hash_456",
+                "source_name_hash": "source_hash_789",
+                "source_name": "Example Source Name",
+                "source_url": "https://example.com/rss.xml",
+                "parameters": {"parameter_name": "value"},
+            }
+        }
+    }

--- a/src/api/routers/source.py
+++ b/src/api/routers/source.py
@@ -4,10 +4,13 @@ from typing import List, Union
 
 from db.feed import Feed
 from db.source import Source
+from db.source_template import SourceTemplate
 from db.user import User
 from ingest.jobs import ingest_source_now
 from route_models.item import ItemResponse
 from route_models.acknowledge import AcknowledgeResponse
+from route_models.source import SourceRouteModel
+from route_models.source_update import SourceUpdate
 from routers.auth import authenticate
 
 source_router = APIRouter()
@@ -26,16 +29,84 @@ def create_source(
     user: User = Depends(authenticate),
 ) -> AcknowledgeResponse:
     feed = Feed.read(user_hash=user.name_hash, name_hash=feed_name_hash)
+    if feed is None:
+        raise HTTPException(status_code=404, detail="Feed not found")
     source = Source(
         user_hash=user.name_hash,
         feed_hash=feed_name_hash,
         name=source_name,
         url=source_url,
     )
+    if source.exists():
+        raise HTTPException(
+            status_code=409,
+            detail=f'A source named "{source_name}" already exists in this feed',
+        )
     feed.add_source(source)
     # kick off the first ingest right away instead of waiting for the schedule
     background_tasks.add_task(ingest_source_now, source)
     return AcknowledgeResponse()
+
+
+@source_router.post(
+    "/update",
+    summary="Update a source's name, URL, or template parameters",
+    response_model=SourceRouteModel,
+)
+def update_source(
+    update: SourceUpdate,
+    background_tasks: BackgroundTasks,
+    user: User = Depends(authenticate),
+) -> SourceRouteModel:
+    try:
+        source = Source.read(
+            user_hash=user.name_hash,
+            feed_hash=update.feed_name_hash,
+            source_hash=update.source_name_hash,
+        )
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Source not found")
+
+    new_name = update.source_name.strip()
+    if not new_name:
+        raise HTTPException(status_code=422, detail="Source name cannot be empty")
+
+    # renaming must not collide with another source in the feed
+    if new_name != source.name:
+        other = Source(
+            user_hash=user.name_hash,
+            feed_hash=update.feed_name_hash,
+            name=new_name,
+            url=str(source.url),
+        )
+        if other.exists():
+            raise HTTPException(
+                status_code=409,
+                detail=f'A source named "{new_name}" already exists in this feed',
+            )
+
+    new_url = str(source.url)
+    new_parameters = None
+    if source.template_name_hash and update.parameters is not None:
+        template = SourceTemplate.read(name_hash=source.template_name_hash)
+        if not template:
+            raise HTTPException(status_code=404, detail="Source template not found")
+        try:
+            new_url = template.create_rss_url(**update.parameters)
+        except Exception as e:
+            raise HTTPException(status_code=422, detail=str(e))
+        new_parameters = update.parameters
+    elif update.source_url:
+        new_url = update.source_url
+
+    url_changed = new_url != str(source.url)
+    source.update(name=new_name, url=new_url, template_parameters=new_parameters)
+
+    if url_changed:
+        # fetch the new URL right away instead of waiting for the schedule
+        background_tasks.add_task(ingest_source_now, source)
+
+    return SourceRouteModel.from_db_model(source)
 
 
 @source_router.get(

--- a/src/api/routers/source_template.py
+++ b/src/api/routers/source_template.py
@@ -74,7 +74,19 @@ def create_source_from_template(
         feed_hash=sf_template.feed_hash,
         name=sf_template.source_name,
         url=source_url,
+        template_name_hash=source_template.name_hash,
+        template_parameters=sf_template.parameters,
     )
+    if source.exists():
+        # add_source() silently no-ops on duplicates, which used to leave the
+        # new source's items attributed to the old source of the same name
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f'A source named "{sf_template.source_name}" already exists '
+                "in this feed. Pick a different name."
+            ),
+        )
     feed.add_source(source)
 
     # kick off the first ingest right away instead of waiting for the schedule

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -10,6 +10,8 @@ const PAGE_SIZE = 20;
 let currentFeed = null;
 let itemSkip = 0;
 let selectedTemplate = null;
+let editingSource = null;
+let editingTemplate = null;
 let onboardingContinue = false; // set when the user creates their very first feed
 
 // ---------- boot ----------
@@ -52,6 +54,7 @@ function bindControls() {
   $('templateBackBtn').onclick = clearTemplateSelection;
   $('templateAddBtn').onclick = handleCreateSourceFromTemplate;
   $('manualSourceForm').onsubmit = handleCreateManualSource;
+  $('editSourceSaveBtn').onclick = handleUpdateSource;
 }
 
 function setView(name) {
@@ -237,13 +240,39 @@ async function loadFeedItems() {
   }
 }
 
+// Parse an item's (server-sanitized) content once to pull out the pieces the
+// UI cares about: a usable image and whether it's reddit-style boilerplate.
+function parseItemContent(item) {
+  const root = document.createElement('div');
+  root.innerHTML = item.item_content || '';
+  const img = root.querySelector('img');
+  const isReddit = Array.from(root.querySelectorAll('a'))
+    .some((a) => a.textContent.trim() === '[comments]');
+  return {
+    root,
+    isReddit,
+    imageUrl: item.item_image_url || (img ? img.src : null),
+    imageFromContent: !item.item_image_url && !!img,
+  };
+}
+
+// Excerpts for reddit posts are mostly "submitted by /u/x [link] [comments]"
+// noise — strip that so cards show real text or nothing.
+function cleanExcerpt(item) {
+  let text = (item.item_excerpt || '').replace(/\s+/g, ' ').trim();
+  text = text.replace(/submitted by\s+\/u\/\S+.*$/i, '').trim();
+  if (/^submitted by\b/i.test(text)) return '';
+  return text;
+}
+
 function itemCard(item) {
   const published = item.item_date_published ? timeAgo(item.item_date_published) : '';
+  const imageUrl = item.item_image_url || parseItemContent(item).imageUrl;
 
-  const image = item.item_image_url
+  const image = imageUrl
     ? h('figure', { class: 'w-24 h-24 flex-shrink-0 rounded-lg overflow-hidden bg-base-300 hidden sm:block' },
         h('img', {
-          src: item.item_image_url, class: 'w-full h-full object-cover', alt: '',
+          src: imageUrl, class: 'w-full h-full object-cover', alt: '',
           onerror: (e) => { e.target.parentElement.style.display = 'none'; },
         }))
     : null;
@@ -263,10 +292,9 @@ function itemCard(item) {
       image,
       h('div', { class: 'flex-1 min-w-0' },
         h('h3', { class: 'font-semibold text-sm leading-snug line-clamp-2' }, item.item_title || 'Untitled'),
-        h('p', { class: 'text-xs text-base-content/50 line-clamp-2 mt-1' }, item.item_excerpt || ''),
+        h('p', { class: 'text-xs text-base-content/50 line-clamp-2 mt-1' }, cleanExcerpt(item)),
         h('div', { class: 'flex flex-wrap items-center gap-2 mt-2' },
           item.item_source_name && h('span', { class: 'badge badge-secondary badge-outline badge-xs' }, item.item_source_name),
-          item.item_domain && h('span', { class: 'badge badge-primary badge-outline badge-xs' }, item.item_domain),
           item.item_author && h('span', { class: 'text-xs text-base-content/40' }, item.item_author),
           published && h('span', { class: 'text-xs text-base-content/40' }, published))),
       h('div', { class: 'flex flex-col items-center gap-0 flex-shrink-0' },
@@ -291,18 +319,48 @@ async function voteItem(item, score, btn) {
 }
 
 // ---------- reader ----------
+
+// Reddit RSS content wraps everything in a "submitted by /u/x [link]
+// [comments]" table that duplicates the title link, the author, and the
+// original link already shown in the reader header — strip it.
+function stripRedditBoilerplate(root, removeImage) {
+  root.querySelectorAll('a').forEach((a) => {
+    const t = a.textContent.trim();
+    if (t === '[link]' || t === '[comments]') a.remove();
+  });
+  if (removeImage) {
+    const img = root.querySelector('img');
+    if (img) (img.closest('a') || img).remove();
+  }
+  root.querySelectorAll('td, p').forEach((el) => {
+    const text = el.textContent.replace(/\s+/g, ' ').trim();
+    if (/^submitted by\b/i.test(text) && text.length < 120) el.remove();
+  });
+  root.querySelectorAll('table').forEach((t) => {
+    if (!t.textContent.trim() && !t.querySelector('img')) t.remove();
+  });
+}
+
 function openReader(item) {
   $('readerTitle').textContent = item.item_title || 'Untitled';
+  const parsed = parseItemContent(item);
+
+  let host = item.item_domain || '';
+  try { host = new URL(item.item_url).hostname.replace(/^www\./, ''); } catch { /* keep fallback */ }
 
   render($('readerMeta'),
-    item.item_domain && h('a', { href: item.item_url, target: '_blank', rel: 'noopener', class: 'link link-primary' }, item.item_domain),
+    item.item_source_name && h('span', { class: 'badge badge-secondary badge-outline badge-xs' }, item.item_source_name),
     item.item_author && h('span', {}, `by ${item.item_author}`),
     item.item_date_published && h('span', {}, timeAgo(item.item_date_published)),
-    h('a', { href: item.item_url, target: '_blank', rel: 'noopener', class: 'link link-primary ml-auto' }, 'Open original ↗'));
+    h('a', { href: item.item_url, target: '_blank', rel: 'noopener', class: 'link link-primary ml-auto' },
+      host ? `Open on ${host} ↗` : 'Open original ↗'));
 
+  // Non-reddit articles keep their images inline in the content; only
+  // promote a content image to the hero slot for reddit-style posts.
+  const heroUrl = item.item_image_url || (parsed.isReddit ? parsed.imageUrl : null);
   const img = $('readerImage');
-  if (item.item_image_url) {
-    img.src = item.item_image_url;
+  if (heroUrl) {
+    img.src = heroUrl;
     img.classList.remove('hidden');
     img.onerror = () => img.classList.add('hidden');
   } else {
@@ -311,10 +369,16 @@ function openReader(item) {
 
   // item_content is sanitized server-side (bleach) before storage; it is the
   // only place raw HTML is intentionally rendered.
-  if (item.item_content) {
-    $('readerContent').innerHTML = item.item_content;
+  if (parsed.isReddit) {
+    // the hero image above already shows the content image
+    stripRedditBoilerplate(parsed.root, parsed.imageFromContent);
+  }
+  if (parsed.root.textContent.trim() || parsed.root.querySelector('img')) {
+    $('readerContent').innerHTML = parsed.root.innerHTML;
+  } else if (!heroUrl) {
+    render($('readerContent'), h('p', {}, cleanExcerpt(item) || 'No content available.'));
   } else {
-    render($('readerContent'), h('p', {}, item.item_excerpt || 'No content available.'));
+    render($('readerContent'));
   }
   showModal('readerModal');
 
@@ -359,10 +423,99 @@ function sourceRow(source) {
         `${count} article${count === 1 ? '' : 's'} · ${checked}`),
       source.source_last_ingest_error && h('div', { class: 'text-xs text-error mt-1' },
         `Last check failed: ${source.source_last_ingest_error}`)),
-    h('button', {
-      class: 'btn btn-ghost btn-xs text-error flex-shrink-0',
-      onclick: () => confirmDeleteSource(source),
-    }, 'Remove'));
+    h('div', { class: 'flex gap-1 flex-shrink-0' },
+      h('button', {
+        class: 'btn btn-ghost btn-xs',
+        onclick: () => openEditSourceModal(source),
+      }, 'Edit'),
+      h('button', {
+        class: 'btn btn-ghost btn-xs text-error',
+        onclick: () => confirmDeleteSource(source),
+      }, 'Remove')));
+}
+
+async function openEditSourceModal(source) {
+  editingSource = source;
+  editingTemplate = null;
+  $('editSourceTitle').textContent = `Edit ${source.source_name}`;
+  $('editSourceName').value = source.source_name;
+
+  const fields = $('editSourceFields');
+  if (source.source_template_name_hash) {
+    render(fields, spinner());
+    showModal('editSourceModal');
+    try {
+      editingTemplate = await sdk.sourceTemplateGet({ name_hash: source.source_template_name_hash });
+      const saved = source.source_template_parameters || {};
+      render(fields,
+        Object.entries(editingTemplate.parameters || {}).map(([key, param]) =>
+          templateParamField(key, param, saved[key])));
+    } catch (err) {
+      // template no longer exists — fall back to editing the raw URL
+      render(fields, editSourceUrlField(source));
+    }
+  } else {
+    render(fields, editSourceUrlField(source));
+    showModal('editSourceModal');
+  }
+}
+
+function editSourceUrlField(source) {
+  return h('div', { class: 'form-control mb-3' },
+    h('label', { class: 'label' }, h('span', { class: 'label-text' }, 'RSS Feed URL')),
+    h('input', {
+      type: 'url', class: 'input input-bordered w-full', name: 'source_url',
+      value: source.source_url, required: true,
+    }));
+}
+
+async function handleUpdateSource() {
+  if (!editingSource || !currentFeed) return;
+  const name = $('editSourceName').value.trim();
+  if (!name) { toast('Please enter a source name', 'alert-error'); return; }
+
+  const body = {
+    feed_name_hash: currentFeed.feed_name_hash,
+    source_name_hash: editingSource.source_name_hash,
+    source_name: name,
+  };
+
+  const urlInput = $('editSourceFields').querySelector('input[name="source_url"]');
+  if (urlInput) {
+    const url = urlInput.value.trim();
+    if (!url) { toast('Please enter a URL', 'alert-error'); return; }
+    body.source_url = url;
+  } else if (editingTemplate) {
+    const parameters = {};
+    let missing = null;
+    $('editSourceFields').querySelectorAll('.input-error').forEach((el) => el.classList.remove('input-error'));
+    $('editSourceFields').querySelectorAll('input, select').forEach((el) => {
+      const value = el.type === 'checkbox' ? (el.checked ? 'on' : '') : el.value.trim();
+      if (el.required && !value && !missing) missing = el;
+      parameters[el.name] = value;
+    });
+    if (missing) {
+      missing.classList.add('input-error');
+      missing.focus();
+      const label = (editingTemplate.parameters[missing.name] || {}).title || missing.name;
+      toast(`"${label}" is required`, 'alert-error');
+      return;
+    }
+    body.parameters = parameters;
+  }
+
+  try {
+    await sdk.sourceUpdate({ body });
+    closeModal('editSourceModal');
+    toast(`Source "${name}" updated`);
+    editingSource = null;
+    editingTemplate = null;
+    loadSources();
+    // an ingest may run in the background after a URL change; refresh
+    setTimeout(loadSources, 5000);
+  } catch (err) {
+    toast(err.message, 'alert-error');
+  }
 }
 
 function confirmDeleteSource(source) {
@@ -447,29 +600,49 @@ async function selectTemplate(hash) {
     $('templateSearch').classList.add('hidden');
     $('templateList').classList.add('hidden');
     $('templateParams').classList.remove('hidden');
-    $('templateSourceName').value = tmpl.user_friendly_name || tmpl.name || '';
+    const nameInput = $('templateSourceName');
+    const baseName = tmpl.user_friendly_name || tmpl.name || '';
+    nameInput.value = baseName;
     render($('templateParamFields'),
       Object.entries(tmpl.parameters || {}).map(([key, param]) => templateParamField(key, param)));
+
+    // Suggest a distinct name from the first required text parameter (e.g.
+    // "Reddit Subreddit - selfhosted") until the user edits the name field,
+    // so adding several sources from the same template doesn't collide.
+    let nameEdited = false;
+    nameInput.oninput = () => { nameEdited = true; };
+    const firstParam = $('templateParamFields').querySelector('input[type="text"][required]');
+    if (firstParam) {
+      firstParam.addEventListener('input', () => {
+        if (nameEdited) return;
+        const v = firstParam.value.trim();
+        nameInput.value = v ? `${baseName} - ${v}` : baseName;
+      });
+    }
   } catch (err) {
     toast(err.message, 'alert-error');
   }
 }
 
-function templateParamField(key, param) {
+// Renders one template parameter input. `current` (optional) prefills the
+// field with a previously saved value when editing an existing source.
+function templateParamField(key, param, current) {
   const label = param.title || param.name || key;
   let input;
   if (param.type === 'select' && param.options) {
+    const selected = current != null && current !== '' ? current : param.default;
     input = h('select', { class: 'select select-bordered w-full', name: key, required: !!param.required },
       Object.entries(param.options).map(([value, text]) =>
-        h('option', { value, selected: value === param.default }, text || value)));
+        h('option', { value, selected: value === selected }, text || value)));
   } else if (param.type === 'checkbox') {
-    input = h('input', { type: 'checkbox', class: 'checkbox', name: key, checked: param.default === 'checked' });
+    const checked = current != null ? current === 'on' : param.default === 'checked';
+    input = h('input', { type: 'checkbox', class: 'checkbox', name: key, checked });
   } else {
     input = h('input', {
       type: param.type === 'number' ? 'number' : 'text',
       class: 'input input-bordered w-full',
       name: key,
-      value: param.default || '',
+      value: current != null && current !== '' ? current : (param.default || ''),
       placeholder: param.example || '',
       required: !!param.required,
     });

--- a/src/api/static/js/sdk.js
+++ b/src/api/static/js/sdk.js
@@ -130,6 +130,11 @@ class AggySDK {
     return this._request("GET", "/source/items", { query: { feed_name_hash, source_name_hash, skip, limit } });
   }
 
+  /** Update a source's name, URL, or template parameters */
+  async sourceUpdate({ body }) {
+    return this._request("POST", "/source/update", { body });
+  }
+
   /** Create a source from a template */
   async sourceTemplateCreate({ body }) {
     return this._request("POST", "/source_template/create", { body });

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -78,7 +78,7 @@
     <form method="dialog"><button class="btn btn-sm btn-circle btn-ghost absolute right-4 top-4">✕</button></form>
     <h2 class="text-xl font-bold pr-8 mb-2" id="readerTitle"></h2>
     <div class="flex flex-wrap gap-3 text-xs text-base-content/50 mb-4 pb-3 border-b border-base-300" id="readerMeta"></div>
-    <img id="readerImage" class="rounded-lg w-full max-h-96 object-cover mb-4 hidden">
+    <img id="readerImage" class="rounded-lg max-w-full max-h-[60vh] object-contain mx-auto mb-4 hidden">
     <div class="prose prose-sm max-w-none" id="readerContent"></div>
   </div>
   <form method="dialog" class="modal-backdrop"><button>close</button></form>
@@ -145,6 +145,23 @@
           <button type="submit" class="btn btn-primary">Add Source</button>
         </div>
       </form>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
+
+<!-- Edit Source Modal -->
+<dialog class="modal" id="editSourceModal">
+  <div class="modal-box max-w-2xl">
+    <h3 class="text-lg font-bold mb-4" id="editSourceTitle">Edit Source</h3>
+    <div class="form-control mb-3">
+      <label class="label" for="editSourceName"><span class="label-text">Source Name</span></label>
+      <input type="text" class="input input-bordered w-full" id="editSourceName" required>
+    </div>
+    <div id="editSourceFields"></div>
+    <div class="modal-action">
+      <button type="button" class="btn btn-ghost" data-close-modal>Cancel</button>
+      <button class="btn btn-primary" id="editSourceSaveBtn">Save Changes</button>
     </div>
   </div>
   <form method="dialog" class="modal-backdrop"><button>close</button></form>

--- a/src/api/tests/routers/feed_test.py
+++ b/src/api/tests/routers/feed_test.py
@@ -144,6 +144,8 @@ def test_sources(client, existing_user, existing_feed, existing_source, token):
             "source_item_count": 0,
             "source_last_ingested_at": None,
             "source_last_ingest_error": None,
+            "source_template_name_hash": None,
+            "source_template_parameters": None,
         }
     ]
 

--- a/src/api/tests/routers/source_template_test.py
+++ b/src/api/tests/routers/source_template_test.py
@@ -192,3 +192,90 @@ def test_search_returns_minimum_results_for_bad_query(
     finally:
         for template in dummies:
             template.delete()
+
+
+def test_create_duplicate_source_from_template_conflict(
+    client, existing_source_template, existing_feed, token, unique_source
+):
+    data = {
+        "source_template_name_hash": existing_source_template.name_hash,
+        "feed_hash": existing_feed.name_hash,
+        "source_name": unique_source.name,
+        "parameters": {"parameter_name": "value"},
+    }
+    args = build_api_request_args(path="/source_template/create", token=token, data=data)
+
+    response = client.post(**args)
+    assert response.status_code == 200
+
+    # same name again — must be rejected instead of silently ignored
+    response = client.post(**args)
+    assert response.status_code == 409
+
+
+def test_update_source_template_parameters(
+    client, existing_source_template, existing_feed, token, unique_source
+):
+    args = build_api_request_args(
+        path="/source_template/create",
+        token=token,
+        data={
+            "source_template_name_hash": existing_source_template.name_hash,
+            "feed_hash": existing_feed.name_hash,
+            "source_name": unique_source.name,
+            "parameters": {"parameter_name": "value"},
+        },
+    )
+    response = client.post(**args)
+    assert response.status_code == 200
+    created = response.json()
+    assert created["source_template_name_hash"] == existing_source_template.name_hash
+    assert created["source_template_parameters"] == {"parameter_name": "value"}
+
+    # change the parameter; the source URL is rebuilt from the template
+    args = build_api_request_args(
+        path="/source/update",
+        token=token,
+        data={
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name_hash": created["source_name_hash"],
+            "source_name": created["source_name"],
+            "parameters": {"parameter_name": "other_value"},
+        },
+    )
+    response = client.post(**args)
+    assert response.status_code == 200
+    updated = response.json()
+    assert "parameter_name=other_value" in updated["source_url"]
+    assert updated["source_template_parameters"] == {"parameter_name": "other_value"}
+
+
+def test_update_source_template_bad_parameters(
+    client, existing_source_template, existing_feed, token, unique_source
+):
+    args = build_api_request_args(
+        path="/source_template/create",
+        token=token,
+        data={
+            "source_template_name_hash": existing_source_template.name_hash,
+            "feed_hash": existing_feed.name_hash,
+            "source_name": unique_source.name,
+            "parameters": {"parameter_name": "value"},
+        },
+    )
+    response = client.post(**args)
+    assert response.status_code == 200
+    created = response.json()
+
+    args = build_api_request_args(
+        path="/source/update",
+        token=token,
+        data={
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name_hash": created["source_name_hash"],
+            "source_name": created["source_name"],
+            "parameters": {"parameter_name": "not_an_option"},
+        },
+    )
+    response = client.post(**args)
+    assert response.status_code == 422

--- a/src/api/tests/routers/source_test.py
+++ b/src/api/tests/routers/source_test.py
@@ -109,3 +109,118 @@ def test_delete_source(client, existing_feed, existing_source, token):
     response = client.get(**args)
     assert response.status_code == 404
     assert response.json() == {"detail": "Source not found"}
+
+
+def test_create_duplicate_source_conflict(client, existing_feed, existing_source, token):
+    args = build_api_request_args(
+        path="/source/create",
+        params={
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name": existing_source.name,
+            "source_url": "http://example.com/other.xml",
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+    assert response.status_code == 409
+
+
+def test_update_source_rename_and_url(client, existing_feed, existing_source, token):
+    args = build_api_request_args(
+        path="/source/update",
+        data={
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name_hash": existing_source.name_hash,
+            "source_name": f"{existing_source.name} renamed",
+            "source_url": "http://example.com/new.xml",
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+    assert response.status_code == 200
+    res_data = response.json()
+    assert res_data["source_name"] == f"{existing_source.name} renamed"
+    assert res_data["source_url"] == "http://example.com/new.xml"
+
+    # the old name_hash no longer resolves; the new one does
+    from db.source import Source
+
+    new_source = Source.read(
+        user_hash=existing_source.user_hash,
+        feed_hash=existing_feed.name_hash,
+        source_hash=res_data["source_name_hash"],
+    )
+    assert new_source.name == f"{existing_source.name} renamed"
+    assert str(new_source.url) == "http://example.com/new.xml"
+
+
+def test_update_source_rename_keeps_items(
+    client, existing_feed, existing_source, existing_item_strict, token
+):
+    args = build_api_request_args(
+        path="/source/update",
+        data={
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name_hash": existing_source.name_hash,
+            "source_name": f"{existing_source.name} renamed",
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+    assert response.status_code == 200
+    new_hash = response.json()["source_name_hash"]
+
+    args = build_api_request_args(
+        path="/source/items",
+        params={
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name_hash": new_hash,
+        },
+        token=token,
+    )
+    response = client.get(**args)
+    assert response.status_code == 200
+    assert response.json()[0]["item_title"] == existing_item_strict.title
+
+
+def test_update_source_rename_conflict(client, existing_feed, existing_source, token):
+    from db.source import Source
+
+    other = Source(
+        user_hash=existing_source.user_hash,
+        feed_hash=existing_feed.name_hash,
+        name=f"{existing_source.name} other",
+        url="http://example.com/other.xml",
+    )
+    existing_feed.add_source(other)
+
+    args = build_api_request_args(
+        path="/source/update",
+        data={
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name_hash": existing_source.name_hash,
+            "source_name": other.name,
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+    assert response.status_code == 409
+
+
+def test_update_source_not_found(client, existing_feed, token):
+    args = build_api_request_args(
+        path="/source/update",
+        data={
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name_hash": "does-not-exist",
+            "source_name": "whatever",
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+    assert response.status_code == 404


### PR DESCRIPTION
- New edit UI + POST /source/update: rename a source, change a manual
  source's URL, or change a template source's parameters (URL is rebuilt
  from the template). Sources now remember the template and parameters
  they were created from (migration V5); renaming cascades name_hash to
  source_items so existing articles stay attached.
- Creating a source whose name already exists in the feed now returns
  409 instead of silently no-oping (which left the new source's articles
  attributed to the old source and invisible in settings). The add-source
  form also auto-suggests a distinct name from the first required
  parameter (e.g. "Reddit Subreddit - selfhosted").
- Better article previews for reddit posts: cards fall back to the first
  content image for the thumbnail, drop the raw URL badge, and strip
  "submitted by ... [link] [comments]" noise from excerpts. The reader
  shows a single "Open on <host>" link, the source's user-defined name,
  a properly-fitted hero image, and de-duplicated reddit content.
- RSS ingest stores the hostname as the item domain instead of the full
  article URL.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RDbs2bYqC5zH7MVW6pugfT