### PR TITLE
Throttle reddit requests and lock subreddit sources to top-today

### DIFF
--- a/src/api/builtin_templates.py
+++ b/src/api/builtin_templates.py
@@ -3,26 +3,18 @@ import logging
 from db.source_template import SourceTemplate, SourceTemplateParameter
 
 
-def _reddit_sort_param() -> SourceTemplateParameter:
-    return SourceTemplateParameter(
-        name="Sort",
-        title="Sort order",
-        required=False,
-        type="select",
-        default="hot",
-        options={"hot": "Hot", "new": "New", "top": "Top", "rising": "Rising"},
-    )
-
-
 BUILTIN_TEMPLATES = [
     SourceTemplate(
         name="Reddit Subreddit",
         url="https://www.reddit.com",
-        url_template="https://www.reddit.com/r/{subreddit}/{sort}.rss",
+        # Locked to "top today": reddit rate-limits hard, so we check each
+        # subreddit only ~twice a day and pull the day's top posts, which
+        # captures nearly everything worth surfacing without other sorts.
+        url_template="https://www.reddit.com/r/{subreddit}/top.rss?t=day",
         description=(
-            "Posts from a subreddit via Reddit's native RSS feed. "
-            "Fetches reddit.com directly, without rss-bridge, which avoids "
-            "the API rate limits that block RedditBridge."
+            "The day's top posts from a subreddit via Reddit's native RSS "
+            "feed. Fetches reddit.com directly, without rss-bridge, which "
+            "avoids the API rate limits that block RedditBridge."
         ),
         parameters={
             "subreddit": SourceTemplateParameter(
@@ -32,7 +24,6 @@ BUILTIN_TEMPLATES = [
                 type="text",
                 example="selfhosted",
             ),
-            "sort": _reddit_sort_param(),
         },
     ),
     SourceTemplate(

--- a/src/api/config.py
+++ b/src/api/config.py
@@ -25,6 +25,12 @@ KNOWN_CONFIG_VALUES = [
     "JWT_EXPIRATION_DAYS",
     "SIGNUP_ENABLED",
     "RANKING_INTERVAL_MINUTES",
+    # Reddit is rate-limited far more aggressively than most feeds, so it gets
+    # its own (slower) default check frequency and a global adaptive throttle.
+    "REDDIT_SOURCE_READ_INTERVAL_MINUTES",
+    "REDDIT_MIN_REQUEST_INTERVAL_SECONDS",
+    "REDDIT_MAX_REQUEST_INTERVAL_SECONDS",
+    "REDDIT_INITIAL_REQUEST_INTERVAL_SECONDS",
 ]
 
 DEFAULT_CONFIG = {
@@ -46,6 +52,17 @@ DEFAULT_CONFIG = {
     "JWT_EXPIRATION_DAYS": 7,
     "SIGNUP_ENABLED": True,
     "RANKING_INTERVAL_MINUTES": 15,
+    # Reddit forces subreddit sources to "top today", which is fully covered by
+    # checking roughly twice a day (12h); this keeps us well under Reddit's
+    # anonymous request limits.
+    "REDDIT_SOURCE_READ_INTERVAL_MINUTES": 720,
+    # Adaptive global throttle for all reddit.com requests. The delay between
+    # requests floats between the min (fastest we'll ever go) and max (deep
+    # backoff), starting at the initial value; it shrinks cautiously on success
+    # and grows exponentially on HTTP 429. Values are seconds.
+    "REDDIT_MIN_REQUEST_INTERVAL_SECONDS": 2.0,
+    "REDDIT_MAX_REQUEST_INTERVAL_SECONDS": 900.0,
+    "REDDIT_INITIAL_REQUEST_INTERVAL_SECONDS": 5.0,
 }
 
 FALSEY_STRINGS = {"", "0", "false", "no", "off"}
@@ -98,6 +115,10 @@ class Config:
     def get_int(self, key, default=_UNSET):
         # env values always come back as strings; coerce for numeric config
         return int(self.get(key, default=default))
+
+    def get_float(self, key, default=_UNSET):
+        # env values always come back as strings; coerce for numeric config
+        return float(self.get(key, default=default))
 
     def get_bool(self, key, default=_UNSET):
         value = self.get(key, default=default)

--- a/src/api/constants.py
+++ b/src/api/constants.py
@@ -3,3 +3,10 @@ from config import config
 # Server-wide default for how often sources are checked; individual sources
 # can override it via sources.ingest_interval_minutes.
 SOURCE_READ_INTERVAL_MINUTES = config.get_int("SOURCE_READ_INTERVAL_MINUTES")
+
+# Reddit sources get a slower default cadence: reddit rate-limits anonymous
+# requests hard, and subreddit sources are locked to "top today", which a
+# roughly twice-daily check covers almost completely.
+REDDIT_SOURCE_READ_INTERVAL_MINUTES = config.get_int(
+    "REDDIT_SOURCE_READ_INTERVAL_MINUTES"
+)

--- a/src/api/db/migrations/V9__reddit_top_today.sql
+++ b/src/api/db/migrations/V9__reddit_top_today.sql
@@ -1,0 +1,26 @@
+-- Reddit subreddit sources are now locked to "top today": reddit rate-limits
+-- anonymous requests hard, and the day's top posts capture nearly everything
+-- worth surfacing. Rewrite any existing subreddit RSS URL -- whatever sort it
+-- used (hot/new/top/rising/controversial, or none) -- to the top-of-day feed,
+-- and drop the now-unsupported "sort" template parameter.
+UPDATE sources
+SET url = regexp_replace(
+        url,
+        '^(https?://(?:www\.|old\.|new\.|np\.)?reddit\.com/r/[^/?#]+)(?:/(?:hot|new|top|rising|controversial))?/?\.rss.*$',
+        '\1/top.rss?t=day'
+    ),
+    next_ingest_at = NOW()
+WHERE url ~* '^https?://(?:www\.|old\.|new\.|np\.)?reddit\.com/r/[^/?#]+(?:/(?:hot|new|top|rising|controversial))?/?\.rss';
+
+UPDATE sources
+SET template_parameters = template_parameters - 'sort'
+WHERE template_parameters ? 'sort'
+  AND url ~* '^https?://(?:www\.|old\.|new\.|np\.)?reddit\.com/';
+
+-- Give existing reddit sources (subreddit and user feeds) the slower reddit
+-- cadence unless the user already set an explicit per-source interval. 720
+-- minutes (~twice a day) is REDDIT_SOURCE_READ_INTERVAL_MINUTES's default.
+UPDATE sources
+SET ingest_interval_minutes = 720
+WHERE ingest_interval_minutes IS NULL
+  AND url ~* '^https?://(?:www\.|old\.|new\.|np\.)?reddit\.com/';

--- a/src/api/db/source.py
+++ b/src/api/db/source.py
@@ -5,7 +5,11 @@ from typing import Dict, Optional
 from pydantic import StringConstraints, HttpUrl
 from typing_extensions import Annotated
 
-from constants import SOURCE_READ_INTERVAL_MINUTES
+from constants import (
+    REDDIT_SOURCE_READ_INTERVAL_MINUTES,
+    SOURCE_READ_INTERVAL_MINUTES,
+)
+from ingest.reddit_rate_limit import is_reddit_url
 from .item_collection import ItemCollection
 
 # Sentinel for update(): distinguishes "leave unchanged" from an explicit
@@ -90,6 +94,11 @@ class Source(ItemCollection):
 
         if self.color is None:
             self.color = random.choice(SOURCE_COLORS)
+
+        # Reddit sources default to the slower reddit cadence unless the caller
+        # picked an explicit interval; a user can still override it afterwards.
+        if self.ingest_interval_minutes is None and is_reddit_url(self.url):
+            self.ingest_interval_minutes = REDDIT_SOURCE_READ_INTERVAL_MINUTES
 
         with self.db_con() as cur:
             cur.execute(

--- a/src/api/ingest/item/reddit.py
+++ b/src/api/ingest/item/reddit.py
@@ -10,10 +10,9 @@ import logging
 import re
 from typing import List, Optional
 
-import requests
-
 from config import config
 from db.item import ItemLoose
+from ingest.reddit_rate_limit import reddit_get
 
 # A reddit post's comments page, which is what reddit RSS uses as the entry
 # link, e.g. https://www.reddit.com/r/pics/comments/abc123/title/
@@ -145,8 +144,10 @@ def ingest_reddit_item(item: ItemLoose) -> Optional[ItemLoose]:
         )
     }
     try:
-        # raw_json=1 stops reddit from HTML-escaping the media URLs
-        response = requests.get(
+        # raw_json=1 stops reddit from HTML-escaping the media URLs. Routed
+        # through the shared adaptive throttle so per-post media fetches share
+        # reddit's rate budget with the feed fetches.
+        response = reddit_get(
             url.rstrip("/") + ".json",
             params={"raw_json": 1},
             timeout=15,

--- a/src/api/ingest/reddit_rate_limit.py
+++ b/src/api/ingest/reddit_rate_limit.py
@@ -1,0 +1,157 @@
+"""A process-global, adaptive throttle for all requests to reddit.com.
+
+Reddit rate-limits anonymous requests aggressively and answers with HTTP 429
+when we push too hard. Every reddit request Aggy makes -- fetching a
+subreddit/user RSS feed and fetching each post's JSON for media -- goes through
+a single shared limiter so the whole process stays under one budget rather than
+each ingest job hammering reddit independently.
+
+The limiter spaces requests by a delay that adapts using AIMD (additive
+increase, multiplicative decrease) in *rate* space:
+
+* on success the request rate creeps up by a small fixed step, so throughput
+  very cautiously climbs back toward reddit's real limit;
+* on HTTP 429 the rate is halved (the delay doubles) for an exponential
+  backoff, honoring any ``Retry-After`` the server sends.
+
+Over time this converges to just under whatever reddit is currently allowing.
+"""
+
+import logging
+import threading
+import time
+from typing import Optional
+from urllib.parse import urlparse
+
+import requests
+
+from config import config
+
+# Rate is halved on each 429 (delay doubles): a sharp exponential backoff.
+_BACKOFF_FACTOR = 2.0
+# Rate gained per successful request, in requests/second. Deliberately tiny so
+# recovery is slow and we don't immediately walk back into a 429.
+_RECOVERY_RATE_STEP = 0.01
+
+
+def is_reddit_url(url: Optional[str]) -> bool:
+    """True if ``url`` points at reddit.com (any subdomain)."""
+    if not url:
+        return False
+    try:
+        host = (urlparse(str(url)).hostname or "").lower()
+    except ValueError:
+        return False
+    return host == "reddit.com" or host.endswith(".reddit.com")
+
+
+def _parse_retry_after(response: requests.Response) -> Optional[float]:
+    value = response.headers.get("Retry-After")
+    if not value:
+        return None
+    try:
+        # reddit sends Retry-After as an integer number of seconds
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+class RedditRateLimiter:
+    """Thread-safe adaptive delay gate shared across all reddit requests."""
+
+    def __init__(
+        self,
+        min_interval: float,
+        max_interval: float,
+        initial_interval: float,
+    ):
+        self._min = max(0.0, float(min_interval))
+        self._max = max(self._min, float(max_interval))
+        self._interval = min(self._max, max(self._min, float(initial_interval)))
+        self._lock = threading.Lock()
+        # monotonic timestamp before which the next request must not fire
+        self._next_allowed = 0.0
+
+    @property
+    def interval(self) -> float:
+        with self._lock:
+            return self._interval
+
+    def acquire(self) -> None:
+        """Block until the next request is allowed, reserving its slot.
+
+        The slot is reserved under the lock (so concurrent callers queue up
+        behind one another spaced by the current delay) but the actual sleep
+        happens outside the lock so waiting threads don't serialize the CPU.
+        """
+        with self._lock:
+            start = max(time.monotonic(), self._next_allowed)
+            self._next_allowed = start + self._interval
+        wait = start - time.monotonic()
+        if wait > 0:
+            time.sleep(wait)
+
+    def record_success(self) -> None:
+        """Cautiously speed up: nudge the request rate up by a fixed step."""
+        with self._lock:
+            rate = 1.0 / self._interval if self._interval > 0 else float("inf")
+            rate += _RECOVERY_RATE_STEP
+            new_interval = 1.0 / rate if rate > 0 else self._max
+            self._interval = min(self._max, max(self._min, new_interval))
+
+    def record_rate_limited(self, retry_after: Optional[float] = None) -> None:
+        """Back off hard: double the delay and respect any Retry-After."""
+        with self._lock:
+            self._interval = min(self._max, self._interval * _BACKOFF_FACTOR)
+            penalty = self._interval
+            if retry_after is not None:
+                penalty = max(penalty, retry_after)
+            self._next_allowed = max(
+                self._next_allowed, time.monotonic() + penalty
+            )
+            logging.warning(
+                "Reddit rate limited (HTTP 429); backing off to "
+                f"{self._interval:.1f}s between requests"
+                + (f", retry after {retry_after:.0f}s" if retry_after else "")
+            )
+
+
+_limiter: Optional[RedditRateLimiter] = None
+_limiter_lock = threading.Lock()
+
+
+def get_limiter() -> RedditRateLimiter:
+    global _limiter
+    if _limiter is None:
+        with _limiter_lock:
+            if _limiter is None:
+                _limiter = RedditRateLimiter(
+                    min_interval=config.get_float(
+                        "REDDIT_MIN_REQUEST_INTERVAL_SECONDS"
+                    ),
+                    max_interval=config.get_float(
+                        "REDDIT_MAX_REQUEST_INTERVAL_SECONDS"
+                    ),
+                    initial_interval=config.get_float(
+                        "REDDIT_INITIAL_REQUEST_INTERVAL_SECONDS"
+                    ),
+                )
+    return _limiter
+
+
+def reddit_get(url: str, **kwargs) -> requests.Response:
+    """``requests.get`` for a reddit URL, gated by the global adaptive throttle.
+
+    Waits for the shared limiter before firing, then feeds the response back
+    into it so a 429 backs the whole process off and a success lets it creep
+    faster. The response (including a 429) is returned to the caller unchanged;
+    network errors propagate as usual and leave the throttle untouched.
+    """
+    limiter = get_limiter()
+    limiter.acquire()
+    response = requests.get(url, **kwargs)
+    if response.status_code == 429:
+        limiter.record_rate_limited(_parse_retry_after(response))
+    elif response.ok:
+        limiter.record_success()
+    return response

--- a/src/api/ingest/source.py
+++ b/src/api/ingest/source.py
@@ -7,6 +7,7 @@ from db.source import Source
 from db.feed import Feed
 from ingest.item.rss import ingest_rss_item
 from ingest.item.reddit import ingest_reddit_item, is_reddit_post
+from ingest.reddit_rate_limit import is_reddit_url, reddit_get
 from ingest.item.open_graph import ingest_open_graph_item
 from ingest.item.mercury import ingest_mercury_item
 
@@ -23,8 +24,11 @@ def ingest_source(source: Source) -> None:
             "(self-hosted feed aggregator; +https://github.com/mullinmax/aggy)"
         )
     }
+    # reddit.com requests share a global adaptive throttle so all ingest jobs
+    # stay under one budget and back off together on 429s.
+    fetch = reddit_get if is_reddit_url(source.url) else requests.get
     try:
-        response = requests.get(str(source.url), timeout=60, headers=headers)
+        response = fetch(str(source.url), timeout=60, headers=headers)
     except requests.RequestException as e:
         raise Exception(f"Could not fetch feed: {e}") from e
 

--- a/src/api/tests/db/source_test.py
+++ b/src/api/tests/db/source_test.py
@@ -79,6 +79,35 @@ def test_source_update_ingest_interval(unique_source):
     assert read_back().ingest_interval_minutes is None
 
 
+def test_reddit_source_defaults_to_reddit_interval(unique_source):
+    from constants import REDDIT_SOURCE_READ_INTERVAL_MINUTES
+
+    unique_source.url = "https://www.reddit.com/r/pics/top.rss?t=day"
+    unique_source.create()
+
+    read_source = Source.read(
+        user_hash=unique_source.user_hash,
+        feed_hash=unique_source.feed_hash,
+        source_hash=unique_source.name_hash,
+    )
+    assert (
+        read_source.ingest_interval_minutes == REDDIT_SOURCE_READ_INTERVAL_MINUTES
+    )
+
+
+def test_reddit_source_keeps_explicit_interval(unique_source):
+    unique_source.url = "https://www.reddit.com/r/pics/top.rss?t=day"
+    unique_source.ingest_interval_minutes = 30
+    unique_source.create()
+
+    read_source = Source.read(
+        user_hash=unique_source.user_hash,
+        feed_hash=unique_source.feed_hash,
+        source_hash=unique_source.name_hash,
+    )
+    assert read_source.ingest_interval_minutes == 30
+
+
 def test_source_add_items(unique_source, unique_item_strict):
     unique_source.create()
     unique_item_strict.create()

--- a/src/api/tests/ingest/reddit_rate_limit_test.py
+++ b/src/api/tests/ingest/reddit_rate_limit_test.py
@@ -1,0 +1,125 @@
+from ingest.reddit_rate_limit import (
+    RedditRateLimiter,
+    _parse_retry_after,
+    is_reddit_url,
+    reddit_get,
+)
+
+
+def test_is_reddit_url():
+    assert is_reddit_url("https://www.reddit.com/r/pics/top.rss?t=day")
+    assert is_reddit_url("https://old.reddit.com/user/spez/.rss")
+    assert is_reddit_url("https://reddit.com/r/pics.json")
+    assert not is_reddit_url("https://example.com/reddit.com/r/pics")
+    assert not is_reddit_url("https://notreddit.com/r/pics")
+    assert not is_reddit_url("https://reddit.com.evil.example/r/pics")
+    assert not is_reddit_url(None)
+
+
+def test_acquire_spaces_requests(monkeypatch):
+    limiter = RedditRateLimiter(min_interval=1, max_interval=10, initial_interval=3)
+
+    clock = {"t": 100.0}
+    sleeps = []
+    monkeypatch.setattr("ingest.reddit_rate_limit.time.monotonic", lambda: clock["t"])
+
+    def fake_sleep(seconds):
+        sleeps.append(seconds)
+        clock["t"] += seconds
+
+    monkeypatch.setattr("ingest.reddit_rate_limit.time.sleep", fake_sleep)
+
+    # first call fires immediately (next_allowed starts at 0)
+    limiter.acquire()
+    assert sleeps == []
+    # the next call must wait a full interval behind the first
+    limiter.acquire()
+    assert sleeps == [3]
+
+
+def test_record_rate_limited_backs_off_exponentially():
+    limiter = RedditRateLimiter(min_interval=1, max_interval=100, initial_interval=4)
+    limiter.record_rate_limited()
+    assert limiter.interval == 8
+    limiter.record_rate_limited()
+    assert limiter.interval == 16
+
+
+def test_record_rate_limited_respects_ceiling():
+    limiter = RedditRateLimiter(min_interval=1, max_interval=10, initial_interval=8)
+    limiter.record_rate_limited()
+    assert limiter.interval == 10
+
+
+def test_record_rate_limited_honors_retry_after(monkeypatch):
+    limiter = RedditRateLimiter(min_interval=1, max_interval=1000, initial_interval=4)
+    monkeypatch.setattr("ingest.reddit_rate_limit.time.monotonic", lambda: 0.0)
+    limiter.record_rate_limited(retry_after=120)
+    # the next request must be pushed out by the retry-after, not just the delay
+    assert limiter._next_allowed == 120
+
+
+def test_record_success_recovers_cautiously():
+    # a big initial delay means a low rate; success nudges the rate up a little,
+    # which only shaves a little off the delay (very cautious recovery)
+    limiter = RedditRateLimiter(min_interval=1, max_interval=100, initial_interval=10)
+    before = limiter.interval
+    limiter.record_success()
+    assert limiter.interval < before
+    # one success shouldn't come anywhere near collapsing to the floor
+    assert limiter.interval > 5
+
+
+def test_record_success_never_below_floor():
+    limiter = RedditRateLimiter(min_interval=2, max_interval=100, initial_interval=2)
+    for _ in range(1000):
+        limiter.record_success()
+    assert limiter.interval >= 2
+
+
+def test_parse_retry_after():
+    class R:
+        def __init__(self, headers):
+            self.headers = headers
+
+    assert _parse_retry_after(R({"Retry-After": "30"})) == 30
+    assert _parse_retry_after(R({})) is None
+    assert _parse_retry_after(R({"Retry-After": "not-a-number"})) is None
+
+
+def test_reddit_get_records_success(monkeypatch):
+    limiter = RedditRateLimiter(min_interval=1, max_interval=100, initial_interval=10)
+    monkeypatch.setattr("ingest.reddit_rate_limit.get_limiter", lambda: limiter)
+
+    class FakeResponse:
+        status_code = 200
+        ok = True
+
+    monkeypatch.setattr(
+        "ingest.reddit_rate_limit.requests.get", lambda url, **kw: FakeResponse()
+    )
+    monkeypatch.setattr("ingest.reddit_rate_limit.time.sleep", lambda s: None)
+
+    before = limiter.interval
+    reddit_get("https://www.reddit.com/r/pics/top.rss")
+    assert limiter.interval < before
+
+
+def test_reddit_get_records_rate_limit(monkeypatch):
+    limiter = RedditRateLimiter(min_interval=1, max_interval=100, initial_interval=4)
+    monkeypatch.setattr("ingest.reddit_rate_limit.get_limiter", lambda: limiter)
+
+    class FakeResponse:
+        status_code = 429
+        ok = False
+        headers = {"Retry-After": "50"}
+
+    monkeypatch.setattr(
+        "ingest.reddit_rate_limit.requests.get", lambda url, **kw: FakeResponse()
+    )
+    monkeypatch.setattr("ingest.reddit_rate_limit.time.sleep", lambda s: None)
+
+    response = reddit_get("https://www.reddit.com/r/pics/top.rss")
+    assert response.status_code == 429
+    # 429 backs the whole limiter off
+    assert limiter.interval == 8

--- a/src/api/tests/ingest/reddit_test.py
+++ b/src/api/tests/ingest/reddit_test.py
@@ -192,7 +192,7 @@ def test_ingest_reddit_item_fetches_post_json(monkeypatch):
         captured["url"] = url
         return FakeResponse()
 
-    monkeypatch.setattr("ingest.item.reddit.requests.get", fake_get)
+    monkeypatch.setattr("ingest.item.reddit.reddit_get", fake_get)
 
     item = ItemLoose(url="https://www.reddit.com/r/pics/comments/abc123/a_gif_post/")
     result = ingest_reddit_item(item)


### PR DESCRIPTION
## Why

Reddit rate-limits anonymous requests aggressively and we've been getting a lot of HTTP 429s. This PR cuts our request load and makes the client adapt to reddit's actual limit.

## Changes

**Global adaptive reddit throttle** — `src/api/ingest/reddit_rate_limit.py`
- A process-global, thread-safe limiter that **every** reddit.com request now flows through: both the feed fetch in `ingest_source` and the per-post media JSON fetch in `ingest_reddit_item`.
- Requests are spaced by a delay that adapts with AIMD in rate space:
  - **HTTP 429 → exponential backoff**: the delay doubles (honoring `Retry-After`), so the whole process backs off together.
  - **success → cautious speed-up**: the request rate creeps up by a tiny fixed step, so throughput slowly climbs back toward reddit's real limit and roughly tracks it.
- Tunable via `REDDIT_MIN_/MAX_/INITIAL_REQUEST_INTERVAL_SECONDS` (defaults 2s / 900s / 5s).

**Slower default cadence for reddit sources**
- New `REDDIT_SOURCE_READ_INTERVAL_MINUTES` (default 720 ≈ twice a day) replaces the 30-min global default for reddit sources. Applied at source creation (`Source.create`) and backfilled for existing reddit sources in the migration. Users can still override per-source.

**Lock subreddit sources to "top today"**
- The `Reddit Subreddit` builtin template drops its `sort` parameter and always fetches `/top.rss?t=day`. Users can no longer pick hot/new/rising. A ~12h check captures nearly all of the day's top posts.
- Migration `V9__reddit_top_today.sql` rewrites existing subreddit URLs (any prior sort) to top-today, drops the stored `sort` template parameter, and sets the reddit cadence on existing reddit sources that had no explicit interval.

## Tests
- New `tests/ingest/reddit_rate_limit_test.py`: `is_reddit_url`, request spacing, exponential backoff, `Retry-After`, cautious recovery, floor/ceiling clamping, and `reddit_get` success/429 accounting.
- New `db/source_test.py` cases: reddit sources default to the reddit interval; an explicit interval is preserved.
- Updated `reddit_test.py` to patch `reddit_get`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkMJ2H2YVLm4VDZFix9kQm

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkMJ2H2YVLm4VDZFix9kQm)_