### PR TITLE
Per-source check frequency, reddit gif/video/gallery ingestion, media-first feed cards

### DIFF
--- a/src/api/constants.py
+++ b/src/api/constants.py
@@ -1,6 +1,5 @@
 from config import config
-from datetime import timedelta
 
-SOURCE_READ_INTERVAL_TIMEDELTA = timedelta(
-    minutes=config.get_int("SOURCE_READ_INTERVAL_MINUTES")
-)
+# Server-wide default for how often sources are checked; individual sources
+# can override it via sources.ingest_interval_minutes.
+SOURCE_READ_INTERVAL_MINUTES = config.get_int("SOURCE_READ_INTERVAL_MINUTES")

--- a/src/api/db/feed.py
+++ b/src/api/db/feed.py
@@ -77,6 +77,7 @@ class Feed(ItemCollection):
             cur.execute(
                 "SELECT s.name, s.url, s.name_hash, s.feed_hash, s.last_ingested_at, "
                 "s.last_ingest_error, s.template_name_hash, s.template_parameters, "
+                "s.ingest_interval_minutes, "
                 "(SELECT COUNT(*) FROM source_items si "
                 " WHERE si.user_hash = s.user_hash AND si.feed_hash = s.feed_hash "
                 " AND si.source_hash = s.name_hash) AS item_count "

--- a/src/api/db/item.py
+++ b/src/api/db/item.py
@@ -20,6 +20,9 @@ class ItemBase(AggyBaseModel):
     author: Optional[str] = None
     date_published: Optional[datetime] = None
     image_url: Optional[str] = None
+    # Rich media extracted at ingest time (gifs, videos, galleries): a list
+    # of {"type": "image"|"gif"|"video", "url": ..., "poster": ...} dicts.
+    media: Optional[List[Dict[str, Optional[str]]]] = None
     embeddings: Optional[Dict[str, List[float]]] = None
 
     @property
@@ -46,6 +49,9 @@ class ItemBase(AggyBaseModel):
             "excerpt": data.get("excerpt"),
             "content": data.get("content"),
             "image_url": data.get("image_url"),
+            "media": json.dumps(data["media"])
+            if data.get("media") is not None
+            else None,
             "date_published": data.get("date_published"),
             "embeddings": json.dumps(data["embeddings"])
             if data.get("embeddings") is not None
@@ -60,14 +66,15 @@ class ItemBase(AggyBaseModel):
         with self.db_con() as cur:
             cur.execute(
                 "INSERT INTO items (url_hash, url, title, author, domain, excerpt, "
-                "content, image_url, date_published, embeddings) "
+                "content, image_url, media, date_published, embeddings) "
                 "VALUES (%(url_hash)s, %(url)s, %(title)s, %(author)s, %(domain)s, "
-                "%(excerpt)s, %(content)s, %(image_url)s, %(date_published)s, "
-                "%(embeddings)s) "
+                "%(excerpt)s, %(content)s, %(image_url)s, %(media)s, "
+                "%(date_published)s, %(embeddings)s) "
                 "ON CONFLICT (url_hash) DO UPDATE SET "
                 "url = EXCLUDED.url, title = EXCLUDED.title, author = EXCLUDED.author, "
                 "domain = EXCLUDED.domain, excerpt = EXCLUDED.excerpt, "
                 "content = EXCLUDED.content, image_url = EXCLUDED.image_url, "
+                "media = EXCLUDED.media, "
                 "date_published = EXCLUDED.date_published, "
                 "embeddings = EXCLUDED.embeddings",
                 v,
@@ -87,7 +94,7 @@ class ItemBase(AggyBaseModel):
         with cls.db_con() as cur:
             cur.execute(
                 "SELECT url, title, author, domain, excerpt, content, image_url, "
-                "date_published, embeddings FROM items WHERE url_hash = %s",
+                "media, date_published, embeddings FROM items WHERE url_hash = %s",
                 (url_hash,),
             )
             row = cur.fetchone()
@@ -171,7 +178,7 @@ class ItemBase(AggyBaseModel):
         return v
 
     def __str__(self):
-        non_printable = ["url_hash", "key", "embeddings"]
+        non_printable = ["url_hash", "key", "embeddings", "media"]
         # all fields besides url_hash, key, and item_embeddings
         print_attrs = [
             f"{k.upper()} {getattr(self, k)}"
@@ -229,6 +236,7 @@ class ItemLoose(ItemStrict):
             date_published=items[0].date_published,
             title=items[0].title,
             image_url=items[0].image_url,
+            media=items[0].media,
             domain=items[0].domain,
             excerpt=items[0].excerpt,
             content=items[0].content,
@@ -244,6 +252,7 @@ class ItemLoose(ItemStrict):
             # prefer non-null values
             best.title = best.title or item.title
             best.image_url = best.image_url or item.image_url
+            best.media = best.media or item.media
             best.domain = best.domain or item.domain
             best.excerpt = best.excerpt or item.excerpt
             best.content = best.content or item.content

--- a/src/api/db/migrations/V6__source_interval_and_item_media.sql
+++ b/src/api/db/migrations/V6__source_interval_and_item_media.sql
@@ -1,0 +1,7 @@
+-- Per-source ingest frequency override, in minutes.
+-- NULL means "use the server-wide SOURCE_READ_INTERVAL_MINUTES default".
+ALTER TABLE sources ADD COLUMN ingest_interval_minutes INTEGER;
+
+-- Rich media (gifs, videos, image galleries) extracted at ingest time,
+-- e.g. from reddit posts. A JSON array of {type, url, poster?} objects.
+ALTER TABLE items ADD COLUMN media JSONB;

--- a/src/api/db/source.py
+++ b/src/api/db/source.py
@@ -4,8 +4,12 @@ from typing import Dict, Optional
 from pydantic import StringConstraints, HttpUrl
 from typing_extensions import Annotated
 
-from constants import SOURCE_READ_INTERVAL_TIMEDELTA
+from constants import SOURCE_READ_INTERVAL_MINUTES
 from .item_collection import ItemCollection
+
+# Sentinel for update(): distinguishes "leave unchanged" from an explicit
+# None ("reset to the server default").
+_UNSET = object()
 
 
 class Source(ItemCollection):
@@ -17,6 +21,9 @@ class Source(ItemCollection):
     # be edited later.
     template_name_hash: Optional[str] = None
     template_parameters: Optional[Dict[str, str]] = None
+    # How often to check this source, in minutes. None uses the server-wide
+    # SOURCE_READ_INTERVAL_MINUTES default.
+    ingest_interval_minutes: Optional[int] = None
 
     @property
     def name_hash(self):
@@ -62,8 +69,9 @@ class Source(ItemCollection):
         with self.db_con() as cur:
             cur.execute(
                 "INSERT INTO sources (user_hash, feed_hash, name_hash, name, url, "
-                "template_name_hash, template_parameters, next_ingest_at) "
-                "VALUES (%s, %s, %s, %s, %s, %s, %s, NOW())",
+                "template_name_hash, template_parameters, ingest_interval_minutes, "
+                "next_ingest_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, NOW())",
                 (
                     self.user_hash,
                     self.feed_hash,
@@ -74,18 +82,31 @@ class Source(ItemCollection):
                     json.dumps(self.template_parameters)
                     if self.template_parameters is not None
                     else None,
+                    self.ingest_interval_minutes,
                 ),
             )
 
-    def update(self, name: str, url: str, template_parameters=None):
+    def update(
+        self, name: str, url: str, template_parameters=None, ingest_interval=_UNSET
+    ):
         """Update this source in place. Renaming changes name_hash; the
         source_items FK cascades so existing items stay attached. Resets
-        next_ingest_at so the (possibly new) URL is fetched promptly."""
+        next_ingest_at so the (possibly new) URL is fetched promptly.
+
+        ``ingest_interval`` sets the per-source check frequency in minutes;
+        pass ``None`` to reset it to the server default, or leave it out to
+        keep the current value."""
         new_name_hash = self.__insecure_hash__(name)
+        interval_sql = ""
+        interval_params: tuple = ()
+        if ingest_interval is not _UNSET:
+            interval_sql = "ingest_interval_minutes = %s, "
+            interval_params = (ingest_interval,)
         with self.db_con() as cur:
             cur.execute(
                 "UPDATE sources SET name = %s, name_hash = %s, url = %s, "
                 "template_parameters = COALESCE(%s, template_parameters), "
+                f"{interval_sql}"
                 "next_ingest_at = NOW() "
                 "WHERE user_hash = %s AND feed_hash = %s AND name_hash = %s",
                 (
@@ -95,6 +116,9 @@ class Source(ItemCollection):
                     json.dumps(template_parameters)
                     if template_parameters is not None
                     else None,
+                )
+                + interval_params
+                + (
                     self.user_hash,
                     self.feed_hash,
                     self.name_hash,
@@ -104,6 +128,8 @@ class Source(ItemCollection):
         self.url = url
         if template_parameters is not None:
             self.template_parameters = template_parameters
+        if ingest_interval is not _UNSET:
+            self.ingest_interval_minutes = ingest_interval
 
     def delete(self):
         with self.db_con() as cur:
@@ -120,8 +146,10 @@ class Source(ItemCollection):
             target_sql = "NOW()"
             params = ()
         else:
-            target_sql = "NOW() + %s"
-            params = (SOURCE_READ_INTERVAL_TIMEDELTA,)
+            target_sql = (
+                "NOW() + make_interval(mins => COALESCE(ingest_interval_minutes, %s))"
+            )
+            params = (SOURCE_READ_INTERVAL_MINUTES,)
 
         # Mirrors the Redis ZADD lt=True semantics: only move next_ingest_at
         # earlier, never later.
@@ -136,10 +164,11 @@ class Source(ItemCollection):
         """Push the next scheduled ingest a full interval out from now."""
         with self.db_con() as cur:
             cur.execute(
-                "UPDATE sources SET next_ingest_at = NOW() + %s "
+                "UPDATE sources SET next_ingest_at = NOW() + "
+                "make_interval(mins => COALESCE(ingest_interval_minutes, %s)) "
                 "WHERE user_hash = %s AND feed_hash = %s AND name_hash = %s",
                 (
-                    SOURCE_READ_INTERVAL_TIMEDELTA,
+                    SOURCE_READ_INTERVAL_MINUTES,
                     self.user_hash,
                     self.feed_hash,
                     self.name_hash,
@@ -166,7 +195,8 @@ class Source(ItemCollection):
     def read(cls, user_hash, feed_hash, source_hash):
         with cls.db_con() as cur:
             cur.execute(
-                "SELECT name, url, template_name_hash, template_parameters "
+                "SELECT name, url, template_name_hash, template_parameters, "
+                "ingest_interval_minutes "
                 "FROM sources "
                 "WHERE user_hash = %s AND feed_hash = %s AND name_hash = %s",
                 (user_hash, feed_hash, source_hash),
@@ -181,6 +211,7 @@ class Source(ItemCollection):
                 url=row["url"],
                 template_name_hash=row["template_name_hash"],
                 template_parameters=row["template_parameters"],
+                ingest_interval_minutes=row["ingest_interval_minutes"],
             )
         raise ValueError("Source not found")
 

--- a/src/api/ingest/item/reddit.py
+++ b/src/api/ingest/item/reddit.py
@@ -1,0 +1,151 @@
+"""Pull rich media (gifs, videos, galleries) out of reddit posts.
+
+Reddit's RSS feeds only carry a small thumbnail; the post's JSON endpoint
+has the full-resolution images, mp4 renditions of gifs, v.redd.it video
+streams, and gallery contents. This module fetches that JSON for reddit
+items and turns it into the item's ``media`` list.
+"""
+
+import logging
+import re
+from typing import List, Optional
+
+import requests
+
+from config import config
+from db.item import ItemLoose
+
+# A reddit post's comments page, which is what reddit RSS uses as the entry
+# link, e.g. https://www.reddit.com/r/pics/comments/abc123/title/
+_REDDIT_POST_RE = re.compile(
+    r"^https?://(?:www|old|new)\.reddit\.com/(?:r|user|u)/[^/]+/comments/", re.I
+)
+
+_IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".webp")
+_VIDEO_EXTENSIONS = (".mp4", ".webm")
+
+
+def is_reddit_post(url: Optional[str]) -> bool:
+    return bool(url and _REDDIT_POST_RE.match(str(url)))
+
+
+def _media_entry(type: str, url: str, poster: Optional[str] = None) -> dict:
+    entry = {"type": type, "url": url}
+    if poster:
+        entry["poster"] = poster
+    return entry
+
+
+def _preview_image(post: dict) -> Optional[str]:
+    try:
+        return post["preview"]["images"][0]["source"]["url"]
+    except (KeyError, IndexError, TypeError):
+        return None
+
+
+def _preview_mp4(post: dict) -> Optional[str]:
+    """Reddit's mp4 rendition of a gif post, when it exists (much smaller)."""
+    try:
+        return post["preview"]["images"][0]["variants"]["mp4"]["source"]["url"]
+    except (KeyError, IndexError, TypeError):
+        return None
+
+
+def _gallery_media(post: dict) -> List[dict]:
+    metadata = post.get("media_metadata") or {}
+    ordered = [
+        i.get("media_id") for i in (post.get("gallery_data") or {}).get("items") or []
+    ]
+    entries = []
+    for media_id in ordered or metadata.keys():
+        meta = metadata.get(media_id) or {}
+        if meta.get("status") != "valid":
+            continue
+        source = meta.get("s") or {}
+        if meta.get("e") == "AnimatedImage":
+            url = source.get("mp4") or source.get("gif")
+            if url:
+                entries.append(_media_entry("gif", url))
+        else:
+            url = source.get("u")
+            if url:
+                entries.append(_media_entry("image", url))
+    return entries
+
+
+def _post_media(post: dict) -> List[dict]:
+    if post.get("is_gallery"):
+        return _gallery_media(post)
+
+    # native reddit video (v.redd.it); fallback_url is a plain mp4 stream
+    reddit_video = ((post.get("secure_media") or post.get("media") or {})).get(
+        "reddit_video"
+    )
+    if reddit_video and reddit_video.get("fallback_url"):
+        media_type = "gif" if reddit_video.get("is_gif") else "video"
+        return [
+            _media_entry(
+                media_type, reddit_video["fallback_url"], _preview_image(post)
+            )
+        ]
+
+    target = post.get("url_overridden_by_dest") or post.get("url") or ""
+    path = target.split("?")[0].lower()
+
+    if path.endswith(".gifv"):
+        # imgur gifv pages wrap an mp4 of the same name
+        return [_media_entry("gif", _preview_mp4(post) or target[:-5] + ".mp4")]
+    if path.endswith(".gif"):
+        return [_media_entry("gif", _preview_mp4(post) or target)]
+    if path.endswith(_VIDEO_EXTENSIONS):
+        return [_media_entry("video", target, _preview_image(post))]
+    if path.endswith(_IMAGE_EXTENSIONS):
+        return [_media_entry("image", target)]
+    if post.get("post_hint") == "image":
+        image = _preview_image(post)
+        if image:
+            return [_media_entry("image", image)]
+    return []
+
+
+def ingest_reddit_item(item: ItemLoose) -> Optional[ItemLoose]:
+    url = str(item.url)
+    if not is_reddit_post(url):
+        return None
+
+    headers = {
+        "User-Agent": (
+            f"aggy/{config.get('BUILD_VERSION')} "
+            "(self-hosted feed aggregator; +https://github.com/mullinmax/aggy)"
+        )
+    }
+    try:
+        # raw_json=1 stops reddit from HTML-escaping the media URLs
+        response = requests.get(
+            url.rstrip("/") + ".json",
+            params={"raw_json": 1},
+            timeout=15,
+            headers=headers,
+        )
+        response.raise_for_status()
+        post = response.json()[0]["data"]["children"][0]["data"]
+    except Exception as e:
+        logging.warning(f"Could not fetch reddit post data for {url}: {e}")
+        return None
+
+    media = _post_media(post)
+
+    # a full-resolution card image beats the RSS thumbnail
+    image_url = _preview_image(post)
+    if not image_url:
+        first_image = next((m for m in media if m["type"] == "image"), None)
+        if first_image:
+            image_url = first_image["url"]
+
+    return ItemLoose(
+        url=item.url,
+        title=post.get("title"),
+        author=f"u/{post['author']}" if post.get("author") else None,
+        media=media or None,
+        image_url=image_url,
+    )

--- a/src/api/ingest/item/rss.py
+++ b/src/api/ingest/item/rss.py
@@ -5,6 +5,20 @@ import feedparser
 from db.item import ItemLoose
 
 
+def _link_media(link):
+    """Media entry for entries whose link points straight at a media file."""
+    if not link:
+        return None
+    path = urlparse(link).path.lower()
+    if path.endswith(".gif"):
+        return [{"type": "gif", "url": link}]
+    if path.endswith((".mp4", ".webm")):
+        return [{"type": "video", "url": link}]
+    if path.endswith((".jpg", ".jpeg", ".png", ".webp")):
+        return [{"type": "image", "url": link}]
+    return None
+
+
 def ingest_rss_item(entry: feedparser.FeedParserDict) -> ItemLoose:
     # TODO more advanced parsing of content (like when there's more than 1 value)
     try:
@@ -24,4 +38,5 @@ def ingest_rss_item(entry: feedparser.FeedParserDict) -> ItemLoose:
         date_published=entry.get("published"),
         domain=domain or None,
         excerpt=entry_content,
+        media=_link_media(link),
     )

--- a/src/api/ingest/jobs.py
+++ b/src/api/ingest/jobs.py
@@ -1,6 +1,6 @@
 import logging
 
-from constants import SOURCE_READ_INTERVAL_TIMEDELTA
+from constants import SOURCE_READ_INTERVAL_MINUTES
 from db.base import get_db_con
 from db.source import Source
 from ingest.source import ingest_source
@@ -41,10 +41,11 @@ def source_ingestion_job() -> None:
             return
 
         cur.execute(
-            "UPDATE sources SET next_ingest_at = NOW() + %s "
+            "UPDATE sources SET next_ingest_at = NOW() + "
+            "make_interval(mins => COALESCE(ingest_interval_minutes, %s)) "
             "WHERE user_hash = %s AND feed_hash = %s AND name_hash = %s",
             (
-                SOURCE_READ_INTERVAL_TIMEDELTA,
+                SOURCE_READ_INTERVAL_MINUTES,
                 row["user_hash"],
                 row["feed_hash"],
                 row["name_hash"],

--- a/src/api/ingest/source.py
+++ b/src/api/ingest/source.py
@@ -6,6 +6,7 @@ from db.item import ItemLoose, ItemStrict
 from db.source import Source
 from db.feed import Feed
 from ingest.item.rss import ingest_rss_item
+from ingest.item.reddit import ingest_reddit_item
 from ingest.item.open_graph import ingest_open_graph_item
 from ingest.item.mercury import ingest_mercury_item
 
@@ -65,11 +66,15 @@ def ingest_source(source: Source) -> None:
             final_item = ItemStrict.read(url_hash=temp_item.url_hash)
         else:
             rss_item = ingest_rss_item(entry)
+            # reddit's post JSON has full-res images, gifs, videos, and
+            # galleries that the RSS feed only thumbnails; merge it in ahead
+            # of open graph so its media wins
+            reddit_item = ingest_reddit_item(rss_item)
             open_graph_item = ingest_open_graph_item(rss_item)
             mercury_item = ingest_mercury_item(rss_item)
 
             best_item = ItemLoose.merge_instances(
-                items=[rss_item, open_graph_item, mercury_item]
+                items=[rss_item, reddit_item, open_graph_item, mercury_item]
             )
 
             # Attempt to make strict item from best of all

--- a/src/api/route_models/item.py
+++ b/src/api/route_models/item.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from typing import Dict, List, Optional
 
 from pydantic import HttpUrl
 from .base import BaseRouteModel
@@ -13,6 +13,7 @@ class ItemResponse(BaseRouteModel):
     item_author: Optional[str] = None
     item_date_published: Optional[datetime] = None
     item_image_url: Optional[str] = None
+    item_media: Optional[List[Dict[str, Optional[str]]]] = None
     item_title: Optional[str] = None
     item_domain: Optional[str] = None
     item_excerpt: Optional[str] = None
@@ -43,6 +44,7 @@ class ItemResponse(BaseRouteModel):
             item_author=db_model.author,
             item_date_published=db_model.date_published,
             item_image_url=db_model.image_url,
+            item_media=db_model.media,
             item_title=db_model.title,
             item_domain=db_model.domain,
             item_excerpt=db_model.excerpt,

--- a/src/api/route_models/source.py
+++ b/src/api/route_models/source.py
@@ -17,6 +17,7 @@ class SourceRouteModel(BaseRouteModel):
     source_last_ingest_error: Optional[str] = None
     source_template_name_hash: Optional[str] = None
     source_template_parameters: Optional[Dict[str, str]] = None
+    source_ingest_interval_minutes: Optional[int] = None
 
     @classmethod
     def from_db_model(cls, db_model: Source):
@@ -27,6 +28,7 @@ class SourceRouteModel(BaseRouteModel):
             source_feed=db_model.feed_hash,
             source_template_name_hash=db_model.template_name_hash,
             source_template_parameters=db_model.template_parameters,
+            source_ingest_interval_minutes=db_model.ingest_interval_minutes,
         )
 
     @classmethod
@@ -41,4 +43,5 @@ class SourceRouteModel(BaseRouteModel):
             source_last_ingest_error=row["last_ingest_error"],
             source_template_name_hash=row.get("template_name_hash"),
             source_template_parameters=row.get("template_parameters"),
+            source_ingest_interval_minutes=row.get("ingest_interval_minutes"),
         )

--- a/src/api/route_models/source_update.py
+++ b/src/api/route_models/source_update.py
@@ -1,5 +1,7 @@
 from typing import Dict, Optional
 
+from pydantic import Field
+
 from .base import BaseRouteModel
 
 
@@ -12,6 +14,9 @@ class SourceUpdate(BaseRouteModel):
     # Template sources: new parameter values; the URL is rebuilt from the
     # source's template.
     parameters: Optional[Dict[str, str]] = None
+    # How often to check this source, in minutes. Send null to reset to the
+    # server default; omit the field entirely to leave it unchanged.
+    ingest_interval_minutes: Optional[int] = Field(default=None, ge=1, le=10080)
 
     model_config = {
         "json_schema_extra": {
@@ -21,6 +26,7 @@ class SourceUpdate(BaseRouteModel):
                 "source_name": "Example Source Name",
                 "source_url": "https://example.com/rss.xml",
                 "parameters": {"parameter_name": "value"},
+                "ingest_interval_minutes": 60,
             }
         }
     }

--- a/src/api/routers/source.py
+++ b/src/api/routers/source.py
@@ -100,7 +100,17 @@ def update_source(
         new_url = update.source_url
 
     url_changed = new_url != str(source.url)
-    source.update(name=new_name, url=new_url, template_parameters=new_parameters)
+    update_kwargs = {}
+    # null means "reset to server default", so only apply the interval when
+    # the field was actually sent
+    if "ingest_interval_minutes" in update.model_fields_set:
+        update_kwargs["ingest_interval"] = update.ingest_interval_minutes
+    source.update(
+        name=new_name,
+        url=new_url,
+        template_parameters=new_parameters,
+        **update_kwargs,
+    )
 
     if url_changed:
         # fetch the new URL right away instead of waiting for the schedule

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -55,6 +55,11 @@ function bindControls() {
   $('templateAddBtn').onclick = handleCreateSourceFromTemplate;
   $('manualSourceForm').onsubmit = handleCreateManualSource;
   $('editSourceSaveBtn').onclick = handleUpdateSource;
+
+  // stop autoplaying gifs/videos when the reader closes
+  $('readerModal').addEventListener('close', () => {
+    $('readerMedia').querySelectorAll('video').forEach((v) => v.pause());
+  });
 }
 
 function setView(name) {
@@ -265,17 +270,75 @@ function cleanExcerpt(item) {
   return text;
 }
 
+// ---------- media ----------
+
+const isVideoFile = (url) => /\.(mp4|webm)(\?|$)/i.test(url || '');
+
+// Pause autoplaying gifs while they're offscreen so a feed full of them
+// doesn't churn bandwidth and CPU.
+const gifVisibility = new IntersectionObserver((entries) => {
+  entries.forEach(({ target, isIntersecting }) => {
+    if (isIntersecting) target.play().catch(() => {});
+    else target.pause();
+  });
+}, { rootMargin: '200px' });
+
+// One media entry ({type, url, poster?}) -> element. Gifs autoplay muted
+// and loop like the reddit app; videos get controls, so their clicks must
+// reach the player instead of opening the reader.
+function mediaElement(m, cls = 'w-full max-h-[70vh] object-contain') {
+  if (m.type === 'video' || (m.type === 'gif' && isVideoFile(m.url))) {
+    const isGif = m.type === 'gif';
+    const video = h('video', {
+      class: cls, src: m.url, poster: m.poster || null,
+      loop: isGif, autoplay: isGif, controls: !isGif,
+      playsinline: true, preload: isGif ? 'auto' : 'metadata',
+      onclick: isGif ? null : (e) => e.stopPropagation(),
+    });
+    // autoplay is only allowed when the muted IDL property is set; the
+    // attribute alone isn't enough in Chrome
+    video.muted = true;
+    if (isGif) gifVisibility.observe(video);
+    return video;
+  }
+  return h('img', { class: cls, src: m.url, alt: '', loading: 'lazy' });
+}
+
+// A media list -> single element or a swipeable snap-scrolling gallery
+// strip with an index badge.
+function mediaGallery(mediaList) {
+  if (mediaList.length === 1) return mediaElement(mediaList[0]);
+  const counter = h('div', {
+    class: 'badge badge-neutral badge-sm absolute top-2 right-2 pointer-events-none',
+  }, `1/${mediaList.length}`);
+  const strip = h('div', { class: 'flex overflow-x-auto snap-x snap-mandatory' },
+    mediaList.map((m) =>
+      h('div', { class: 'w-full flex-none snap-center flex items-center justify-center bg-base-300' },
+        mediaElement(m))));
+  strip.addEventListener('scroll', () => {
+    const index = Math.min(Math.round(strip.scrollLeft / strip.clientWidth) + 1, mediaList.length);
+    counter.textContent = `${index}/${mediaList.length}`;
+  }, { passive: true });
+  return h('div', { class: 'relative' }, strip, counter);
+}
+
+// Reddit-app-style card: meta row and title up top, full-feed-width media
+// below, then the vote row.
 function itemCard(item) {
   const published = item.item_date_published ? timeAgo(item.item_date_published) : '';
-  const imageUrl = item.item_image_url || parseItemContent(item).imageUrl;
+  const media = (item.item_media || []).length ? item.item_media : null;
+  const imageUrl = media ? null : (item.item_image_url || parseItemContent(item).imageUrl);
+  const excerpt = cleanExcerpt(item);
 
-  const image = imageUrl
-    ? h('figure', { class: 'w-24 h-24 flex-shrink-0 rounded-lg overflow-hidden bg-base-300 hidden sm:block' },
-        h('img', {
-          src: imageUrl, class: 'w-full h-full object-cover', alt: '',
-          onerror: (e) => { e.target.parentElement.style.display = 'none'; },
-        }))
-    : null;
+  const mediaBlock = media
+    ? h('figure', { class: 'bg-base-300' }, mediaGallery(media))
+    : imageUrl
+      ? h('figure', { class: 'bg-base-300' },
+          h('img', {
+            src: imageUrl, class: 'w-full max-h-[70vh] object-contain', alt: '', loading: 'lazy',
+            onerror: (e) => { e.target.closest('figure').remove(); },
+          }))
+      : null;
 
   const voteButton = (label, score, title) =>
     h('button', {
@@ -285,21 +348,20 @@ function itemCard(item) {
     }, label);
 
   return h('div', {
-    class: 'card card-side bg-base-200 border border-base-300 hover:border-primary/50 transition-colors cursor-pointer',
+    class: 'card bg-base-200 border border-base-300 hover:border-primary/50 transition-colors cursor-pointer overflow-hidden',
     onclick: () => openReader(item),
   },
-    h('div', { class: 'card-body p-4 flex-row gap-4' },
-      image,
-      h('div', { class: 'flex-1 min-w-0' },
-        h('h3', { class: 'font-semibold text-sm leading-snug line-clamp-2' }, item.item_title || 'Untitled'),
-        h('p', { class: 'text-xs text-base-content/50 line-clamp-2 mt-1' }, cleanExcerpt(item)),
-        h('div', { class: 'flex flex-wrap items-center gap-2 mt-2' },
-          item.item_source_name && h('span', { class: 'badge badge-secondary badge-outline badge-xs' }, item.item_source_name),
-          item.item_author && h('span', { class: 'text-xs text-base-content/40' }, item.item_author),
-          published && h('span', { class: 'text-xs text-base-content/40' }, published))),
-      h('div', { class: 'flex flex-col items-center gap-0 flex-shrink-0' },
-        voteButton('▲', 1, 'Upvote'),
-        voteButton('▼', -1, 'Downvote'))));
+    h('div', { class: 'px-4 pt-3 pb-2' },
+      h('div', { class: 'flex flex-wrap items-center gap-2 text-xs text-base-content/50 mb-1' },
+        item.item_source_name && h('span', { class: 'badge badge-secondary badge-outline badge-xs' }, item.item_source_name),
+        item.item_author && h('span', {}, item.item_author),
+        published && h('span', {}, published)),
+      h('h3', { class: 'font-semibold leading-snug' }, item.item_title || 'Untitled'),
+      !mediaBlock && excerpt && h('p', { class: 'text-xs text-base-content/50 line-clamp-2 mt-1' }, excerpt)),
+    mediaBlock,
+    h('div', { class: 'flex items-center px-2 py-1' },
+      voteButton('▲', 1, 'Upvote'),
+      voteButton('▼', -1, 'Downvote')));
 }
 
 async function voteItem(item, score, btn) {
@@ -355,27 +417,34 @@ function openReader(item) {
     h('a', { href: item.item_url, target: '_blank', rel: 'noopener', class: 'link link-primary ml-auto' },
       host ? `Open on ${host} ↗` : 'Open original ↗'));
 
-  // Non-reddit articles keep their images inline in the content; only
-  // promote a content image to the hero slot for reddit-style posts.
-  const heroUrl = item.item_image_url || (parsed.isReddit ? parsed.imageUrl : null);
-  const img = $('readerImage');
-  if (heroUrl) {
-    img.src = heroUrl;
-    img.classList.remove('hidden');
-    img.onerror = () => img.classList.add('hidden');
+  // Ingested media (gifs, videos, galleries) takes the hero slot. Otherwise
+  // non-reddit articles keep their images inline in the content and only
+  // reddit-style posts promote a content image to the hero.
+  const media = item.item_media || [];
+  const heroUrl = media.length
+    ? null
+    : item.item_image_url || (parsed.isReddit ? parsed.imageUrl : null);
+  const mediaHost = $('readerMedia');
+  if (media.length) {
+    render(mediaHost, mediaGallery(media));
+  } else if (heroUrl) {
+    render(mediaHost, h('img', {
+      src: heroUrl, class: 'rounded-lg max-w-full max-h-[60vh] object-contain mx-auto',
+      alt: '', onerror: (e) => e.target.remove(),
+    }));
   } else {
-    img.classList.add('hidden');
+    render(mediaHost);
   }
 
   // item_content is sanitized server-side (bleach) before storage; it is the
   // only place raw HTML is intentionally rendered.
   if (parsed.isReddit) {
-    // the hero image above already shows the content image
-    stripRedditBoilerplate(parsed.root, parsed.imageFromContent);
+    // the hero media above already shows the content image
+    stripRedditBoilerplate(parsed.root, media.length > 0 || parsed.imageFromContent);
   }
   if (parsed.root.textContent.trim() || parsed.root.querySelector('img')) {
     $('readerContent').innerHTML = parsed.root.innerHTML;
-  } else if (!heroUrl) {
+  } else if (!heroUrl && !media.length) {
     render($('readerContent'), h('p', {}, cleanExcerpt(item) || 'No content available.'));
   } else {
     render($('readerContent'));
@@ -410,17 +479,26 @@ async function loadSources() {
   }
 }
 
+// "60" -> "every hour", "1440" -> "daily" — for the source list row.
+function intervalLabel(mins) {
+  if (!mins) return '';
+  if (mins % 1440 === 0) { const days = mins / 1440; return days === 1 ? 'daily' : `every ${days} days`; }
+  if (mins % 60 === 0) { const hours = mins / 60; return hours === 1 ? 'hourly' : `every ${hours} hours`; }
+  return `every ${mins} min`;
+}
+
 function sourceRow(source) {
   const count = source.source_item_count ?? 0;
   const checked = source.source_last_ingested_at
     ? `checked ${timeAgo(source.source_last_ingested_at)}`
     : 'not checked yet';
+  const interval = intervalLabel(source.source_ingest_interval_minutes);
   return h('div', { class: 'flex items-center justify-between gap-3 p-3 bg-base-200 border border-base-300 rounded-lg mb-2' },
     h('div', { class: 'min-w-0' },
       h('div', { class: 'font-medium text-sm' }, source.source_name),
       h('div', { class: 'text-xs text-base-content/40 truncate' }, source.source_url),
       h('div', { class: 'text-xs text-base-content/60 mt-1' },
-        `${count} article${count === 1 ? '' : 's'} · ${checked}`),
+        `${count} article${count === 1 ? '' : 's'} · ${checked}${interval ? ` · checks ${interval}` : ''}`),
       source.source_last_ingest_error && h('div', { class: 'text-xs text-error mt-1' },
         `Last check failed: ${source.source_last_ingest_error}`)),
     h('div', { class: 'flex gap-1 flex-shrink-0' },
@@ -439,6 +517,15 @@ async function openEditSourceModal(source) {
   editingTemplate = null;
   $('editSourceTitle').textContent = `Edit ${source.source_name}`;
   $('editSourceName').value = source.source_name;
+
+  // custom intervals (set via the API) get their own option so they survive
+  // a save that doesn't touch the frequency
+  const intervalSelect = $('editSourceInterval');
+  const saved = source.source_ingest_interval_minutes;
+  if (saved && !Array.from(intervalSelect.options).some((o) => o.value === String(saved))) {
+    intervalSelect.append(h('option', { value: String(saved) }, `Every ${saved} minutes`));
+  }
+  intervalSelect.value = saved ? String(saved) : '';
 
   const fields = $('editSourceFields');
   if (source.source_template_name_hash) {
@@ -474,10 +561,13 @@ async function handleUpdateSource() {
   const name = $('editSourceName').value.trim();
   if (!name) { toast('Please enter a source name', 'alert-error'); return; }
 
+  const intervalValue = $('editSourceInterval').value;
   const body = {
     feed_name_hash: currentFeed.feed_name_hash,
     source_name_hash: editingSource.source_name_hash,
     source_name: name,
+    // null resets the source to the server default frequency
+    ingest_interval_minutes: intervalValue ? Number(intervalValue) : null,
   };
 
   const urlInput = $('editSourceFields').querySelector('input[name="source_url"]');
@@ -606,17 +696,23 @@ async function selectTemplate(hash) {
     render($('templateParamFields'),
       Object.entries(tmpl.parameters || {}).map(([key, param]) => templateParamField(key, param)));
 
-    // Suggest a distinct name from the first required text parameter (e.g.
-    // "Reddit Subreddit - selfhosted") until the user edits the name field,
-    // so adding several sources from the same template doesn't collide.
+    // Suggest a distinct name from the first required text parameter until
+    // the user edits the name field, so adding several sources from the same
+    // template doesn't collide. Reddit sources read best as "r/name" and
+    // "u/name"; other templates get "Template - value".
     let nameEdited = false;
     nameInput.oninput = () => { nameEdited = true; };
     const firstParam = $('templateParamFields').querySelector('input[type="text"][required]');
     if (firstParam) {
+      const suggestName = (value) => {
+        if (!value) return baseName;
+        if (firstParam.name === 'subreddit') return `r/${value.replace(/^\/?r\//i, '')}`;
+        if (firstParam.name === 'username' && /reddit/i.test(baseName)) return `u/${value.replace(/^\/?u\//i, '')}`;
+        return `${baseName} - ${value}`;
+      };
       firstParam.addEventListener('input', () => {
         if (nameEdited) return;
-        const v = firstParam.value.trim();
-        nameInput.value = v ? `${baseName} - ${v}` : baseName;
+        nameInput.value = suggestName(firstParam.value.trim());
       });
     }
   } catch (err) {

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -78,7 +78,7 @@
     <form method="dialog"><button class="btn btn-sm btn-circle btn-ghost absolute right-4 top-4">✕</button></form>
     <h2 class="text-xl font-bold pr-8 mb-2" id="readerTitle"></h2>
     <div class="flex flex-wrap gap-3 text-xs text-base-content/50 mb-4 pb-3 border-b border-base-300" id="readerMeta"></div>
-    <img id="readerImage" class="rounded-lg max-w-full max-h-[60vh] object-contain mx-auto mb-4 hidden">
+    <div id="readerMedia" class="mb-4 empty:hidden"></div>
     <div class="prose prose-sm max-w-none" id="readerContent"></div>
   </div>
   <form method="dialog" class="modal-backdrop"><button>close</button></form>
@@ -157,6 +157,19 @@
     <div class="form-control mb-3">
       <label class="label" for="editSourceName"><span class="label-text">Source Name</span></label>
       <input type="text" class="input input-bordered w-full" id="editSourceName" required>
+    </div>
+    <div class="form-control mb-3">
+      <label class="label" for="editSourceInterval"><span class="label-text">Check for new posts</span></label>
+      <select class="select select-bordered w-full" id="editSourceInterval">
+        <option value="">Server default</option>
+        <option value="15">Every 15 minutes</option>
+        <option value="30">Every 30 minutes</option>
+        <option value="60">Every hour</option>
+        <option value="180">Every 3 hours</option>
+        <option value="360">Every 6 hours</option>
+        <option value="720">Every 12 hours</option>
+        <option value="1440">Once a day</option>
+      </select>
     </div>
     <div id="editSourceFields"></div>
     <div class="modal-action">

--- a/src/api/tests/db/item_test.py
+++ b/src/api/tests/db/item_test.py
@@ -27,6 +27,29 @@ def test_content_sanitization(html_input, expected_output, unique_item_strict):
     assert item.content == expected_output
 
 
+def test_media_roundtrip(unique_item_strict):
+    """Media entries survive a write/read cycle through the JSONB column."""
+    media = [
+        {"type": "gif", "url": "https://i.redd.it/example.mp4"},
+        {"type": "image", "url": "https://i.redd.it/example.jpg"},
+    ]
+    unique_item_strict.media = media
+    unique_item_strict.create()
+
+    item = ItemLoose.read(unique_item_strict.url_hash)
+    assert item.media == media
+
+
+def test_merge_items_prefers_media(unique_item_strict):
+    """Merging keeps the first non-null media list."""
+    item1 = unique_item_strict.model_copy()
+    item2 = unique_item_strict.model_copy()
+    item2.media = [{"type": "video", "url": "https://v.redd.it/example/DASH_720.mp4"}]
+
+    merged_item = ItemLoose.merge_instances([item1, item2])
+    assert merged_item.media == item2.media
+
+
 def test_merge_items(unique_item_strict):
     """Tests merging of multiple loose items."""
     item1 = unique_item_strict

--- a/src/api/tests/db/source_test.py
+++ b/src/api/tests/db/source_test.py
@@ -39,6 +39,46 @@ def test_read_source(unique_source):
     ), "Source feed_hash should match"
 
 
+def test_source_ingest_interval_roundtrip(unique_source):
+    unique_source.ingest_interval_minutes = 120
+    unique_source.create()
+
+    read_source = Source.read(
+        user_hash=unique_source.user_hash,
+        feed_hash=unique_source.feed_hash,
+        source_hash=unique_source.name_hash,
+    )
+    assert read_source.ingest_interval_minutes == 120
+
+
+def test_source_update_ingest_interval(unique_source):
+    unique_source.create()
+
+    def read_back():
+        return Source.read(
+            user_hash=unique_source.user_hash,
+            feed_hash=unique_source.feed_hash,
+            source_hash=unique_source.name_hash,
+        )
+
+    assert read_back().ingest_interval_minutes is None
+
+    unique_source.update(
+        name=unique_source.name, url=str(unique_source.url), ingest_interval=45
+    )
+    assert read_back().ingest_interval_minutes == 45
+
+    # leaving the interval out of an update keeps the current value
+    unique_source.update(name=unique_source.name, url=str(unique_source.url))
+    assert read_back().ingest_interval_minutes == 45
+
+    # an explicit None resets to the server default
+    unique_source.update(
+        name=unique_source.name, url=str(unique_source.url), ingest_interval=None
+    )
+    assert read_back().ingest_interval_minutes is None
+
+
 def test_source_add_items(unique_source, unique_item_strict):
     unique_source.create()
     unique_item_strict.create()

--- a/src/api/tests/ingest/reddit_test.py
+++ b/src/api/tests/ingest/reddit_test.py
@@ -1,0 +1,165 @@
+from db.item import ItemLoose
+from ingest.item.reddit import _post_media, ingest_reddit_item, is_reddit_post
+from ingest.item.rss import _link_media
+
+
+def test_is_reddit_post():
+    assert is_reddit_post("https://www.reddit.com/r/pics/comments/abc123/a_title/")
+    assert is_reddit_post("https://old.reddit.com/r/pics/comments/abc123/a_title/")
+    assert is_reddit_post("https://www.reddit.com/user/spez/comments/abc123/a_title/")
+    assert not is_reddit_post("https://www.reddit.com/r/pics/")
+    assert not is_reddit_post("https://example.com/r/pics/comments/abc123/")
+    assert not is_reddit_post(None)
+
+
+def test_post_media_gif_prefers_mp4_rendition():
+    post = {
+        "url_overridden_by_dest": "https://i.redd.it/example.gif",
+        "preview": {
+            "images": [
+                {
+                    "source": {"url": "https://preview.redd.it/example.jpg"},
+                    "variants": {
+                        "mp4": {"source": {"url": "https://preview.redd.it/example.mp4"}}
+                    },
+                }
+            ]
+        },
+    }
+    assert _post_media(post) == [
+        {"type": "gif", "url": "https://preview.redd.it/example.mp4"}
+    ]
+
+
+def test_post_media_gif_without_mp4_rendition():
+    post = {"url_overridden_by_dest": "https://i.redd.it/example.gif"}
+    assert _post_media(post) == [
+        {"type": "gif", "url": "https://i.redd.it/example.gif"}
+    ]
+
+
+def test_post_media_gifv_rewrites_to_mp4():
+    post = {"url_overridden_by_dest": "https://i.imgur.com/example.gifv"}
+    assert _post_media(post) == [
+        {"type": "gif", "url": "https://i.imgur.com/example.mp4"}
+    ]
+
+
+def test_post_media_reddit_video():
+    post = {
+        "secure_media": {
+            "reddit_video": {
+                "fallback_url": "https://v.redd.it/example/DASH_720.mp4",
+                "is_gif": False,
+            }
+        },
+        "preview": {"images": [{"source": {"url": "https://preview.redd.it/poster.jpg"}}]},
+    }
+    assert _post_media(post) == [
+        {
+            "type": "video",
+            "url": "https://v.redd.it/example/DASH_720.mp4",
+            "poster": "https://preview.redd.it/poster.jpg",
+        }
+    ]
+
+
+def test_post_media_reddit_video_gif():
+    post = {
+        "media": {
+            "reddit_video": {
+                "fallback_url": "https://v.redd.it/example/DASH_480.mp4",
+                "is_gif": True,
+            }
+        }
+    }
+    assert _post_media(post) == [
+        {"type": "gif", "url": "https://v.redd.it/example/DASH_480.mp4"}
+    ]
+
+
+def test_post_media_gallery_preserves_order():
+    post = {
+        "is_gallery": True,
+        "gallery_data": {"items": [{"media_id": "b"}, {"media_id": "a"}]},
+        "media_metadata": {
+            "a": {"status": "valid", "e": "Image", "s": {"u": "https://i.redd.it/a.jpg"}},
+            "b": {
+                "status": "valid",
+                "e": "AnimatedImage",
+                "s": {"mp4": "https://i.redd.it/b.mp4", "gif": "https://i.redd.it/b.gif"},
+            },
+        },
+    }
+    assert _post_media(post) == [
+        {"type": "gif", "url": "https://i.redd.it/b.mp4"},
+        {"type": "image", "url": "https://i.redd.it/a.jpg"},
+    ]
+
+
+def test_post_media_image_post_hint():
+    post = {
+        "url_overridden_by_dest": "https://example.com/article",
+        "post_hint": "image",
+        "preview": {"images": [{"source": {"url": "https://preview.redd.it/img.jpg"}}]},
+    }
+    assert _post_media(post) == [
+        {"type": "image", "url": "https://preview.redd.it/img.jpg"}
+    ]
+
+
+def test_post_media_plain_link_has_no_media():
+    post = {"url_overridden_by_dest": "https://example.com/article"}
+    assert _post_media(post) == []
+
+
+def test_ingest_reddit_item_skips_non_reddit_urls():
+    item = ItemLoose(url="https://example.com/article")
+    assert ingest_reddit_item(item) is None
+
+
+def test_ingest_reddit_item_fetches_post_json(monkeypatch):
+    post = {
+        "title": "A gif post",
+        "author": "someone",
+        "url_overridden_by_dest": "https://i.redd.it/example.gif",
+        "preview": {"images": [{"source": {"url": "https://preview.redd.it/img.jpg"}}]},
+    }
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return [{"data": {"children": [{"data": post}]}}]
+
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        return FakeResponse()
+
+    monkeypatch.setattr("ingest.item.reddit.requests.get", fake_get)
+
+    item = ItemLoose(url="https://www.reddit.com/r/pics/comments/abc123/a_gif_post/")
+    result = ingest_reddit_item(item)
+
+    assert captured["url"] == "https://www.reddit.com/r/pics/comments/abc123/a_gif_post.json"
+    assert result.title == "A gif post"
+    assert result.author == "u/someone"
+    assert result.media == [{"type": "gif", "url": "https://i.redd.it/example.gif"}]
+    assert result.image_url == "https://preview.redd.it/img.jpg"
+
+
+def test_rss_link_media():
+    assert _link_media("https://example.com/funny.gif") == [
+        {"type": "gif", "url": "https://example.com/funny.gif"}
+    ]
+    assert _link_media("https://example.com/clip.mp4") == [
+        {"type": "video", "url": "https://example.com/clip.mp4"}
+    ]
+    assert _link_media("https://example.com/photo.jpg?width=100") == [
+        {"type": "image", "url": "https://example.com/photo.jpg?width=100"}
+    ]
+    assert _link_media("https://example.com/article") is None
+    assert _link_media(None) is None

--- a/src/api/tests/routers/feed_test.py
+++ b/src/api/tests/routers/feed_test.py
@@ -146,6 +146,7 @@ def test_sources(client, existing_user, existing_feed, existing_source, token):
             "source_last_ingest_error": None,
             "source_template_name_hash": None,
             "source_template_parameters": None,
+            "source_ingest_interval_minutes": None,
         }
     ]
 

--- a/src/api/tests/routers/source_test.py
+++ b/src/api/tests/routers/source_test.py
@@ -211,6 +211,68 @@ def test_update_source_rename_conflict(client, existing_feed, existing_source, t
     assert response.status_code == 409
 
 
+def test_update_source_ingest_interval(client, existing_feed, existing_source, token):
+    args = build_api_request_args(
+        path="/source/update",
+        data={
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name_hash": existing_source.name_hash,
+            "source_name": existing_source.name,
+            "ingest_interval_minutes": 120,
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+    assert response.status_code == 200
+    assert response.json()["source_ingest_interval_minutes"] == 120
+
+    # omitting the field leaves the interval unchanged
+    args = build_api_request_args(
+        path="/source/update",
+        data={
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name_hash": existing_source.name_hash,
+            "source_name": existing_source.name,
+        },
+        token=token,
+    )
+    response = client.post(**args)
+    assert response.status_code == 200
+    assert response.json()["source_ingest_interval_minutes"] == 120
+
+    # an explicit null resets to the server default
+    args = build_api_request_args(
+        path="/source/update",
+        data={
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name_hash": existing_source.name_hash,
+            "source_name": existing_source.name,
+            "ingest_interval_minutes": None,
+        },
+        token=token,
+    )
+    response = client.post(**args)
+    assert response.status_code == 200
+    assert response.json()["source_ingest_interval_minutes"] is None
+
+
+def test_update_source_invalid_interval(client, existing_feed, existing_source, token):
+    args = build_api_request_args(
+        path="/source/update",
+        data={
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name_hash": existing_source.name_hash,
+            "source_name": existing_source.name,
+            "ingest_interval_minutes": 0,
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+    assert response.status_code == 422
+
+
 def test_update_source_not_found(client, existing_feed, token):
     args = build_api_request_args(
         path="/source/update",


### PR DESCRIPTION
## What this does

### Per-source check frequency
- New `sources.ingest_interval_minutes` column (migration V6); `NULL` means "use the server-wide `SOURCE_READ_INTERVAL_MINUTES` default".
- The ingestion scheduler and the post-ingest reschedule both compute the next check with `COALESCE(ingest_interval_minutes, <default>)`, so overrides take effect without any scheduler changes.
- The Edit Source modal gets a "Check for new posts" dropdown (15 min → daily, or server default), and the source list row shows the override (e.g. `· checks every 3 hours`).
- `/source/update` accepts an optional `ingest_interval_minutes` (1–10080); sending `null` resets to the default, omitting it leaves it unchanged.

### Reddit source naming
- Creating a source from the Reddit Subreddit template now suggests `r/<subreddit>` as the name (and `u/<username>` for Reddit User feeds) instead of "Reddit Subreddit - name".

### Media ingestion (gifs, videos, galleries)
- New `items.media` JSONB column storing a list of `{type: image|gif|video, url, poster?}` entries, exposed as `item_media` on the API.
- New ingest step (`ingest/item/reddit.py`) fetches a reddit post's JSON (`<comments-url>.json?raw_json=1`) and extracts:
  - mp4 renditions of gif posts (falling back to the raw gif), imgur `.gifv` rewrites
  - v.redd.it videos via `fallback_url` (with a preview poster)
  - gallery posts in order, mixing images and animated entries
  - full-resolution preview images (replacing the RSS thumbnail)
- Direct `.gif`/`.mp4`/`.webm`/image links in any RSS feed are also detected.

### Reddit-app-style feed layout
- Feed cards are now vertical: source/author/time meta row, title, then media at the full width of the feed (mobile included — media was previously hidden on phones), then the vote row.
- Gifs autoplay muted and looped, and an `IntersectionObserver` pauses them offscreen; videos get controls; galleries are swipeable snap-scroll strips with a `1/n` index badge.
- The reader modal renders the same media in its hero slot and pauses playback on close.

## Testing
- New unit tests for the reddit media extraction (`tests/ingest/reddit_test.py`) covering gifs, gifv, v.redd.it video, galleries, image posts, and the fetch flow (mocked).
- New DB/router tests for the interval (roundtrip, update/keep/reset semantics, 422 on invalid values) and media JSONB roundtrip/merge.
- Full suite run locally against Postgres 16 with migrations V1–V6 applied: all failures remaining are pre-existing on `main` in that environment (missing rss-bridge env / TZ differences), verified by running the base commit as a baseline.
- `generate_sdk.py --check` passes (no route signature changes), and the Tailwind build was run to confirm the new utility classes are generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aGMeF6qqAa4ZKUmLVAv44

---
_Generated by [Claude Code](https://claude.ai/code/session_012aGMeF6qqAa4ZKUmLVAv44)_