### PR TITLE
Use open-in-new-tab icon for source link button

### DIFF
--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -448,13 +448,31 @@ function sourceBadge(name, storedColor) {
   }, name);
 }
 
-// Square "open original" button with an arrow, shown next to titles.
+// "Open in new tab" icon (matches the modal close button's size/style),
+// shown next to titles to open the source's original link.
+function openInNewTabIcon() {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '1.8');
+  svg.setAttribute('class', 'w-4 h-4');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('stroke-linecap', 'round');
+  path.setAttribute('stroke-linejoin', 'round');
+  path.setAttribute('d', 'M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 '
+    + '005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25');
+  svg.appendChild(path);
+  return svg;
+}
+
+// "Open original" button, shown next to titles.
 function openLinkButton(url, cls = 'btn btn-ghost btn-xs btn-square text-base-content/60') {
   if (!url) return null;
   return h('a', {
     class: cls, href: url, target: '_blank', rel: 'noopener', title: 'Open original',
     onclick: (e) => e.stopPropagation(),
-  }, '↗');
+  }, openInNewTabIcon());
 }
 
 // Bar-chart icon that opens the per-article "why recommended?" breakdown.
@@ -643,7 +661,7 @@ function itemCard(item) {
   },
     h('div', { class: 'px-4 pt-3 pb-2' },
       h('div', { class: 'flex items-start gap-2' },
-        h('h3', { class: 'font-semibold leading-snug flex-1 min-w-0' }, item.item_title || 'Untitled'),
+        h('h3', { class: 'font-semibold leading-snug flex-1 min-w-0 line-clamp-2' }, item.item_title || 'Untitled'),
         explainButton(item),
         openLinkButton(item.item_url)),
       !mediaBlock && excerpt && h('p', { class: 'text-xs text-base-content/50 line-clamp-2 mt-1' }, excerpt)),

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -125,8 +125,12 @@
   <div class="modal-box max-w-3xl max-h-[90vh]">
     <form method="dialog"><button class="btn btn-sm btn-circle btn-ghost absolute right-4 top-4">✕</button></form>
     <div class="flex items-start gap-2 pr-8 mb-4">
-      <h2 class="text-xl font-bold flex-1 min-w-0" id="readerTitle"></h2>
-      <a class="btn btn-ghost btn-sm btn-square text-base-content/60" id="readerOpenLink" target="_blank" rel="noopener" title="Open original">↗</a>
+      <h2 class="text-xl font-bold flex-1 min-w-0 line-clamp-2" id="readerTitle"></h2>
+      <a class="btn btn-ghost btn-sm btn-circle text-base-content/60" id="readerOpenLink" target="_blank" rel="noopener" title="Open original">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="w-4 h-4">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"/>
+        </svg>
+      </a>
     </div>
     <div id="readerMedia" class="mb-4 empty:hidden"></div>
     <div class="prose prose-sm max-w-none" id="readerContent"></div>


### PR DESCRIPTION
## Summary

Updates the "open source's original link" button on articles to use the standard **open-in-new-tab** icon instead of the `↗` arrow glyph.

## Changes

- **Icon**: Replaced the `↗` character with the standard open-in-new-tab SVG icon (`w-4 h-4`), both in the feed card (`openLinkButton` in `app.js`) and the reader modal (`app.html`).
- **Size & style**: In the reader modal, the button now matches the close (X) button — `btn btn-sm btn-circle btn-ghost`. In the feed card it stays consistent with the neighboring "why recommended?" (explain) button.
- **Long titles**: Added `line-clamp-2` to the reader modal title and the feed card title so long titles wrap to two rows and then truncate with an ellipsis, instead of pushing into / overlapping the buttons.

## Testing

- `node --check` passes on `app.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSJY9R1VP8Kx53Ts72XyT5

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSJY9R1VP8Kx53Ts72XyT5)_