### PR TITLE
Fix feed filtering, interleave sources, reddit media backfill, YouTube embeds, infinite scroll

### DIFF
--- a/src/api/db/feed.py
+++ b/src/api/db/feed.py
@@ -67,7 +67,8 @@ class Feed(ItemCollection):
 
         with self.db_con() as cur:
             cur.execute(
-                "SELECT user_hash, feed_hash, name_hash, name, url FROM sources "
+                "SELECT user_hash, feed_hash, name_hash, name, url, color "
+                "FROM sources "
                 "WHERE user_hash = %s AND feed_hash = %s",
                 (self.user_hash, self.name_hash),
             )
@@ -79,6 +80,7 @@ class Feed(ItemCollection):
                 feed_hash=row["feed_hash"],
                 name=row["name"],
                 url=row["url"],
+                color=row["color"],
             )
             for row in rows
         ]
@@ -89,7 +91,7 @@ class Feed(ItemCollection):
             cur.execute(
                 "SELECT s.name, s.url, s.name_hash, s.feed_hash, s.last_ingested_at, "
                 "s.last_ingest_error, s.template_name_hash, s.template_parameters, "
-                "s.ingest_interval_minutes, "
+                "s.ingest_interval_minutes, s.color, "
                 "(SELECT COUNT(*) FROM source_items si "
                 " WHERE si.user_hash = s.user_hash AND si.feed_hash = s.feed_hash "
                 " AND si.source_hash = s.name_hash) AS item_count "
@@ -134,7 +136,7 @@ class Feed(ItemCollection):
             "SELECT i.*, c.score, c.added_at, "
             "c.predicted_score, c.predicted_confidence, "
             "st.score AS user_score, st.is_read AS is_read, "
-            "src.name AS source_name, "
+            "src.name AS source_name, src.color AS source_color, "
             "ROW_NUMBER() OVER (PARTITION BY src.name_hash "
             f"ORDER BY {order_by}) AS source_rank "
             "FROM items i "
@@ -143,7 +145,7 @@ class Feed(ItemCollection):
             " AND st.feed_hash = c.feed_hash"
             " AND st.item_url_hash = c.item_url_hash "
             "LEFT JOIN LATERAL ("
-            " SELECT s.name, s.name_hash FROM source_items si"
+            " SELECT s.name, s.name_hash, s.color FROM source_items si"
             " JOIN sources s ON s.user_hash = si.user_hash"
             "  AND s.feed_hash = si.feed_hash AND s.name_hash = si.source_hash"
             " WHERE si.user_hash = c.user_hash AND si.feed_hash = c.feed_hash"
@@ -197,6 +199,7 @@ class Feed(ItemCollection):
             row.pop("source_rank", None)
             meta = {
                 "source_name": row.pop("source_name", None),
+                "source_color": row.pop("source_color", None),
                 "user_score": row.pop("user_score", None),
                 "is_read": row.pop("is_read", None),
                 "predicted_score": row.pop("predicted_score", None),
@@ -204,6 +207,40 @@ class Feed(ItemCollection):
             }
             results.append((ItemStrict.from_row(row), meta))
         return results
+
+    def stats(self) -> dict:
+        """Dashboard summary numbers: total items, unvoted items, and the
+        average posts per day over the last 30 days (or since the first
+        item arrived, whichever window is shorter)."""
+        with self.db_con() as cur:
+            cur.execute(
+                "SELECT COUNT(*) AS total, "
+                "COUNT(*) FILTER (WHERE st.score IS NULL) AS unread, "
+                "COUNT(*) FILTER "
+                " (WHERE c.added_at >= NOW() - INTERVAL '30 days') AS recent, "
+                "MIN(c.added_at) AS first_added_at "
+                "FROM feed_items c "
+                "LEFT JOIN item_states st ON st.user_hash = c.user_hash"
+                " AND st.feed_hash = c.feed_hash"
+                " AND st.item_url_hash = c.item_url_hash "
+                "WHERE c.user_hash = %s AND c.feed_hash = %s",
+                (self.user_hash, self.name_hash),
+            )
+            row = cur.fetchone()
+            cur.execute("SELECT NOW() AS now")
+            now = cur.fetchone()["now"]
+
+        days = 30.0
+        if row["first_added_at"] is not None:
+            age_days = (now - row["first_added_at"]).total_seconds() / 86400
+            days = max(1.0, min(30.0, age_days))
+        posts_per_day = (row["recent"] or 0) / days
+
+        return {
+            "feed_item_count": row["total"] or 0,
+            "feed_unread_count": row["unread"] or 0,
+            "feed_posts_per_day": round(posts_per_day, 1),
+        }
 
     def exists(self) -> bool:
         with self.db_con() as cur:

--- a/src/api/db/feed.py
+++ b/src/api/db/feed.py
@@ -118,24 +118,36 @@ class Feed(ItemCollection):
         - ``source_hashes`` restricts to items produced by those sources.
         - ``text_only=True`` keeps only items with no image or media;
           ``False`` keeps only items that have some; ``None`` keeps all.
+
+        Results interleave sources within the sort order: each source's best
+        item first (ordered by the sort key), then each source's second-best,
+        and so on, so the feed mixes sources instead of long runs of one.
         """
         from .item import ItemStrict
 
         order_by = ITEM_SORTS.get(sort, ITEM_SORTS["best"])
+        # the same sort keys, without table prefixes, for the outer
+        # interleave query where every column is already flattened
+        outer_order = order_by.replace("c.", "").replace("i.", "")
 
         sql = (
-            "SELECT i.*, c.predicted_score, c.predicted_confidence, "
-            "st.score AS user_score, st.is_read AS is_read, ("
-            " SELECT s.name FROM source_items si"
-            " JOIN sources s ON s.user_hash = si.user_hash"
-            "  AND s.feed_hash = si.feed_hash AND s.name_hash = si.source_hash"
-            " WHERE si.user_hash = c.user_hash AND si.feed_hash = c.feed_hash"
-            "  AND si.item_url_hash = c.item_url_hash LIMIT 1) AS source_name "
+            "SELECT i.*, c.score, c.added_at, "
+            "c.predicted_score, c.predicted_confidence, "
+            "st.score AS user_score, st.is_read AS is_read, "
+            "src.name AS source_name, "
+            "ROW_NUMBER() OVER (PARTITION BY src.name_hash "
+            f"ORDER BY {order_by}) AS source_rank "
             "FROM items i "
             "JOIN feed_items c ON c.item_url_hash = i.url_hash "
             "LEFT JOIN item_states st ON st.user_hash = c.user_hash"
             " AND st.feed_hash = c.feed_hash"
             " AND st.item_url_hash = c.item_url_hash "
+            "LEFT JOIN LATERAL ("
+            " SELECT s.name, s.name_hash FROM source_items si"
+            " JOIN sources s ON s.user_hash = si.user_hash"
+            "  AND s.feed_hash = si.feed_hash AND s.name_hash = si.source_hash"
+            " WHERE si.user_hash = c.user_hash AND si.feed_hash = c.feed_hash"
+            "  AND si.item_url_hash = c.item_url_hash LIMIT 1) src ON TRUE "
             "WHERE c.user_hash = %s AND c.feed_hash = %s"
         )
         params: tuple = (self.user_hash, self.name_hash)
@@ -150,16 +162,20 @@ class Feed(ItemCollection):
                 " AND sf.source_hash = ANY(%s))"
             )
             params = params + (list(source_hashes),)
+        # An item counts as visual if it has a card image, ingested media,
+        # or an image embedded in its (sanitized) content HTML — many feeds
+        # only carry images inside the content body.
         has_visual = (
             "(i.image_url IS NOT NULL OR (i.media IS NOT NULL"
-            " AND i.media::text NOT IN ('null', '[]')))"
+            " AND i.media::text NOT IN ('null', '[]'))"
+            " OR i.content ~* '<img\\s')"
         )
         if text_only is True:
             sql += f" AND NOT {has_visual}"
         elif text_only is False:
             sql += f" AND {has_visual}"
 
-        sql += f" ORDER BY {order_by}"
+        sql = f"SELECT * FROM ({sql}) q ORDER BY q.source_rank, {outer_order}"
         if limit is not None and limit >= 0:
             sql += " LIMIT %s"
             params = params + (limit,)
@@ -175,6 +191,10 @@ class Feed(ItemCollection):
         for row in rows:
             if not row:
                 continue
+            # interleave/sort bookkeeping columns aren't item fields
+            row.pop("score", None)
+            row.pop("added_at", None)
+            row.pop("source_rank", None)
             meta = {
                 "source_name": row.pop("source_name", None),
                 "user_score": row.pop("user_score", None),

--- a/src/api/db/migrations/V8__source_color.sql
+++ b/src/api/db/migrations/V8__source_color.sql
@@ -1,0 +1,3 @@
+-- Per-source display color (hex, e.g. #e57373), chosen randomly at creation
+-- and user-editable in the source settings.
+ALTER TABLE sources ADD COLUMN color TEXT;

--- a/src/api/db/source.py
+++ b/src/api/db/source.py
@@ -1,4 +1,5 @@
 import json
+import random
 from typing import Dict, Optional
 
 from pydantic import StringConstraints, HttpUrl
@@ -10,6 +11,25 @@ from .item_collection import ItemCollection
 # Sentinel for update(): distinguishes "leave unchanged" from an explicit
 # None ("reset to the server default").
 _UNSET = object()
+
+# Default palette for per-source colors: distinct mid-tone hues that read
+# well as badge accents on both light and dark surfaces.
+SOURCE_COLORS = [
+    "#ef5350",  # red
+    "#ec407a",  # pink
+    "#ab47bc",  # purple
+    "#7e57c2",  # deep purple
+    "#5c6bc0",  # indigo
+    "#42a5f5",  # blue
+    "#26c6da",  # cyan
+    "#26a69a",  # teal
+    "#66bb6a",  # green
+    "#9ccc65",  # light green
+    "#d4b106",  # gold
+    "#ffa726",  # orange
+    "#ff7043",  # deep orange
+    "#8d6e63",  # brown
+]
 
 
 class Source(ItemCollection):
@@ -24,6 +44,8 @@ class Source(ItemCollection):
     # How often to check this source, in minutes. None uses the server-wide
     # SOURCE_READ_INTERVAL_MINUTES default.
     ingest_interval_minutes: Optional[int] = None
+    # Display color (hex). Assigned randomly at creation, editable later.
+    color: Optional[str] = None
 
     @property
     def name_hash(self):
@@ -66,12 +88,15 @@ class Source(ItemCollection):
         if self.exists():
             raise Exception(f"Cannot create duplicate source {self.key}")
 
+        if self.color is None:
+            self.color = random.choice(SOURCE_COLORS)
+
         with self.db_con() as cur:
             cur.execute(
                 "INSERT INTO sources (user_hash, feed_hash, name_hash, name, url, "
                 "template_name_hash, template_parameters, ingest_interval_minutes, "
-                "next_ingest_at) "
-                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, NOW())",
+                "color, next_ingest_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())",
                 (
                     self.user_hash,
                     self.feed_hash,
@@ -83,11 +108,17 @@ class Source(ItemCollection):
                     if self.template_parameters is not None
                     else None,
                     self.ingest_interval_minutes,
+                    self.color,
                 ),
             )
 
     def update(
-        self, name: str, url: str, template_parameters=None, ingest_interval=_UNSET
+        self,
+        name: str,
+        url: str,
+        template_parameters=None,
+        ingest_interval=_UNSET,
+        color=_UNSET,
     ):
         """Update this source in place. Renaming changes name_hash; the
         source_items FK cascades so existing items stay attached. Resets
@@ -102,6 +133,9 @@ class Source(ItemCollection):
         if ingest_interval is not _UNSET:
             interval_sql = "ingest_interval_minutes = %s, "
             interval_params = (ingest_interval,)
+        if color is not _UNSET and color is not None:
+            interval_sql += "color = %s, "
+            interval_params = interval_params + (color,)
         with self.db_con() as cur:
             cur.execute(
                 "UPDATE sources SET name = %s, name_hash = %s, url = %s, "
@@ -130,6 +164,8 @@ class Source(ItemCollection):
             self.template_parameters = template_parameters
         if ingest_interval is not _UNSET:
             self.ingest_interval_minutes = ingest_interval
+        if color is not _UNSET and color is not None:
+            self.color = color
 
     def delete(self):
         with self.db_con() as cur:
@@ -196,7 +232,7 @@ class Source(ItemCollection):
         with cls.db_con() as cur:
             cur.execute(
                 "SELECT name, url, template_name_hash, template_parameters, "
-                "ingest_interval_minutes "
+                "ingest_interval_minutes, color "
                 "FROM sources "
                 "WHERE user_hash = %s AND feed_hash = %s AND name_hash = %s",
                 (user_hash, feed_hash, source_hash),
@@ -212,6 +248,7 @@ class Source(ItemCollection):
                 template_name_hash=row["template_name_hash"],
                 template_parameters=row["template_parameters"],
                 ingest_interval_minutes=row["ingest_interval_minutes"],
+                color=row["color"],
             )
         raise ValueError("Source not found")
 

--- a/src/api/ingest/item/reddit.py
+++ b/src/api/ingest/item/reddit.py
@@ -24,6 +24,9 @@ _REDDIT_POST_RE = re.compile(
 _IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".webp")
 _VIDEO_EXTENSIONS = (".mp4", ".webm")
 
+# redgifs watch page, e.g. https://www.redgifs.com/watch/valhaalaand
+_REDGIFS_RE = re.compile(r"^https?://(?:www\.)?redgifs\.com/watch/(\w+)", re.I)
+
 
 def is_reddit_post(url: Optional[str]) -> bool:
     return bool(url and _REDDIT_POST_RE.match(str(url)))
@@ -89,8 +92,30 @@ def _post_media(post: dict) -> List[dict]:
             )
         ]
 
