### PR TITLE
Add per-article recommendation explainability

### DIFF
--- a/src/api/ranking/explain.py
+++ b/src/api/ranking/explain.py
@@ -1,0 +1,138 @@
+"""Explain why the recommendation model scored a single article the way it did.
+
+The prediction models are opaque (a kNN vote, a ridge regression, a small net),
+so instead of reading their internals we probe them: hold the article fixed and,
+one field at a time, swap that field for many random/average values drawn from
+the rest of the feed. If the article's real value scores higher than those
+substitutes, that field is *pushing the recommendation up*; if lower, it's
+*dragging it down*. The size of the gap becomes 0, 1, or 2 marks.
+
+This is a per-instance permutation importance, computed on demand (it retrains
+the winning model on the feed's votes), because users look at it rarely.
+"""
+
+import random
+from dataclasses import dataclass, replace
+from typing import List, Optional
+
+import numpy as np
+
+from db.base import get_db_con
+from db.feed import Feed
+from .engine import MIN_LABELS_TO_RANK, load_feed_features
+from .models import ItemFeatures, all_models, evaluate_models
+
+# How many substitute values to try per field. Enough to average out the
+# noise of random draws without making the on-demand call slow.
+_SAMPLES = 40
+
+# |Δ score| thresholds for 0 / 1 / 2 marks. Predicted scores live in [-1, 1].
+_LEVEL1 = 0.04
+_LEVEL2 = 0.12
+
+# Fields the model actually consumes, in display order, mapped to the
+# ItemFeatures attribute each one perturbs. "content" is the text embedding,
+# which is generated from the article's title + body together.
+_FIELDS = [
+    ("content", "Content", "embedding"),
+    ("source", "Source", "source"),
+    ("author", "Author", "author"),
+    ("recency", "Recency", "date_published"),
+    ("image", "Image", "has_image"),
+    ("media", "Media", "has_media"),
+]
+
+
+@dataclass
+class FieldContribution:
+    field: str
+    label: str
+    # -1 dragging the score down, 0 no measurable effect, +1 pushing it up
+    sign: int
+    # 0, 1, or 2 marks
+    level: int
+    delta: float
+
+
+@dataclass
+class ItemExplanation:
+    model_name: str
+    baseline_score: float
+    fields: List[FieldContribution]
+
+
+def _winner_model(feed: Feed, labeled: List[ItemFeatures]):
+    """The model currently ranking this feed, so the explanation matches the
+    score the user sees. Prefer the persisted choice; fall back to evaluating."""
+    chosen = None
+    with get_db_con() as cur:
+        cur.execute(
+            "SELECT model_name FROM ranking_model_stats "
+            "WHERE user_hash = %s AND feed_hash = %s AND chosen = TRUE LIMIT 1",
+            (feed.user_hash, feed.name_hash),
+        )
+        row = cur.fetchone()
+        if row:
+            chosen = row["model_name"]
+    if chosen is None:
+        stats = evaluate_models(labeled)
+        chosen = next((s.model_name for s in stats if s.chosen), None)
+    if chosen is None:
+        return None
+    return next((m for m in all_models() if m.name == chosen), None)
+
+
+def _marks(delta: float):
+    magnitude = abs(delta)
+    if magnitude >= _LEVEL2:
+        level = 2
+    elif magnitude >= _LEVEL1:
+        level = 1
+    else:
+        level = 0
+    sign = 0 if level == 0 else (1 if delta > 0 else -1)
+    return sign, level
+
+
+def explain_item(
+    feed: Feed, item_url_hash: str, samples: int = _SAMPLES, seed: int = 0
+) -> Optional[ItemExplanation]:
+    """Return a per-field breakdown of what drives this item's predicted score,
+    or None when the feed has too few votes / the item isn't in the feed."""
+    features = load_feed_features(feed)
+    labeled = [f for f in features if f.label is not None]
+    if len(labeled) < MIN_LABELS_TO_RANK:
+        return None
+
+    target = next((f for f in features if f.url_hash == item_url_hash), None)
+    if target is None:
+        return None
+
+    model = _winner_model(feed, labeled)
+    if model is None:
+        return None
+    model.fit(labeled)
+
+    # score the article and its substitutes as-of now (not vote time)
+    target = replace(target, label_date=None)
+    baseline = float(model.predict([target])[0][0])
+
+    rng = random.Random(seed)
+    contributions: List[FieldContribution] = []
+    for field, label, attr in _FIELDS:
+        population = [getattr(f, attr) for f in features]
+        variations = [
+            replace(target, **{attr: rng.choice(population)}) for _ in range(samples)
+        ]
+        substitute_scores, _ = model.predict(variations)
+        delta = baseline - float(np.mean(substitute_scores))
+        sign, level = _marks(delta)
+        contributions.append(
+            FieldContribution(
+                field=field, label=label, sign=sign, level=level, delta=delta
+            )
+        )
+
+    return ItemExplanation(
+        model_name=model.name, baseline_score=baseline, fields=contributions
+    )

