### PR TITLE
Add feed rename and scope the filter to the article list

### DIFF
--- a/src/api/db/feed.py
+++ b/src/api/db/feed.py
@@ -262,6 +262,23 @@ class Feed(ItemCollection):
 
         return self.key
 
+    def rename(self, new_name: str):
+        """Rename this feed in place.
+
+        The name_hash is derived from the name, so it changes too. The
+        sources, feed_items, item_states, and ranking_model_stats foreign
+        keys are ON UPDATE CASCADE, so every source, item, vote, and model
+        stat stays attached to the feed under its new hash.
+        """
+        new_name_hash = self.__insecure_hash__(new_name)
+        with self.db_con() as cur:
+            cur.execute(
+                "UPDATE feeds SET name = %s, name_hash = %s "
+                "WHERE user_hash = %s AND name_hash = %s",
+                (new_name, new_name_hash, self.user_hash, self.name_hash),
+            )
+        self.name = new_name
+
     def delete(self):
         # ON DELETE CASCADE removes sources, feed_items, source_items, and
         # item_states tied to this feed.

--- a/src/api/db/migrations/V10__feed_rename_cascade.sql
+++ b/src/api/db/migrations/V10__feed_rename_cascade.sql
@@ -1,0 +1,44 @@
+-- Renaming a feed changes its name_hash (the hash is derived from the name).
+-- Every table keyed on a feed references feeds(user_hash, name_hash) with
+-- ON DELETE CASCADE only; add ON UPDATE CASCADE so a rename carries the new
+-- key through to sources, feed items, item states, and model stats instead of
+-- being rejected by the foreign keys. (source_items already cascades updates
+-- from sources, so a change to sources.feed_hash reaches it in turn.)
+DO $$
+DECLARE r RECORD;
+BEGIN
+    FOR r IN
+        SELECT conrelid::regclass::text AS tbl, conname AS con
+        FROM pg_constraint
+        WHERE contype = 'f'
+          AND confrelid = 'feeds'::regclass
+          AND conrelid IN (
+              'sources'::regclass,
+              'feed_items'::regclass,
+              'item_states'::regclass,
+              'ranking_model_stats'::regclass
+          )
+    LOOP
+        EXECUTE format('ALTER TABLE %I DROP CONSTRAINT %I', r.tbl, r.con);
+    END LOOP;
+END $$;
+
+ALTER TABLE sources
+    ADD FOREIGN KEY (user_hash, feed_hash)
+        REFERENCES feeds(user_hash, name_hash)
+        ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE feed_items
+    ADD FOREIGN KEY (user_hash, feed_hash)
+        REFERENCES feeds(user_hash, name_hash)
+        ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE item_states
+    ADD FOREIGN KEY (user_hash, feed_hash)
+        REFERENCES feeds(user_hash, name_hash)
+        ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE ranking_model_stats
+    ADD FOREIGN KEY (user_hash, feed_hash)
+        REFERENCES feeds(user_hash, name_hash)
+        ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/api/routers/feed.py
+++ b/src/api/routers/feed.py
@@ -38,6 +38,29 @@ def create_feed(feed_name: str, user: User = Depends(authenticate)) -> FeedRespo
     return FeedResponse.from_db_model(feed)
 
 
+# rename feed
+@feed_router.post("/rename", summary="Rename a feed", response_model=FeedResponse)
+def rename_feed(
+    feed_name_hash: str, new_name: str, user: User = Depends(authenticate)
+) -> FeedResponse:
+    feed = get_feed_by_name_hash(user.name_hash, feed_name_hash)
+
+    new_name = new_name.strip()
+    if not new_name:
+        raise HTTPException(status_code=422, detail="Feed name cannot be empty")
+
+    if new_name != feed.name:
+        # renaming must not collide with another of the user's feeds
+        if Feed(user_hash=user.name_hash, name=new_name).exists():
+            raise HTTPException(
+                status_code=409,
+                detail=f'A feed named "{new_name}" already exists',
+            )
+        feed.rename(new_name)
+
+    return FeedResponse.from_db_model(feed)
+
+
 # delete feed
 @feed_router.delete(
     "/delete",

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -47,6 +47,8 @@ function bindControls() {
   $('createFeedForm').onsubmit = handleCreateFeed;
 
   $('deleteFeedBtn').onclick = confirmDeleteFeed;
+  $('renameFeedBtn').onclick = openRenameFeed;
+  $('renameFeedForm').onsubmit = handleRenameFeed;
   $('manageSourcesBtn').onclick = () => switchFeedTab('sources');
   $('filterBtn').onclick = toggleFilterPanel;
   $('statsBtn').onclick = openStatsModal;
@@ -185,6 +187,32 @@ function confirmDeleteFeed() {
   });
 }
 