+    # gifs hosted off-site (redgifs, gfycat, imgur pages): reddit renders an
+    # mp4 rendition under preview.reddit_video_preview
+    video_preview = (post.get("preview") or {}).get("reddit_video_preview")
+    if video_preview and video_preview.get("fallback_url"):
+        media_type = "gif" if video_preview.get("is_gif") else "video"
+        return [
+            _media_entry(
+                media_type, video_preview["fallback_url"], _preview_image(post)
+            )
+        ]
+
     target = post.get("url_overridden_by_dest") or post.get("url") or ""
     path = target.split("?")[0].lower()
+
+    # no rendition available: embed redgifs' own player
+    redgifs = _REDGIFS_RE.match(target)
+    if redgifs:
+        return [
+            _media_entry(
+                "embed",
+                f"https://www.redgifs.com/ifr/{redgifs.group(1)}",
+                _preview_image(post),
+            )
+        ]
 
     if path.endswith(".gifv"):
         # imgur gifv pages wrap an mp4 of the same name

--- a/src/api/ingest/item/reddit.py
+++ b/src/api/ingest/item/reddit.py
@@ -146,6 +146,8 @@ def ingest_reddit_item(item: ItemLoose) -> Optional[ItemLoose]:
         url=item.url,
         title=post.get("title"),
         author=f"u/{post['author']}" if post.get("author") else None,