--- a/src/api/route_models/ranking.py
+++ b/src/api/route_models/ranking.py
@@ -24,3 +24,20 @@ class RankingStatsResponse(BaseRouteModel):
     neutral_votes: int
     total_items: int
     predicted_items: int
+
+
+class FieldContributionResponse(BaseRouteModel):
+    field: str
+    label: str
+    # -1 drags the predicted score down, 0 no measurable effect, +1 pushes up
+    sign: int
+    # number of marks to show: 0, 1, or 2
+    level: int
+
+
+class ItemExplanationResponse(BaseRouteModel):
+    model_config = {"protected_namespaces": ()}
+
+    model_name: str
+    baseline_score: float
+    fields: List[FieldContributionResponse]

--- a/src/api/routers/feed.py
+++ b/src/api/routers/feed.py
@@ -8,9 +8,15 @@ from route_models.feed import FeedResponse
 from route_models.source import SourceRouteModel
 from route_models.item import ItemResponse
 from route_models.acknowledge import AcknowledgeResponse
-from route_models.ranking import ModelStatsResponse, RankingStatsResponse
+from route_models.ranking import (
+    FieldContributionResponse,
+    ItemExplanationResponse,
+    ModelStatsResponse,
+    RankingStatsResponse,
+)
 from routers.auth import authenticate
 from ranking.engine import label_counts, load_model_stats, rank_feed
+from ranking.explain import explain_item
 
 feed_router = APIRouter()
 
@@ -191,6 +197,35 @@ def rerank_feed(
         neutral_votes=counts["neutral"],
         total_items=counts["total_items"],
         predicted_items=counts["predicted_items"],
+    )
+
+
+@feed_router.get(
+    "/item_explanation",
+    summary="Explain why an item got its predicted score",
+    response_model=ItemExplanationResponse,
+)
+def get_item_explanation(
+    feed_name_hash: str,
+    item_url_hash: str,
+    user: User = Depends(authenticate),
+) -> ItemExplanationResponse:
+    feed = get_feed_by_name_hash(user.name_hash, feed_name_hash)
+    explanation = explain_item(feed, item_url_hash)
+    if explanation is None:
+        raise HTTPException(
+            status_code=409,
+            detail="Not enough votes yet to explain this recommendation.",
+        )
+    return ItemExplanationResponse(
+        model_name=explanation.model_name,
+        baseline_score=explanation.baseline_score,
+        fields=[
+            FieldContributionResponse(
+                field=f.field, label=f.label, sign=f.sign, level=f.level
+            )
+            for f in explanation.fields
+        ],
     )
 
 

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -457,6 +457,26 @@ function openLinkButton(url, cls = 'btn btn-ghost btn-xs btn-square text-base-co
   }, '↗');
 }
 
+// Bar-chart icon that opens the per-article "why recommended?" breakdown.
+function explainButton(item) {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '1.8');
+  svg.setAttribute('class', 'w-4 h-4');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('stroke-linecap', 'round');
+  path.setAttribute('stroke-linejoin', 'round');
+  path.setAttribute('d', 'M4 20V10M10 20V4M16 20v-7M20 20H3');
+  svg.appendChild(path);
+  return h('button', {
+    class: 'btn btn-ghost btn-xs btn-square text-base-content/60',
+    title: 'Why is this recommended?',
+    onclick: (e) => { e.stopPropagation(); openExplanationModal(item); },
+  }, svg);
+}
+
 // ---------- media ----------
 
 const isVideoFile = (url) => /\.(mp4|webm)(\?|$)/i.test(url || '');
