### PR TITLE
Fix Ollama embedding 500s on long items via larger context + truncation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,15 @@ JWT_SECRET=
 # the internal services (e.g. aggy-api:8000) from the dashboard.
 CLOUDFLARE_TUNNEL_TOKEN=
 
-# Ollama model used to embed items for relevance ranking
+# Ollama model used to embed items for relevance ranking.
+# nomic-embed-text handles up to 8192 tokens, enough for full articles.
 OLLAMA_EMBEDDING_MODEL=nomic-embed-text
+
+# Context window (and physical batch size) used when embedding items.
+# Ollama defaults to 2048, which rejects longer items with a 500 error and
+# leaves them without an embedding. Raise this if you embed longer documents
+# (needs more RAM); it must not exceed the model's max context.
+OLLAMA_EMBEDDING_NUM_CTX=8192
 
 # Set to false to disable new account creation
 SIGNUP_ENABLED=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - OLLAMA_HOST=aggy-ollama
       - OLLAMA_PORT=11434
       - OLLAMA_EMBEDDING_MODEL=${OLLAMA_EMBEDDING_MODEL:-nomic-embed-text}
+      - OLLAMA_EMBEDDING_NUM_CTX=${OLLAMA_EMBEDDING_NUM_CTX:-8192}
       - JWT_ALGORITHM=HS256
       - JWT_SECRET=${JWT_SECRET:?Set JWT_SECRET in .env (generate with `openssl rand -hex 32`)}
       - SIGNUP_ENABLED=${SIGNUP_ENABLED:-true}