-        media=media or None,
+        # an empty list still means "post scraped, no media found", which
+        # stops re-scrape attempts on later ingest cycles
+        media=media,
         image_url=image_url,
     )

--- a/src/api/ingest/source.py
+++ b/src/api/ingest/source.py
@@ -6,7 +6,7 @@ from db.item import ItemLoose, ItemStrict
 from db.source import Source
 from db.feed import Feed
 from ingest.item.rss import ingest_rss_item
-from ingest.item.reddit import ingest_reddit_item
+from ingest.item.reddit import ingest_reddit_item, is_reddit_post
 from ingest.item.open_graph import ingest_open_graph_item
 from ingest.item.mercury import ingest_mercury_item
 
@@ -64,6 +64,20 @@ def ingest_source(source: Source) -> None:
 
             # TODO check how long ago we ingested this item and re-ingest if it's been long enough
             final_item = ItemStrict.read(url_hash=temp_item.url_hash)
+            if final_item is None:
+                continue
+
+            # Items ingested before the reddit media scraper existed only
+            # have the RSS thumbnail; backfill galleries/gifs/videos from
+            # the post JSON. An empty list marks "scraped, no media" so
+            # text posts aren't re-fetched every cycle.
+            if final_item.media is None and is_reddit_post(str(final_item.url)):
+                reddit_item = ingest_reddit_item(final_item)
+                if reddit_item is not None:
+                    final_item.update(
+                        media=reddit_item.media or [],
+                        image_url=reddit_item.image_url or final_item.image_url,
+                    )
         else:
             rss_item = ingest_rss_item(entry)
             # reddit's post JSON has full-res images, gifs, videos, and

--- a/src/api/route_models/feed.py
+++ b/src/api/route_models/feed.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from .base import BaseRouteModel
 
 from db.feed import Feed
@@ -6,6 +8,10 @@ from db.feed import Feed
 class FeedResponse(BaseRouteModel):
     feed_name: str
     feed_name_hash: str
+    # Summary stats, filled in by /feed/list for the dashboard cards.
+    feed_item_count: Optional[int] = None
+    feed_unread_count: Optional[int] = None
+    feed_posts_per_day: Optional[float] = None
 
     model_config = {
         "json_schema_extra": {
@@ -17,5 +23,9 @@ class FeedResponse(BaseRouteModel):
     }
 
     @classmethod
-    def from_db_model(cls, db_model: Feed):
-        return cls(feed_name=db_model.name, feed_name_hash=db_model.name_hash)
+    def from_db_model(cls, db_model: Feed, stats: dict = None):
+        return cls(
+            feed_name=db_model.name,
+            feed_name_hash=db_model.name_hash,
+            **(stats or {}),
+        )

--- a/src/api/route_models/item.py
+++ b/src/api/route_models/item.py
@@ -19,6 +19,7 @@ class ItemResponse(BaseRouteModel):
     item_excerpt: Optional[str] = None
     item_content: Optional[str] = None
     item_source_name: Optional[str] = None
+    item_source_color: Optional[str] = None
     item_user_score: Optional[float] = None
     item_is_read: Optional[bool] = None
     item_predicted_score: Optional[float] = None
@@ -44,6 +45,7 @@ class ItemResponse(BaseRouteModel):
         cls,
         db_model: ItemLoose,
         source_name: str = None,
+        source_color: str = None,
         user_score: float = None,
         is_read: bool = None,
         predicted_score: float = None,
@@ -51,6 +53,7 @@ class ItemResponse(BaseRouteModel):
     ):
         return cls(
             item_source_name=source_name,
+            item_source_color=source_color,
             item_user_score=user_score,
             item_is_read=is_read,
             item_predicted_score=predicted_score,

--- a/src/api/route_models/source.py
+++ b/src/api/route_models/source.py
@@ -18,6 +18,7 @@ class SourceRouteModel(BaseRouteModel):
     source_template_name_hash: Optional[str] = None
     source_template_parameters: Optional[Dict[str, str]] = None
     source_ingest_interval_minutes: Optional[int] = None
+    source_color: Optional[str] = None
 
     @classmethod
     def from_db_model(cls, db_model: Source):
@@ -29,6 +30,7 @@ class SourceRouteModel(BaseRouteModel):
             source_template_name_hash=db_model.template_name_hash,
             source_template_parameters=db_model.template_parameters,
             source_ingest_interval_minutes=db_model.ingest_interval_minutes,
+            source_color=db_model.color,
         )
 
     @classmethod
@@ -44,4 +46,5 @@ class SourceRouteModel(BaseRouteModel):
             source_template_name_hash=row.get("template_name_hash"),
             source_template_parameters=row.get("template_parameters"),
             source_ingest_interval_minutes=row.get("ingest_interval_minutes"),
+            source_color=row.get("color"),
         )

--- a/src/api/route_models/source_update.py
+++ b/src/api/route_models/source_update.py
@@ -17,6 +17,8 @@ class SourceUpdate(BaseRouteModel):
     # How often to check this source, in minutes. Send null to reset to the
     # server default; omit the field entirely to leave it unchanged.
     ingest_interval_minutes: Optional[int] = Field(default=None, ge=1, le=10080)