@@ -624,6 +644,7 @@ function itemCard(item) {
     h('div', { class: 'px-4 pt-3 pb-2' },
       h('div', { class: 'flex items-start gap-2' },
         h('h3', { class: 'font-semibold leading-snug flex-1 min-w-0' }, item.item_title || 'Untitled'),
+        explainButton(item),
         openLinkButton(item.item_url)),
       !mediaBlock && excerpt && h('p', { class: 'text-xs text-base-content/50 line-clamp-2 mt-1' }, excerpt)),
     mediaBlock,
@@ -636,6 +657,43 @@ function itemCard(item) {
         item.item_author && h('span', { class: 'truncate max-w-32' }, item.item_author),
         published && h('span', { class: 'whitespace-nowrap' }, published),
         predictedBadge)));
+}
+
+// ---------- why recommended ----------
+
+// A field's contribution rendered as up to two green "+" or red "−" marks,
+// or a muted dash when it had no measurable effect on the prediction.
+function contributionMarks(sign, level) {
+  if (!level || !sign) return h('span', { class: 'text-base-content/30' }, '·');
+  const symbol = sign > 0 ? '+' : '−';
+  const cls = sign > 0 ? 'text-success' : 'text-error';
+  return h('span', { class: `font-bold ${cls}` }, symbol.repeat(level));
+}
+
+function renderExplanation(data) {
+  const rows = data.fields.map((f) =>
+    h('div', { class: 'flex items-center justify-between py-1.5 border-b border-base-300 last:border-b-0' },
+      h('span', { class: 'text-sm' }, f.label),
+      h('span', { class: 'text-lg leading-none tracking-widest' }, contributionMarks(f.sign, f.level))));
+
+  const pct = Math.round(data.baseline_score * 100);
+  render($('explainBody'),
+    h('div', { class: 'flex flex-col' }, rows),
+    h('p', { class: 'text-xs text-base-content/50 mt-4' },
+      `Predicted match ${pct > 0 ? '+' : ''}${pct}% · model: ${MODEL_LABELS[data.model_name] || data.model_name}`));
+}
+
+async function openExplanationModal(item) {
+  showModal('explainModal');
+  render($('explainBody'), spinner());
+  try {
+    renderExplanation(await sdk.feedItemExplanation({
+      feed_name_hash: currentFeed.feed_name_hash,
+      item_url_hash: item.item_hash,
+    }));
+  } catch (err) {
+    render($('explainBody'), h('p', { class: 'text-sm text-base-content/60' }, err.message));
+  }
 }
 
 // Animate a voted card shrinking away, then drop it from the DOM.

--- a/src/api/static/js/sdk.js
+++ b/src/api/static/js/sdk.js
@@ -85,6 +85,11 @@ class AggySDK {
     return this._request("GET", "/feed/get", { query: { feed_name_hash } });
   }
 