+function openRenameFeed() {
+  if (!currentFeed) return;
+  $('renameFeedName').value = currentFeed.feed_name;
+  showModal('renameFeedModal');
+  $('renameFeedName').focus();
+}
+
+async function handleRenameFeed(e) {
+  e.preventDefault();
+  if (!currentFeed) return;
+  const name = $('renameFeedName').value.trim();
+  if (!name) return;
+  if (name === currentFeed.feed_name) { closeModal('renameFeedModal'); return; }
+  try {
+    const feed = await sdk.feedRename({ feed_name_hash: currentFeed.feed_name_hash, new_name: name });
+    closeModal('renameFeedModal');
+    toast(`Feed renamed to "${name}"`);
+    // the name_hash (and the feed's URL) changes on rename; drop the cached
+    // feed and navigate to the new hash
+    currentFeed = null;
+    router.go(`feed/${feed.feed_name_hash}`);
+  } catch (err) {
+    toast(err.message, 'alert-error');
+  }
+}
+
 // ---------- feed view ----------
 async function showFeed(hash) {
   setView('feed');
@@ -228,6 +256,10 @@ async function showFeed(hash) {
 function switchFeedTab(tab) {
   $('tabItems').classList.toggle('hidden', tab !== 'items');
   $('tabSources').classList.toggle('hidden', tab !== 'sources');
+  // The filter only applies to the article list; hide the button (and any
+  // open panel) on the sources/settings tab.
+  $('filterBtn').classList.toggle('hidden', tab !== 'items');
+  if (tab !== 'items') $('filterPanel').classList.add('hidden');
   if (tab === 'sources') loadSources();
 }
 

--- a/src/api/static/js/sdk.js
+++ b/src/api/static/js/sdk.js
@@ -105,6 +105,11 @@ class AggySDK {
     return this._request("GET", "/feed/ranking_stats", { query: { feed_name_hash } });
   }
 
+  /** Rename a feed */
+  async feedRename({ feed_name_hash, new_name }) {
+    return this._request("POST", "/feed/rename", { query: { feed_name_hash, new_name } });
+  }
+
   /** Re-evaluate prediction models and re-rank a feed now */
   async feedRerank({ feed_name_hash }) {
     return this._request("POST", "/feed/rerank", { query: { feed_name_hash } });

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -113,7 +113,8 @@
         <button class="btn btn-primary btn-sm" id="addSourceBtn">+ Add Source</button>
       </div>
       <div id="sourceList"></div>
-      <div class="mt-8 pt-4 border-t border-base-300 flex justify-end">
+      <div class="mt-8 pt-4 border-t border-base-300 flex justify-end gap-2">
+        <button class="btn btn-ghost btn-sm" id="renameFeedBtn">Rename Feed</button>
         <button class="btn btn-error btn-outline btn-sm" id="deleteFeedBtn">Delete Feed</button>
       </div>
     </div>
@@ -180,6 +181,24 @@
       <div class="modal-action">
         <button type="button" class="btn btn-ghost" data-close-modal>Cancel</button>
         <button type="submit" class="btn btn-primary">Create Feed</button>
+      </div>
+    </form>
+  </div>
+  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
+
+<!-- Rename Feed Modal -->
+<dialog class="modal" id="renameFeedModal">
+  <div class="modal-box">
+    <h3 class="text-lg font-bold mb-4">Rename Feed</h3>
+    <form id="renameFeedForm">
+      <div class="form-control mb-4">
+        <label class="label" for="renameFeedName"><span class="label-text">Feed Name</span></label>
+        <input type="text" class="input input-bordered w-full" id="renameFeedName" placeholder="e.g. Technology, Science, Sports..." required>
+      </div>
+      <div class="modal-action">
+        <button type="button" class="btn btn-ghost" data-close-modal>Cancel</button>
+        <button type="submit" class="btn btn-primary">Save</button>
       </div>
     </form>
   </div>

--- a/src/api/tests/db/feed_test.py
+++ b/src/api/tests/db/feed_test.py
@@ -360,6 +360,43 @@ def test_feed_stats(unique_feed, unique_item_strict):
     assert stats["feed_posts_per_day"] == 3.0  # 3 items on day one
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_rename_feed_keeps_attached_data(unique_feed, unique_item_strict):
+    """Renaming a feed changes its hash but carries sources, items, votes,
+    and model stats along via the ON UPDATE CASCADE foreign keys."""
+    from db.item_state import ItemState
+
+    unique_feed.create()
+    source = _make_source(unique_feed, "source-a")
+    item = _add_item(
+        unique_feed, source, unique_item_strict, "http://example.com/keep", 3
+    )
+    ItemState(
+        user_hash=unique_feed.user_hash,
+        feed_hash=unique_feed.name_hash,
+        item_url_hash=item.url_hash,
+        score=1,
+    ).create()
+
+    old_hash = unique_feed.name_hash
+    unique_feed.rename("renamed feed")
+    new_hash = unique_feed.name_hash
+
+    assert new_hash != old_hash
+    # the old hash no longer resolves; the new one does
+    assert Feed.read(user_hash=unique_feed.user_hash, name_hash=old_hash) is None
+    renamed = Feed.read(user_hash=unique_feed.user_hash, name_hash=new_hash)
+    assert renamed is not None
+    assert renamed.name == "renamed feed"
+
+    # source, item, and vote all followed the feed to its new hash
+    assert source.name_hash in renamed.source_hashes
+    results = renamed.query_items_with_sources()
+    assert [i.url_hash for i, _ in results] == [item.url_hash]
+    assert results[0][1]["source_name"] == "source-a"
+    assert results[0][1]["user_score"] == 1
+
+
 def test_source_color_assigned_and_editable(unique_feed):
     """Sources get a palette color at creation; updates can change it."""
     from db.source import SOURCE_COLORS, Source

--- a/src/api/tests/routers/feed_test.py
+++ b/src/api/tests/routers/feed_test.py
@@ -59,6 +59,77 @@ def test_delete_nonexistent_feed(client, existing_user, token):
     assert response.json() == {"detail": "Feed not found"}
 
 
+def test_rename_feed(client, existing_user, existing_feed, token):
+    from db.feed import Feed
+
+    renamed = Feed(user_hash=existing_user.name_hash, name="a brand new name")
+    args = build_api_request_args(
+        path="/feed/rename",
+        params={
+            "feed_name_hash": existing_feed.name_hash,
+            "new_name": renamed.name,
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "feed_name": renamed.name,
+        "feed_name_hash": renamed.name_hash,
+        "feed_item_count": None,
+        "feed_unread_count": None,
+        "feed_posts_per_day": None,
+    }
+    assert renamed.exists()
+    assert not existing_feed.exists()
+
+
+def test_rename_nonexistent_feed(client, existing_user, token):
+    args = build_api_request_args(
+        path="/feed/rename",
+        params={"feed_name_hash": "nonexistent", "new_name": "whatever"},
+        token=token,
+    )
+
+    response = client.post(**args)
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Feed not found"}
+
+
+def test_rename_feed_empty_name(client, existing_user, existing_feed, token):
+    args = build_api_request_args(
+        path="/feed/rename",
+        params={"feed_name_hash": existing_feed.name_hash, "new_name": "   "},
+        token=token,
+    )
+
+    response = client.post(**args)
+
+    assert response.status_code == 422
+
+
+def test_rename_feed_name_collision(client, existing_user, existing_feed, token):
+    from db.feed import Feed
+
+    other = Feed(user_hash=existing_user.name_hash, name="already taken")
+    other.create()
+
+    args = build_api_request_args(
+        path="/feed/rename",
+        params={"feed_name_hash": existing_feed.name_hash, "new_name": other.name},
+        token=token,
+    )
+
+    response = client.post(**args)
+
+    assert response.status_code == 409
+    # the original feed is untouched
+    assert existing_feed.exists()
+
+
 def test_get_feed(client, existing_user, existing_feed, token):
     args = build_api_request_args(
         path="/feed/get",


### PR DESCRIPTION
## Summary

Two changes to the feed view:

1. **Rename a feed from its settings** — the Manage Sources tab (which already holds the Delete Feed action) now has a **Rename Feed** button that opens a small modal pre-filled with the current name.
2. **Scope the filter/sort control to the article list** — the filter button (and any open filter panel) is now hidden on the sources/settings tab, since sorting and source filtering only apply to the list of articles.

## How rename works

A feed's `name_hash` is derived from its name, and that hash is the identity referenced by sources, feed items, item states, and model stats. Renaming therefore changes the hash. Migration **`V10__feed_rename_cascade.sql`** adds `ON UPDATE CASCADE` to the four foreign keys pointing at `feeds(user_hash, name_hash)` (`sources`, `feed_items`, `item_states`, `ranking_model_stats`) — mirroring the existing `V5` treatment of `source_items` — so a single update to `feeds.name_hash` carries every attached source, article, vote, and model stat to the new hash. `source_items` follows automatically via its own cascade from `sources`.

The rename endpoint (`POST /feed/rename`) validates a non-empty name and rejects collisions with another of the user's feeds (409). The frontend navigates to the feed's new hash after a successful rename.

## Changes

- `db/migrations/V10__feed_rename_cascade.sql` — new migration adding `ON UPDATE CASCADE`
- `db/feed.py` — `Feed.rename()`
- `routers/feed.py` — `POST /feed/rename`
- `static/js/sdk.js` — regenerated (`feedRename`)
- `templates/app.html` — Rename Feed button + modal
- `static/js/app.js` — rename handlers; hide the filter button off the article list
- Tests: DB test that a rename preserves attached sources/items/votes under the new hash; router tests for success, 404, empty-name (422), and collision (409)

## Testing

- Applied all migrations V1–V10 in order against Postgres 16 — V10 applies cleanly.
- `tests/db/feed_test.py` and `tests/routers/feed_test.py` pass, including the 5 new tests.
- SDK is up to date (`generate_sdk.py --check`).
- The full `tests/db` + `tests/routers` run shows no new failures versus the base branch (the 14 pre-existing failures are unrelated environment issues — a locally stubbed `feedparser` and datetime-tz comparisons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PikeaGP2BjKc4sLVT2qW7

---
_Generated by [Claude Code](https://claude.ai/code/session_013PikeaGP2BjKc4sLVT2qW7)_