+    # Display color as a hex string, e.g. "#ef5350". Omit to leave unchanged.
+    source_color: Optional[str] = Field(default=None, pattern=r"^#[0-9a-fA-F]{6}$")
 
     model_config = {
         "json_schema_extra": {

--- a/src/api/routers/feed.py
+++ b/src/api/routers/feed.py
@@ -68,7 +68,11 @@ def get_feed(feed_name_hash: str, user: User = Depends(authenticate)) -> FeedRes
 )
 def list_feeds(user: User = Depends(authenticate)) -> List[FeedResponse]:
     # TODO add list of sources in each feed in the response
-    return [FeedResponse.from_db_model(f) for f in user.feeds if f is not None]
+    return [
+        FeedResponse.from_db_model(f, stats=f.stats())
+        for f in user.feeds
+        if f is not None
+    ]
 
 
 # get all sources in a feed

--- a/src/api/routers/source.py
+++ b/src/api/routers/source.py
@@ -105,6 +105,8 @@ def update_source(
     # the field was actually sent
     if "ingest_interval_minutes" in update.model_fields_set:
         update_kwargs["ingest_interval"] = update.ingest_interval_minutes
+    if update.source_color is not None:
+        update_kwargs["color"] = update.source_color
     source.update(
         name=new_name,
         url=new_url,

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -138,20 +138,22 @@ function onboardingWelcome() {
 }
 
 function feedCard(feed) {
+  // summary line: total posts, unread, average posts/day (last 30 days)
+  const stats = [];
+  if (feed.feed_item_count != null) {
+    stats.push(`${feed.feed_item_count} post${feed.feed_item_count === 1 ? '' : 's'}`);
+    if (feed.feed_unread_count != null) stats.push(`${feed.feed_unread_count} unread`);
+    if (feed.feed_posts_per_day != null) stats.push(`~${feed.feed_posts_per_day}/day`);
+  }
   return h('div', {
     class: 'card bg-base-200 shadow-sm hover:shadow-md transition-shadow cursor-pointer border border-base-300 hover:border-primary',
     onclick: () => router.go(`feed/${feed.feed_name_hash}`),
   },
     h('div', { class: 'card-body p-5' },
-      h('div', { class: 'flex items-start justify-between' },
-        h('div', { class: 'badge badge-primary badge-outline font-bold text-lg p-3' },
-          feed.feed_name.charAt(0).toUpperCase()),
-        h('button', {
-          class: 'btn btn-ghost btn-xs hover:text-error',
-          title: 'Delete feed',
-          onclick: (e) => { e.stopPropagation(); confirmDeleteFeedCard(feed); },
-        }, '✕')),
-      h('h2', { class: 'card-title text-base mt-2' }, feed.feed_name)));
+      h('div', { class: 'badge badge-primary badge-outline font-bold text-lg p-3' },
+        feed.feed_name.charAt(0).toUpperCase()),
+      h('h2', { class: 'card-title text-base mt-2' }, feed.feed_name),
+      stats.length ? h('div', { class: 'text-xs text-base-content/50' }, stats.join(' · ')) : null));
 }
 
 async function handleCreateFeed(e) {
@@ -167,19 +169,6 @@ async function handleCreateFeed(e) {
   } catch (err) {
     toast(err.message, 'alert-error');
   }
-}
-
-function confirmDeleteFeedCard(feed) {
-  confirmDialog({
-    title: 'Delete Feed',
-    message: `Are you sure you want to delete "${feed.feed_name}"? All sources and items within it will be removed.`,
-    action: 'Delete Feed',
-    onConfirm: async () => {
-      await sdk.feedDelete({ feed_name_hash: feed.feed_name_hash });
-      toast(`Feed "${feed.feed_name}" deleted`);
-      loadFeeds();
-    },
-  });
 }
 
 function confirmDeleteFeed() {
@@ -286,6 +275,10 @@ function renderFilterSources() {
                 renderFilterSources();
                 reloadItems();
               },
+            }),
+            h('span', {
+              class: 'inline-block w-2 h-2 rounded-full',
+              style: `background:${sourceColor(s.source_name, s.source_color)}`,
             }),
             h('span', { class: 'label-text text-xs' }, s.source_name)))
       : h('span', { class: 'text-xs text-base-content/40' }, 'No sources in this feed'));
@@ -428,6 +421,40 @@ function cleanExcerpt(item) {
   text = text.replace(/submitted by\s+\/u\/\S+.*$/i, '').trim();
   if (/^submitted by\b/i.test(text)) return '';
   return text;
+}
+
+// ---------- source colors ----------
+
+// Mirrors SOURCE_COLORS in db/source.py: sources created before colors
+// existed get a deterministic fallback from the same palette.
+const SOURCE_COLOR_PALETTE = [
+  '#ef5350', '#ec407a', '#ab47bc', '#7e57c2', '#5c6bc0', '#42a5f5', '#26c6da',
+  '#26a69a', '#66bb6a', '#9ccc65', '#d4b106', '#ffa726', '#ff7043', '#8d6e63',
+];
+
+function sourceColor(name, stored) {
+  if (stored) return stored;
+  let hash = 0;
+  for (const ch of String(name || '')) hash = (hash * 31 + ch.codePointAt(0)) >>> 0;
+  return SOURCE_COLOR_PALETTE[hash % SOURCE_COLOR_PALETTE.length];
+}
+
+function sourceBadge(name, storedColor) {
+  if (!name) return null;
+  const color = sourceColor(name, storedColor);
+  return h('span', {
+    class: 'badge badge-outline badge-xs',
+    style: `border-color:${color};color:${color}`,
+  }, name);
+}
+
+// Square "open original" button with an arrow, shown next to titles.
+function openLinkButton(url, cls = 'btn btn-ghost btn-xs btn-square text-base-content/60') {
+  if (!url) return null;
+  return h('a', {
+    class: cls, href: url, target: '_blank', rel: 'noopener', title: 'Open original',
+    onclick: (e) => e.stopPropagation(),
+  }, '↗');
 }
 
 // ---------- media ----------
