### PR TITLE
Move article vote buttons to the right of the card footer

### DIFF
--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -628,14 +628,15 @@ function itemCard(item) {
       !mediaBlock && excerpt && h('p', { class: 'text-xs text-base-content/50 line-clamp-2 mt-1' }, excerpt)),
     mediaBlock,
     h('div', { class: 'flex items-center gap-1 px-2 py-1.5' },
-      voteButton('▲', 1, 'Upvote'),
-      voteButton('●', 0, 'Neutral — seen it, no strong feelings'),
-      voteButton('▼', -1, 'Downvote'),
-      h('div', { class: 'flex flex-wrap items-center justify-end gap-2 text-xs text-base-content/50 ml-auto min-w-0 pr-2' },
+      h('div', { class: 'flex flex-wrap items-center gap-2 text-xs text-base-content/50 min-w-0 pl-2' },
         sourceBadge(item.item_source_name, item.item_source_color),
         item.item_author && h('span', { class: 'truncate max-w-32' }, item.item_author),
         published && h('span', { class: 'whitespace-nowrap' }, published),
-        predictedBadge)));
+        predictedBadge),
+      h('div', { class: 'flex items-center gap-1 ml-auto' },
+        voteButton('▲', 1, 'Upvote'),
+        voteButton('●', 0, 'Neutral — seen it, no strong feelings'),
+        voteButton('▼', -1, 'Downvote'))));
 }
 
 // Animate a voted card shrinking away, then drop it from the DOM.


### PR DESCRIPTION
## Summary

Swaps the layout of the article card footer so the vote buttons (▲ ● ▼) sit on the **right** side and the meta text (source badge, author, published date, prediction badge) sits on the **left**.

Previously the vote buttons were on the left with the meta text pushed to the right via `ml-auto`. Now the meta group is first and left-aligned, and the vote button group is pushed right with `ml-auto`.

## Changes

- `src/api/static/js/app.js`: reorder the card footer flex row — meta text first, vote buttons wrapped in their own group with `ml-auto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWvY8EyUTwkzCQKmxwzxtr)_