--- a/src/api/config.py
+++ b/src/api/config.py
@@ -18,6 +18,7 @@ KNOWN_CONFIG_VALUES = [
     "OLLAMA_USER",
     "OLLAMA_PASSWORD",
     "OLLAMA_EMBEDDING_MODEL",
+    "OLLAMA_EMBEDDING_NUM_CTX",
     "RSS_BRIDGE_HOST",
     "RSS_BRIDGE_PORT",
     "BUILD_VERSION",
@@ -32,6 +33,11 @@ DEFAULT_CONFIG = {
     "PYTEST_RUNTIME_TYPE": "local",
     "JWT_ALGORITHM": "HS256",
     "OLLAMA_PORT": 11434,
+    # Context window (and physical batch size) used when embedding items.
+    # Ollama defaults to 2048; items longer than that get a 500 "input too
+    # large to process" and end up with no embedding. nomic-embed-text
+    # supports up to 8192 tokens, so we raise the default to match.
+    "OLLAMA_EMBEDDING_NUM_CTX": 8192,
     "RSS_BRIDGE_PORT": 80,
     "BUILD_VERSION": "0.0.0-beta",
     "DB_PORT": 5432,

--- a/src/api/db/item.py
+++ b/src/api/db/item.py
@@ -187,9 +187,26 @@ class ItemBase(AggyBaseModel):
         ]
         return "\n".join(print_attrs)
 
+    # Conservative lower bound on characters per token. Real tokenizers
+    # average ~4 chars/token for prose, but dense content (URLs, code,
+    # markup) can be ~3, so we budget at 3 to guarantee the character-capped
+    # prompt stays under the token context window.
+    _CHARS_PER_TOKEN = 3
+
+    def embedding_prompt(self, num_ctx: int) -> str:
+        """The text embedded for this item, truncated so it fits the model's
+        context window. Ollama processes an embedding prompt in a single
+        physical batch, so anything longer than ``num_ctx`` tokens is rejected
+        with a 500 and the item ends up with no embedding at all. We cap the
+        prompt by characters (a conservative proxy for tokens) to stay safely
+        inside the window."""
+        prompt = str(self)
+        char_budget = num_ctx * self._CHARS_PER_TOKEN
+        if len(prompt) > char_budget:
+            prompt = prompt[:char_budget]
+        return prompt
+
     def add_embedding(self, model_name: str, force_refresh=False) -> None:
-        # TODO write tests for this
-        # TODO make sure the input isn't truncated by the context window (often)
         if not self.embeddings:
             self.embeddings = {}
 
@@ -200,9 +217,15 @@ class ItemBase(AggyBaseModel):
 
         # get the embedding
         ollama_embedding_model = config.get("OLLAMA_EMBEDDING_MODEL")
-        embedding = ollama.embeddings(model=ollama_embedding_model, prompt=str(self))[
-            "embedding"
-        ]
+        num_ctx = config.get_int("OLLAMA_EMBEDDING_NUM_CTX")
+        embedding = ollama.embeddings(
+            model=ollama_embedding_model,
+            prompt=self.embedding_prompt(num_ctx),
+            # num_batch must match num_ctx: an embedding prompt is processed in
+            # one batch, so a small physical batch (Ollama's 2048 default)
+            # rejects longer inputs even when the context window is large.
+            options={"num_ctx": num_ctx, "num_batch": num_ctx},
+        )["embedding"]
 
         # add the embedding to self
         self.embeddings[ollama_embedding_model] = embedding

--- a/src/api/docker-compose.yml
+++ b/src/api/docker-compose.yml
@@ -83,7 +83,10 @@ services:
       - EXTRACT_PORT=3000
       - OLLAMA_HOST=dev-aggy-ollama
       - OLLAMA_PORT=11434
-      - OLLAMA_EMBEDDING_MODEL=mxbai-embed-large:latest
+      # nomic-embed-text (8192-token context) matches prod and handles full
+      # articles; mxbai-embed-large caps at 512 tokens and truncates most items.
+      - OLLAMA_EMBEDDING_MODEL=nomic-embed-text
+      - OLLAMA_EMBEDDING_NUM_CTX=8192
       - JWT_ALGORITHM=HS256
       - JWT_SECRET=429bceb2ab20f5785a4b609a725b0164be73a95d8ce04706ed8366cfe6ade896 # openssl rand -hex 32
     labels:

--- a/src/api/tests/db/item_test.py
+++ b/src/api/tests/db/item_test.py
@@ -1,5 +1,8 @@
+from unittest.mock import MagicMock
+
 import pytest
 
+from config import config
 from db.item import ItemLoose, ItemStrict
 
 
@@ -166,3 +169,48 @@ def test_relative_img_sanitization(unique_item_strict):
 
     item = ItemLoose.read(unique_item_strict.url_hash)
     assert item.content == f'<img src="{unique_item_strict.url}example.jpg">'
+
+
+def test_embedding_prompt_truncates_to_context_window(unique_item_strict):
+    """Long items are capped by characters so they can't exceed the model's
+    token context window (which would make Ollama 500 on the embed call)."""
+    unique_item_strict.content = "x" * 100_000
+    num_ctx = 8192
+    prompt = unique_item_strict.embedding_prompt(num_ctx)
+    assert len(prompt) == num_ctx * ItemStrict._CHARS_PER_TOKEN
+
+
+def test_embedding_prompt_leaves_short_items_untouched(unique_item_strict):
+    """Items that already fit are embedded verbatim."""
+    prompt = unique_item_strict.embedding_prompt(8192)
+    assert prompt == str(unique_item_strict)
+
+
+def test_add_embedding_expands_context_and_batch(unique_item_strict, monkeypatch):
+    """add_embedding requests a context window and physical batch large enough
+    for the whole prompt, so long items don't get rejected."""
+    config.set("OLLAMA_EMBEDDING_MODEL", "nomic-embed-text")
+    config.set("OLLAMA_EMBEDDING_NUM_CTX", 8192)
+
+    fake_client = MagicMock()
+    fake_client.embeddings.return_value = {"embedding": [0.1, 0.2, 0.3]}
+    monkeypatch.setattr("db.item.get_ollama_connection", lambda: fake_client)
+
+    unique_item_strict.add_embedding("nomic-embed-text")
+
+    fake_client.embeddings.assert_called_once()
+    kwargs = fake_client.embeddings.call_args.kwargs
+    assert kwargs["model"] == "nomic-embed-text"
+    assert kwargs["options"] == {"num_ctx": 8192, "num_batch": 8192}
+    assert unique_item_strict.embeddings["nomic-embed-text"] == [0.1, 0.2, 0.3]
+
+
+def test_add_embedding_skips_when_already_present(unique_item_strict, monkeypatch):
+    """An existing embedding for the model is not recomputed unless forced."""
+    fake_client = MagicMock()
+    monkeypatch.setattr("db.item.get_ollama_connection", lambda: fake_client)
+
+    unique_item_strict.embeddings = {"nomic-embed-text": [0.0]}
+    unique_item_strict.add_embedding("nomic-embed-text")
+
+    fake_client.embeddings.assert_not_called()


### PR DESCRIPTION
## Problem

Ollama logs showed embedding requests failing on longer items:

```
srv send_error: task id = 67, error: input (3317 tokens) is too large to process.
increase the physical batch size (current batch size: 2048)
[GIN] POST "/api/embeddings" → 500
```

`Item.add_embedding` sent `str(self)` — the full item including the entire article `content` — to Ollama with **no options**, so Ollama used its default 2048-token context/batch. Any item over that limit returned a 500, so the item silently ended up with **no embedding**, which degrades relevance ranking. This resolves the long-standing `TODO` on the method ("make sure the input isn't truncated by the context window (often)").

## Fix

Two-part, belt-and-suspenders:

1. **Expand context + batch.** The embed call now passes `options={"num_ctx": N, "num_batch": N}`, configurable via the new `OLLAMA_EMBEDDING_NUM_CTX` env var (default **8192**, which `nomic-embed-text` supports). An embedding prompt is processed in a single physical batch, so `num_batch` must be raised alongside `num_ctx` — raising only the context window would still trip the exact "physical batch size" error in the log.
2. **Truncate the prompt.** `embedding_prompt()` caps the text to a character budget derived from the context window (conservative 3 chars/token), so an unusually long article can never re-trigger the 500.

## Model choice

`nomic-embed-text` (prod default) already supports 8192-token context and is a strong general-purpose embedding model — well suited here. The dev compose was using `mxbai-embed-large`, whose context caps at **512 tokens** (worse for this exact problem), so it's switched to `nomic-embed-text` to match prod.

Memory note: larger `num_ctx`/`num_batch` uses more RAM per request, which the deployment has to spare. Bump `OLLAMA_EMBEDDING_NUM_CTX` further if you embed even longer documents (must stay within the model's max context).

## Changes

- `src/api/db/item.py` — configurable context/batch on the embed call + prompt truncation
- `src/api/config.py` — new `OLLAMA_EMBEDDING_NUM_CTX` (default 8192)
- `.env.example`, `docker-compose.yml` — document/expose the new var
- `src/api/docker-compose.yml` (dev) — switch to `nomic-embed-text`
- `src/api/tests/db/item_test.py` — tests for truncation, options passed, and skip-when-present

## Testing

Ran the new embedding logic standalone (DB not required for these paths): truncation, verbatim short items, correct `num_ctx`/`num_batch` options, and the already-present skip all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLY7oyiknyS6UdNJ2SSGdD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLY7oyiknyS6UdNJ2SSGdD)_