@@ -575,7 +602,7 @@ function itemCard(item) {
   const voteClass = (score) => (score > 0 ? 'text-success' : score < 0 ? 'text-error' : 'text-warning');
   const voteButton = (label, score, title) =>
     h('button', {
-      class: `btn btn-ghost btn-xs${item.item_user_score === score ? ` ${voteClass(score)}` : ''}`,
+      class: `btn btn-ghost btn-sm px-4${item.item_user_score === score ? ` ${voteClass(score)}` : ''}`,
       'data-score': String(score),
       title,
       onclick: (e) => { e.stopPropagation(); voteItem(item, score, e.currentTarget); },
@@ -585,7 +612,7 @@ function itemCard(item) {
   const predicted = item.item_predicted_score;
   const predictedBadge = predicted != null
     ? h('span', {
-        class: 'badge badge-ghost badge-xs ml-auto text-base-content/50',
+        class: 'badge badge-ghost badge-xs text-base-content/50',
         title: `Predicted vote ${predicted.toFixed(2)} · confidence ${((item.item_predicted_confidence ?? 0) * 100).toFixed(0)}%`,
       }, `${predicted > 0 ? '+' : ''}${(predicted * 100).toFixed(0)}% match`)
     : null;
@@ -595,18 +622,33 @@ function itemCard(item) {
     onclick: () => openReader(item),
   },
     h('div', { class: 'px-4 pt-3 pb-2' },
-      h('div', { class: 'flex flex-wrap items-center gap-2 text-xs text-base-content/50 mb-1' },
-        item.item_source_name && h('span', { class: 'badge badge-secondary badge-outline badge-xs' }, item.item_source_name),
-        item.item_author && h('span', {}, item.item_author),
-        published && h('span', {}, published)),
-      h('h3', { class: 'font-semibold leading-snug' }, item.item_title || 'Untitled'),
+      h('div', { class: 'flex items-start gap-2' },
+        h('h3', { class: 'font-semibold leading-snug flex-1 min-w-0' }, item.item_title || 'Untitled'),
+        openLinkButton(item.item_url)),
       !mediaBlock && excerpt && h('p', { class: 'text-xs text-base-content/50 line-clamp-2 mt-1' }, excerpt)),
     mediaBlock,
-    h('div', { class: 'flex items-center px-2 py-1' },
+    h('div', { class: 'flex items-center gap-1 px-2 py-1.5' },
       voteButton('▲', 1, 'Upvote'),
       voteButton('●', 0, 'Neutral — seen it, no strong feelings'),
       voteButton('▼', -1, 'Downvote'),
-      predictedBadge));
+      h('div', { class: 'flex flex-wrap items-center justify-end gap-2 text-xs text-base-content/50 ml-auto min-w-0 pr-2' },
+        sourceBadge(item.item_source_name, item.item_source_color),
+        item.item_author && h('span', { class: 'truncate max-w-32' }, item.item_author),
+        published && h('span', { class: 'whitespace-nowrap' }, published),
+        predictedBadge)));
+}
+
+// Animate a voted card shrinking away, then drop it from the DOM.
+function collapseCard(card) {
+  card.style.height = `${card.offsetHeight}px`;
+  card.style.overflow = 'hidden';
+  requestAnimationFrame(() => {
+    card.style.transition = 'height 0.3s ease, opacity 0.3s ease';
+    card.style.height = '0px';
+    card.style.opacity = '0';
+    card.style.pointerEvents = 'none';
+  });
+  setTimeout(() => card.remove(), 320);
 }
 
 async function voteItem(item, score, btn) {
@@ -621,6 +663,11 @@ async function voteItem(item, score, btn) {
     btn.parentElement.querySelectorAll('button').forEach((b) =>
       b.classList.remove('text-success', 'text-error', 'text-warning'));
     btn.classList.add(score > 0 ? 'text-success' : score < 0 ? 'text-error' : 'text-warning');
+    // voted items leave the feed unless the user opted to keep them visible
+    if (!feedFilters.includeRead) {
+      const card = btn.closest('.card');
+      if (card) collapseCard(card);
+    }
   } catch (err) {
     toast(err.message, 'alert-error');
   }
@@ -653,15 +700,13 @@ function openReader(item) {
   $('readerTitle').textContent = item.item_title || 'Untitled';
   const parsed = parseItemContent(item);
 
-  let host = item.item_domain || '';
-  try { host = new URL(item.item_url).hostname.replace(/^www\./, ''); } catch { /* keep fallback */ }
+  $('readerOpenLink').href = item.item_url;
 
   render($('readerMeta'),
-    item.item_source_name && h('span', { class: 'badge badge-secondary badge-outline badge-xs' }, item.item_source_name),
+    sourceBadge(item.item_source_name, item.item_source_color),
     item.item_author && h('span', {}, `by ${item.item_author}`),
     item.item_date_published && h('span', {}, timeAgo(item.item_date_published)),
-    h('a', { href: item.item_url, target: '_blank', rel: 'noopener', class: 'link link-primary ml-auto' },
-      host ? `Open on ${host} ↗` : 'Open original ↗'));
+    item.item_domain && h('span', { class: 'ml-auto' }, item.item_domain));
 
   // YouTube links embed the actual player; ingested media (gifs, videos,
   // galleries) takes the hero slot. Otherwise non-reddit articles keep
@@ -747,7 +792,12 @@ function sourceRow(source) {
   const interval = intervalLabel(source.source_ingest_interval_minutes);
   return h('div', { class: 'flex items-center justify-between gap-3 p-3 bg-base-200 border border-base-300 rounded-lg mb-2' },
     h('div', { class: 'min-w-0' },
-      h('div', { class: 'font-medium text-sm' }, source.source_name),
+      h('div', { class: 'font-medium text-sm flex items-center gap-2' },
+        h('span', {
+          class: 'inline-block w-2.5 h-2.5 rounded-full flex-shrink-0',
+          style: `background:${sourceColor(source.source_name, source.source_color)}`,
+        }),
+        source.source_name),
       h('div', { class: 'text-xs text-base-content/40 truncate' }, source.source_url),
       h('div', { class: 'text-xs text-base-content/60 mt-1' },
         `${count} article${count === 1 ? '' : 's'} · ${checked}${interval ? ` · checks ${interval}` : ''}`),
@@ -769,6 +819,7 @@ async function openEditSourceModal(source) {
   editingTemplate = null;
   $('editSourceTitle').textContent = `Edit ${source.source_name}`;
   $('editSourceName').value = source.source_name;
+  $('editSourceColor').value = sourceColor(source.source_name, source.source_color);
 
   // custom intervals (set via the API) get their own option so they survive
   // a save that doesn't touch the frequency
@@ -818,6 +869,7 @@ async function handleUpdateSource() {
     feed_name_hash: currentFeed.feed_name_hash,
     source_name_hash: editingSource.source_name_hash,
     source_name: name,
+    source_color: $('editSourceColor').value,
     // null resets the source to the server default frequency
     ingest_interval_minutes: intervalValue ? Number(intervalValue) : null,
   };

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -507,6 +507,15 @@ document.addEventListener('scroll', () => {
 // and loop like the reddit app; videos get controls, so their clicks must
 // reach the player instead of opening the reader.
 function mediaElement(m, cls = 'w-full max-h-[70vh] object-contain') {
+  // third-party players (e.g. redgifs) embed as an iframe; their clicks
+  // never bubble, so they don't open the reader
+  if (m.type === 'embed') {
+    return h('div', { class: 'aspect-video w-full' },
+      h('iframe', {
+        class: 'w-full h-full', src: m.url, loading: 'lazy',
+        allowfullscreen: true, allow: 'autoplay; fullscreen; picture-in-picture',
+      }));
+  }
   if (m.type === 'video' || (m.type === 'gif' && isVideoFile(m.url))) {
     const isGif = m.type === 'gif';
     const video = h('video', {

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -66,10 +66,19 @@ function bindControls() {
   $('manualSourceForm').onsubmit = handleCreateManualSource;
   $('editSourceSaveBtn').onclick = handleUpdateSource;
 
-  // stop autoplaying gifs/videos when the reader closes
+  // stop gifs/videos/embeds when the reader closes: emptying the media
+  // host halts <video> playback and unloads youtube iframes
   $('readerModal').addEventListener('close', () => {
-    $('readerMedia').querySelectorAll('video').forEach((v) => v.pause());
+    render($('readerMedia'));
+    updateGifPlayback();
   });
+
+  // infinite scroll: when the load-more button scrolls near the viewport,
+  // click it automatically
+  new IntersectionObserver((entries) => {
+    const btn = $('loadMoreBtn');
+    if (entries.some((en) => en.isIntersecting) && !btn.classList.contains('hidden')) btn.click();
+  }, { rootMargin: '600px' }).observe($('loadMoreBtn'));
 }
 
 function setView(name) {
@@ -256,7 +265,9 @@ async function toggleFilterPanel() {
   }
 }
 
-// Source checkboxes; all checked (sources: null) by default.
+// Source checkboxes; all checked (sources: null) by default. Always read
+// and re-render from feedFilters.sources so repeated toggles never work
+// against a stale snapshot of the selection.
 function renderFilterSources() {
   const selected = feedFilters.sources; // null = all
   render($('filterSources'),
@@ -268,10 +279,11 @@ function renderFilterSources() {
               checked: selected === null || selected.includes(s.source_name_hash),
               onchange: (e) => {
                 const all = feedSourceList.map((x) => x.source_name_hash);
-                let picked = selected === null ? all.slice() : feedFilters.sources.slice();
+                let picked = feedFilters.sources === null ? all.slice() : feedFilters.sources.slice();
                 if (e.target.checked) { if (!picked.includes(s.source_name_hash)) picked.push(s.source_name_hash); }
                 else picked = picked.filter((hsh) => hsh !== s.source_name_hash);
                 feedFilters.sources = picked.length === all.length ? null : picked;
+                renderFilterSources();
                 reloadItems();
               },
             }),
@@ -354,9 +366,14 @@ async function handleRerank() {
 }
 
 // ---------- items ----------
+let itemsRequestSeq = 0; // discards out-of-order responses
+
 async function loadFeedItems() {
+  const seq = ++itemsRequestSeq;
   const list = $('itemList');
   if (itemSkip === 0) render(list, spinner());
+  // hide while loading so the infinite-scroll observer can't double-fire
+  $('loadMoreBtn').classList.add('hidden');
 
   try {
     const items = await sdk.feedItems({
@@ -368,6 +385,7 @@ async function loadFeedItems() {
       sources: feedFilters.sources === null ? null : feedFilters.sources.join(','),
       text_only: feedFilters.textOnly === '' ? null : feedFilters.textOnly,
     });
+    if (seq !== itemsRequestSeq) return; // a newer request superseded this one
     if (itemSkip === 0) render(list);
 
     if (!items.length && itemSkip === 0) {
@@ -381,6 +399,7 @@ async function loadFeedItems() {
     items.forEach((item) => list.append(itemCard(item)));
     $('loadMoreBtn').classList.toggle('hidden', items.length < PAGE_SIZE);
   } catch (err) {
+    if (seq !== itemsRequestSeq) return;
     if (itemSkip === 0) render(list, h('div', { class: 'text-center py-16 text-base-content/50' }, 'Failed to load articles'));
     toast(err.message, 'alert-error');
   }
@@ -415,14 +434,74 @@ function cleanExcerpt(item) {
 
 const isVideoFile = (url) => /\.(mp4|webm)(\?|$)/i.test(url || '');
 
-// Pause autoplaying gifs while they're offscreen so a feed full of them
-// doesn't churn bandwidth and CPU.
-const gifVisibility = new IntersectionObserver((entries) => {
-  entries.forEach(({ target, isIntersecting }) => {
-    if (isIntersecting) target.play().catch(() => {});
-    else target.pause();
+// Video id for youtube watch/short/embed/youtu.be links, else null.
+function youtubeId(url) {
+  try {
+    const u = new URL(url);
+    const host = u.hostname.replace(/^www\.|^m\./, '');
+    if (host === 'youtu.be') return u.pathname.slice(1).split('/')[0] || null;
+    if (host === 'youtube.com' || host === 'youtube-nocookie.com') {
+      if (u.pathname === '/watch') return u.searchParams.get('v');
+      const m = u.pathname.match(/^\/(?:embed|shorts|live|v)\/([\w-]{6,})/);
+      if (m) return m[1];
+    }
+  } catch { /* not a URL */ }
+  return null;
+}
+
+function youtubeEmbed(id) {
+  return h('div', { class: 'aspect-video w-full' },
+    h('iframe', {
+      class: 'w-full h-full', src: `https://www.youtube-nocookie.com/embed/${id}`,
+      title: 'YouTube video player', loading: 'lazy', allowfullscreen: true,
+      allow: 'accelerometer; encrypted-media; gyroscope; picture-in-picture',
+    }));
+}
+
+// Gif playback policy: pause everything offscreen, and of the gifs on
+// screen play only the topmost fully-visible one, so a feed full of gifs
+// doesn't churn bandwidth and CPU or fight for attention.
+const gifRatios = new Map(); // gif <video> -> latest intersection ratio
+
+function updateGifPlayback() {
+  // gifs in an open reader modal take priority over the feed behind it
+  const readerOpen = Array.from(gifRatios.keys())
+    .some((v) => v.isConnected && v.closest('dialog[open]'));
+  let playing = null;
+  for (const [video, ratio] of gifRatios) {
+    if (!video.isConnected) { gifRatios.delete(video); continue; }
+    if (readerOpen && !video.closest('dialog[open]')) continue;
+    if (ratio < 0.98) continue; // fully visible only
+    const top = video.getBoundingClientRect().top;
+    if (!playing || top < playing.top) playing = { video, top };
+  }
+  // nothing fully visible (e.g. mid-scroll between gifs): fall back to the
+  // most-visible one so playback doesn't stall
+  if (!playing) {
+    for (const [video, ratio] of gifRatios) {
+      if (readerOpen && !video.closest('dialog[open]')) continue;
+      if (ratio > 0.5 && (!playing || ratio > playing.ratio)) playing = { video, ratio };
+    }
+  }
+  gifRatios.forEach((_, video) => {
+    if (playing && video === playing.video) video.play().catch(() => {});
+    else video.pause();
   });
-}, { rootMargin: '200px' });
+}
+
+const gifVisibility = new IntersectionObserver((entries) => {
+  entries.forEach((en) => gifRatios.set(en.target, en.intersectionRatio));
+  updateGifPlayback();
+}, { threshold: [0, 0.25, 0.5, 0.75, 0.98, 1] });
+
+// Which gif is "topmost" can change while scrolling without crossing an
+// intersection threshold; re-evaluate on scroll (rAF-throttled).
+let gifScrollTick = false;
+document.addEventListener('scroll', () => {
+  if (gifScrollTick || !gifRatios.size) return;
+  gifScrollTick = true;
+  requestAnimationFrame(() => { gifScrollTick = false; updateGifPlayback(); });
+}, { passive: true, capture: true });
 
 // One media entry ({type, url, poster?}) -> element. Gifs autoplay muted
 // and loop like the reddit app; videos get controls, so their clicks must
@@ -467,11 +546,14 @@ function mediaGallery(mediaList) {
 // below, then the vote row.
 function itemCard(item) {
   const published = item.item_date_published ? timeAgo(item.item_date_published) : '';
-  const media = (item.item_media || []).length ? item.item_media : null;
-  const imageUrl = media ? null : (item.item_image_url || parseItemContent(item).imageUrl);
+  const ytId = youtubeId(item.item_url);
+  const media = !ytId && (item.item_media || []).length ? item.item_media : null;
+  const imageUrl = ytId || media ? null : (item.item_image_url || parseItemContent(item).imageUrl);
   const excerpt = cleanExcerpt(item);
 
-  const mediaBlock = media
+  const mediaBlock = ytId
+    ? h('figure', { class: 'bg-base-300' }, youtubeEmbed(ytId))
+    : media
     ? h('figure', { class: 'bg-base-300' }, mediaGallery(media))
     : imageUrl
       ? h('figure', { class: 'bg-base-300' },
@@ -572,15 +654,21 @@ function openReader(item) {
     h('a', { href: item.item_url, target: '_blank', rel: 'noopener', class: 'link link-primary ml-auto' },
       host ? `Open on ${host} ↗` : 'Open original ↗'));
 
-  // Ingested media (gifs, videos, galleries) takes the hero slot. Otherwise
-  // non-reddit articles keep their images inline in the content and only
-  // reddit-style posts promote a content image to the hero.
-  const media = item.item_media || [];
-  const heroUrl = media.length
+  // YouTube links embed the actual player; ingested media (gifs, videos,
+  // galleries) takes the hero slot. Otherwise non-reddit articles keep
+  // their images inline in the content and only reddit-style posts promote
+  // a content image to the hero.
+  const ytId = youtubeId(item.item_url);
+  const media = ytId ? [] : item.item_media || [];
+  const heroUrl = ytId || media.length
     ? null
     : item.item_image_url || (parsed.isReddit ? parsed.imageUrl : null);
   const mediaHost = $('readerMedia');
-  if (media.length) {
+  if (ytId) {
+    render(mediaHost, youtubeEmbed(ytId));
+    // the content's thumbnails would just duplicate the player
+    parsed.root.querySelectorAll('img').forEach((img) => (img.closest('a') || img).remove());
+  } else if (media.length) {
     render(mediaHost, mediaGallery(media));
   } else if (heroUrl) {
     render(mediaHost, h('img', {

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -124,10 +124,13 @@
 <dialog class="modal" id="readerModal">
   <div class="modal-box max-w-3xl max-h-[90vh]">
     <form method="dialog"><button class="btn btn-sm btn-circle btn-ghost absolute right-4 top-4">✕</button></form>
-    <h2 class="text-xl font-bold pr-8 mb-2" id="readerTitle"></h2>
-    <div class="flex flex-wrap gap-3 text-xs text-base-content/50 mb-4 pb-3 border-b border-base-300" id="readerMeta"></div>
+    <div class="flex items-start gap-2 pr-8 mb-4">
+      <h2 class="text-xl font-bold flex-1 min-w-0" id="readerTitle"></h2>
+      <a class="btn btn-ghost btn-sm btn-square text-base-content/60" id="readerOpenLink" target="_blank" rel="noopener" title="Open original">↗</a>
+    </div>
     <div id="readerMedia" class="mb-4 empty:hidden"></div>
     <div class="prose prose-sm max-w-none" id="readerContent"></div>
+    <div class="flex flex-wrap items-center gap-3 text-xs text-base-content/50 mt-4 pt-3 border-t border-base-300" id="readerMeta"></div>
   </div>
   <form method="dialog" class="modal-backdrop"><button>close</button></form>
 </dialog>
@@ -223,6 +226,10 @@
     <div class="form-control mb-3">
       <label class="label" for="editSourceName"><span class="label-text">Source Name</span></label>
       <input type="text" class="input input-bordered w-full" id="editSourceName" required>
+    </div>
+    <div class="form-control mb-3">
+      <label class="label" for="editSourceColor"><span class="label-text">Color</span></label>
+      <input type="color" class="w-16 h-10 p-1 rounded-lg border border-base-300 bg-base-100 cursor-pointer" id="editSourceColor" title="Badge color for this source">
     </div>
     <div class="form-control mb-3">
       <label class="label" for="editSourceInterval"><span class="label-text">Check for new posts</span></label>

--- a/src/api/tests/db/feed_test.py
+++ b/src/api/tests/db/feed_test.py
@@ -151,7 +151,10 @@ def test_get_items_with_skip_and_limit(unique_feed, unique_item_strict):
 
 def test_sources(unique_feed, unique_source):
     """Tests adding and removing sources from a feed."""
-    unique_feed.create()
+    # the unique_source fixture's existing_feed dependency already
+    # persisted this feed
+    if not unique_feed.exists():
+        unique_feed.create()
 
     unique_feed.add_source(unique_source)
     assert unique_source.name_hash in unique_feed.source_hashes
@@ -166,7 +169,10 @@ def test_sources(unique_feed, unique_source):
 
 def test_delete_feed_removes_sources(unique_feed, unique_source):
     """Tests that deleting a feed removes its sources."""
-    unique_feed.create()
+    # the unique_source fixture's existing_feed dependency already
+    # persisted this feed
+    if not unique_feed.exists():
+        unique_feed.create()
     unique_feed.add_source(unique_source)
 
     assert unique_feed.exists()
@@ -188,3 +194,143 @@ def test_remove_items(unique_feed, unique_item_strict):
     unique_feed.remove_items(unique_item_strict)
     assert unique_item_strict not in unique_feed.query_items()
     assert unique_item_strict.exists()
+
+
+def _make_source(feed, name):
+    from db.source import Source
+
+    source = Source(
+        user_hash=feed.user_hash,
+        feed_hash=feed.name_hash,
+        name=name,
+        url="http://example.com",
+    )
+    feed.add_source(source)
+    return source
+
+
+def _add_item(feed, source, item, url, score, **overrides):
+    new = item.model_copy()
+    new.url = url
+    for field, value in overrides.items():
+        setattr(new, field, value)
+    new.create()
+    if source is not None:
+        source.add_items(new)
+    feed.add_items(new)
+    feed.set_items_scores({new.url_hash: score})
+    return new
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_query_items_text_only_counts_content_images(unique_feed, unique_item_strict):
+    """A content-embedded <img> counts as visual media for text_only."""
+    unique_feed.create()
+
+    visual = _add_item(
+        unique_feed,
+        None,
+        unique_item_strict,
+        "http://example.com/content-img",
+        2,
+        image_url=None,
+        media=None,
+        content='<p>words</p><img src="http://example.com/pic.jpg">',
+    )
+    text = _add_item(
+        unique_feed,
+        None,
+        unique_item_strict,
+        "http://example.com/plain-text",
+        1,
+        image_url=None,
+        media=None,
+        content="<p>just words</p>",
+    )
+
+    with_media = unique_feed.query_items_with_sources(text_only=False)
+    assert [item.url_hash for item, _ in with_media] == [visual.url_hash]
+
+    text_only = unique_feed.query_items_with_sources(text_only=True)
+    assert [item.url_hash for item, _ in text_only] == [text.url_hash]
+
+    everything = unique_feed.query_items_with_sources(text_only=None)
+    assert len(everything) == 2
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_query_items_text_only_counts_media_list(unique_feed, unique_item_strict):
+    """Ingested media counts as visual; an empty media list does not."""
+    unique_feed.create()
+
+    gif = _add_item(
+        unique_feed,
+        None,
+        unique_item_strict,
+        "http://example.com/gif",
+        2,
+        image_url=None,
+        media=[{"type": "gif", "url": "http://example.com/a.mp4"}],
+        content="<p>words</p>",
+    )
+    _add_item(
+        unique_feed,
+        None,
+        unique_item_strict,
+        "http://example.com/scraped-no-media",
+        1,
+        image_url=None,
+        media=[],
+        content="<p>words</p>",
+    )
+
+    with_media = unique_feed.query_items_with_sources(text_only=False)
+    assert [item.url_hash for item, _ in with_media] == [gif.url_hash]
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_query_items_interleaves_sources(unique_feed, unique_item_strict):
+    """Items alternate between sources while respecting the sort order."""
+    unique_feed.create()
+    source_a = _make_source(unique_feed, "source-a")
+    source_b = _make_source(unique_feed, "source-b")
+
+    # source-a's items all outscore source-b's, so a plain sort would put
+    # all of source-a first
+    _add_item(unique_feed, source_a, unique_item_strict, "http://example.com/a1", 40)
+    _add_item(unique_feed, source_a, unique_item_strict, "http://example.com/a2", 30)
+    _add_item(unique_feed, source_b, unique_item_strict, "http://example.com/b1", 20)
+    _add_item(unique_feed, source_b, unique_item_strict, "http://example.com/b2", 10)
+
+    results = unique_feed.query_items_with_sources(sort="best")
+    names = [meta["source_name"] for _, meta in results]
+    assert names == ["source-a", "source-b", "source-a", "source-b"]
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_query_items_source_filter(unique_feed, unique_item_strict):
+    """source_hashes restricts results to the selected sources."""
+    unique_feed.create()
+    source_a = _make_source(unique_feed, "source-a")
+    source_b = _make_source(unique_feed, "source-b")
+
+    item_a = _add_item(
+        unique_feed, source_a, unique_item_strict, "http://example.com/a", 2
+    )
+    item_b = _add_item(
+        unique_feed, source_b, unique_item_strict, "http://example.com/b", 1
+    )
+
+    only_a = unique_feed.query_items_with_sources(source_hashes=[source_a.name_hash])
+    assert [item.url_hash for item, _ in only_a] == [item_a.url_hash]
+
+    only_b = unique_feed.query_items_with_sources(source_hashes=[source_b.name_hash])
+    assert [item.url_hash for item, _ in only_b] == [item_b.url_hash]
+
+    none = unique_feed.query_items_with_sources(source_hashes=[])
+    assert none == []
+
+    both = unique_feed.query_items_with_sources(
+        source_hashes=[source_a.name_hash, source_b.name_hash]
+    )
+    assert len(both) == 2

--- a/src/api/tests/db/feed_test.py
+++ b/src/api/tests/db/feed_test.py
@@ -334,3 +334,55 @@ def test_query_items_source_filter(unique_feed, unique_item_strict):
         source_hashes=[source_a.name_hash, source_b.name_hash]
     )
     assert len(both) == 2
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_feed_stats(unique_feed, unique_item_strict):
+    """Dashboard stats: totals, unvoted count, and posts/day."""
+    from db.item_state import ItemState
+
+    unique_feed.create()
+
+    items = [
+        _add_item(unique_feed, None, unique_item_strict, f"http://example.com/{i}", i)
+        for i in range(3)
+    ]
+    ItemState(
+        user_hash=unique_feed.user_hash,
+        feed_hash=unique_feed.name_hash,
+        item_url_hash=items[0].url_hash,
+        score=1,
+    ).create()
+
+    stats = unique_feed.stats()
+    assert stats["feed_item_count"] == 3
+    assert stats["feed_unread_count"] == 2
+    assert stats["feed_posts_per_day"] == 3.0  # 3 items on day one
+
+
+def test_source_color_assigned_and_editable(unique_feed):
+    """Sources get a palette color at creation; updates can change it."""
+    from db.source import SOURCE_COLORS, Source
+
+    unique_feed.create()
+    source = Source(
+        user_hash=unique_feed.user_hash,
+        feed_hash=unique_feed.name_hash,
+        name="colorful",
+        url="http://example.com",
+    )
+    unique_feed.add_source(source)
+    stored = Source.read(
+        user_hash=unique_feed.user_hash,
+        feed_hash=unique_feed.name_hash,
+        source_hash=source.name_hash,
+    )
+    assert stored.color in SOURCE_COLORS
+
+    stored.update(name=stored.name, url=str(stored.url), color="#123abc")
+    reread = Source.read(
+        user_hash=unique_feed.user_hash,
+        feed_hash=unique_feed.name_hash,
+        source_hash=stored.name_hash,
+    )
+    assert reread.color == "#123abc"

--- a/src/api/tests/ingest/reddit_test.py
+++ b/src/api/tests/ingest/reddit_test.py
@@ -108,6 +108,59 @@ def test_post_media_image_post_hint():
     ]
 
 
+def test_post_media_reddit_video_preview_for_external_gif():
+    """redgifs/gfycat-style link posts expose an mp4 via reddit_video_preview."""
+    post = {
+        "url_overridden_by_dest": "https://www.redgifs.com/watch/valhaalaand",
+        "post_hint": "rich:video",
+        "preview": {
+            "images": [{"source": {"url": "https://preview.redd.it/img.jpg"}}],
+            "reddit_video_preview": {
+                "fallback_url": "https://v.redd.it/xyz/DASH_720.mp4",
+                "is_gif": True,
+            },
+        },
+    }
+    assert _post_media(post) == [
+        {
+            "type": "gif",
+            "url": "https://v.redd.it/xyz/DASH_720.mp4",
+            "poster": "https://preview.redd.it/img.jpg",
+        }
+    ]
+
+
+def test_post_media_reddit_video_preview_not_gif_is_video():
+    post = {
+        "url_overridden_by_dest": "https://gfycat.com/somename",
+        "preview": {
+            "reddit_video_preview": {
+                "fallback_url": "https://v.redd.it/xyz/DASH_720.mp4",
+                "is_gif": False,
+            }
+        },
+    }
+    assert _post_media(post) == [
+        {"type": "video", "url": "https://v.redd.it/xyz/DASH_720.mp4"}
+    ]
+
+
+def test_post_media_redgifs_embed_without_rendition():
+    """No mp4 rendition available: fall back to redgifs' iframe player."""
+    post = {
+        "url_overridden_by_dest": "https://www.redgifs.com/watch/valhaalaand",
+        "post_hint": "rich:video",
+        "preview": {"images": [{"source": {"url": "https://preview.redd.it/img.jpg"}}]},
+    }
+    assert _post_media(post) == [
+        {
+            "type": "embed",
+            "url": "https://www.redgifs.com/ifr/valhaalaand",
+            "poster": "https://preview.redd.it/img.jpg",
+        }
+    ]
+
+
 def test_post_media_plain_link_has_no_media():
     post = {"url_overridden_by_dest": "https://example.com/article"}
     assert _post_media(post) == []

--- a/src/api/tests/routers/feed_test.py
+++ b/src/api/tests/routers/feed_test.py
@@ -15,6 +15,9 @@ def test_create_feed(client, unique_feed, existing_user, token):
     assert response.json() == {
         "feed_name": unique_feed.name,
         "feed_name_hash": unique_feed.name_hash,
+        "feed_item_count": None,
+        "feed_unread_count": None,
+        "feed_posts_per_day": None,
     }
 
 
@@ -69,6 +72,9 @@ def test_get_feed(client, existing_user, existing_feed, token):
     assert response.json() == {
         "feed_name": existing_feed.name,
         "feed_name_hash": existing_feed.name_hash,
+        "feed_item_count": None,
+        "feed_unread_count": None,
+        "feed_posts_per_day": None,
     }
 
 
@@ -98,6 +104,9 @@ def test_list_feeds(client, existing_user, existing_feed, token):
         {
             "feed_name": existing_feed.name,
             "feed_name_hash": existing_feed.name_hash,
+            "feed_item_count": 0,
+            "feed_unread_count": 0,
+            "feed_posts_per_day": 0.0,
         }
     ]
 
@@ -147,8 +156,11 @@ def test_sources(client, existing_user, existing_feed, existing_source, token):
             "source_template_name_hash": None,
             "source_template_parameters": None,
             "source_ingest_interval_minutes": None,
+            "source_color": response.json()[0]["source_color"],
         }
     ]
+    # a palette color was assigned at creation
+    assert response.json()[0]["source_color"].startswith("#")
 
 
 def test_get_all_items(


### PR DESCRIPTION
Fixes the feed filtering/media issues reported:

## Media filter hid everything
"With image / media" only checked the `image_url`/`media` columns, which are null for every item ingested before those columns existed (PR #96) — even though the cards display images pulled from the content HTML. The SQL visual check now also counts an `<img>` in the item's sanitized content, so anything with any image is included.

## Deselecting sources didn't filter
The checkbox `onchange` closures captured the selection from render time, so after the first toggle every later toggle worked against a stale snapshot (deselecting B silently re-added A). The handler now reads live filter state and the panel re-renders after each change.

## Multi-image galleries & gifs showing only the RSS preview
The reddit post-JSON scraper (from #96) only ran for brand-new items; anything already in the database kept its thumbnail forever. Ingest now backfills media (galleries, gifs, v.redd.it video) from the post JSON for existing reddit items that were never scraped. A successful scrape that finds no media stores `[]` so text posts aren't re-fetched every cycle.

## Gif playback
Offscreen gifs pause, and only the topmost fully-visible gif plays at any moment (falling back to the most-visible one mid-scroll). Gifs inside the open reader modal take priority over the feed behind it.

## Infinite scroll
An IntersectionObserver auto-clicks "Load More" when it nears the viewport, with a request-sequence guard so scroll/filter races can't double-fetch or render stale responses.

## Source interleaving
`/feed/items` now round-robins sources within the chosen sort order (each source's best item first, then each source's second-best, …) so the feed mixes sources instead of long runs of one. Paging stays consistent since the interleave is computed in SQL.

## YouTube posts
YouTube links now render the embedded player (youtube-nocookie) in both the feed card and the reader, replacing the duplicated thumbnail + description; content thumbnails are stripped in the reader since they'd duplicate the player.

## Tests
- New db tests: content-image visual filter, media-list filter, source interleave, source-hash filtering.
- Fixed two pre-existing feed db tests that failed from fixture double-create.
- Verified end-to-end against a real Postgres via the HTTP API with the exact query strings the UI sends (media filter both ways, interleave order, source filter incl. empty selection, paging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PrtP4yZ3ViGkxRVjuLj7e

---
_Generated by [Claude Code](https://claude.ai/code/session_019PrtP4yZ3ViGkxRVjuLj7e)_