+  /** Explain why an item got its predicted score */
+  async feedItemExplanation({ feed_name_hash, item_url_hash }) {
+    return this._request("GET", "/feed/item_explanation", { query: { feed_name_hash, item_url_hash } });
+  }
+
   /** List all items in a feed */
   async feedItems({ feed_name_hash, skip, limit, sort, include_read, sources, text_only }) {
     return this._request("GET", "/feed/items", { query: { feed_name_hash, skip, limit, sort, include_read, sources, text_only } });

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -153,6 +153,21 @@
   <form method="dialog" class="modal-backdrop"><button>close</button></form>
 </dialog>
 
+<!-- Why Recommended Modal -->
+<dialog class="modal" id="explainModal">
+  <div class="modal-box max-w-md">
+    <form method="dialog"><button class="btn btn-sm btn-circle btn-ghost absolute right-4 top-4">✕</button></form>
+    <h3 class="text-lg font-bold mb-1">Why this article?</h3>
+    <p class="text-xs text-base-content/60 mb-4">
+      Each field is scored by how much it pushes this recommendation up
+      (<span class="text-success font-bold">+</span>) or down
+      (<span class="text-error font-bold">−</span>), compared to average content.
+    </p>
+    <div id="explainBody"></div>
+  </div>
+  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
+
 <!-- Create Feed Modal -->
 <dialog class="modal" id="createFeedModal">
   <div class="modal-box">

--- a/src/api/tests/routers/ranking_test.py
+++ b/src/api/tests/routers/ranking_test.py
@@ -185,6 +185,58 @@ def test_rerank_and_stats(
             assert entry["item_predicted_score"] * unvoted[entry["item_url"]] > 0
 
 
+def test_item_explanation(
+    client, existing_user, existing_feed, existing_source, unique_item_strict, token
+):
+    items = _make_items(existing_feed, existing_source, unique_item_strict)
+    # even items up, odd down — the embedding cluster fully separates the vote
+    for i, item in enumerate(items[:4]):
+        ItemState.set_state(
+            user_hash=existing_user.name_hash,
+            feed_hash=existing_feed.name_hash,
+            item_url_hash=item.url_hash,
+            score=1 if i % 2 == 0 else -1,
+            is_read=True,
+        )
+
+    args = build_api_request_args(
+        path="/feed/item_explanation",
+        params={
+            "feed_name_hash": existing_feed.name_hash,
+            "item_url_hash": items[4].url_hash,  # unvoted, even (liked) cluster
+        },
+        token=token,
+    )
+    response = client.get(**args)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["model_name"]
+    fields = {f["field"]: f for f in body["fields"]}
+    assert {"content", "source", "author", "recency", "image", "media"} <= set(fields)
+    # every field reports a valid mark count and direction
+    for f in body["fields"]:
+        assert f["level"] in (0, 1, 2)
+        assert f["sign"] in (-1, 0, 1)
+        assert (f["level"] == 0) == (f["sign"] == 0)
+    # content (the embedding) drives this recommendation and pushes it up
+    assert fields["content"]["level"] >= 1
+    assert fields["content"]["sign"] == 1
+
+
+def test_item_explanation_needs_votes(
+    client, existing_user, existing_feed, existing_source, existing_item_strict, token
+):
+    args = build_api_request_args(
+        path="/feed/item_explanation",
+        params={
+            "feed_name_hash": existing_feed.name_hash,
+            "item_url_hash": existing_item_strict.url_hash,
+        },
+        token=token,
+    )
+    assert client.get(**args).status_code == 409
+
+
 def test_ranking_stats_empty_feed(client, existing_user, existing_feed, token):
     args = build_api_request_args(
         path="/feed/ranking_stats",


### PR DESCRIPTION
## What & why

Adds a stats icon next to each article's "open original" button that answers **"why is this being recommended to me?"** — one of the roadmap items in the README (*Recommendation transparency*).

## How it works

Clicking the icon opens a **"Why this article?"** modal. On demand (never pre-computed, since it's looked at rarely), the backend:

1. Retrains the feed's currently-winning prediction model on the user's votes.
2. Runs a **per-instance permutation importance** probe: it holds the article fixed and, one field at a time, swaps that field for many random values drawn from the rest of the feed, then measures how far the predicted score moves.
3. Converts each field's effect into **0, 1, or 2 marks** — green `+` when the field's real value pushes the recommendation *up* vs. average content, red `−` when it drags it *down*.

Only the field *name* is shown (never its contents): **Content** (the text embedding, which covers title + body), **Source**, **Author**, **Recency**, **Image**, **Media**.

## Changes

- **`ranking/explain.py`** — new `explain_item()` implementing the perturbation probe; reuses the persisted winning model so the explanation matches the score the user sees.
- **`routers/feed.py`** — new `GET /feed/item_explanation`; returns `409` until the feed has enough votes to rank.
- **`route_models/ranking.py`** — `ItemExplanationResponse` / `FieldContributionResponse`.
- **`static/js/app.js` + `templates/app.html`** — bar-chart icon on each card, plus the explanation modal that renders the marks.
- **`static/js/sdk.js`** — regenerated client method `feedItemExplanation`.
- **`tests/routers/ranking_test.py`** — covers the field breakdown and the too-few-votes `409`.

## Notes

- Thresholds: `|Δ score|` of `0.04` → 1 mark, `0.12` → 2 marks (predicted scores live in `[-1, 1]`).
- Models that ignore a feature (e.g. the source-average model) naturally report 0 marks for the fields they don't use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GXsVH2oC5yo5c2sH2dsnV

---
_Generated by [Claude Code](https://claude.ai/code/session_013GXsVH2oC5yo5c2sH2dsnV)_