### PR TITLE
Show a link preview card for reddit posts that link off-site

### DIFF
--- a/src/api/ingest/item/reddit.py
+++ b/src/api/ingest/item/reddit.py
@@ -9,6 +9,7 @@ items and turns it into the item's ``media`` list.
 import logging
 import re
 from typing import List, Optional
+from urllib.parse import urlparse
 
 from config import config
 from db.item import ItemLoose
@@ -73,6 +74,39 @@ def _gallery_media(post: dict) -> List[dict]:
             if url:
                 entries.append(_media_entry("image", url))
     return entries
+
+
+def _external_link_media(post: dict) -> List[dict]:
+    """A "link" media entry for reddit link posts pointing off-site.
+
+    Reddit link posts (``post_hint == "link"``) point at an external URL that
+    the RSS feed never surfaces on its own — the reader only ever sees the
+    reddit comments permalink, so the actual destination stays hidden unless
+    you open the post on reddit. Expose it as a ``link`` media entry so the UI
+    can render a preview card instead of dropping the destination entirely.
+
+    Self (text) posts and posts whose destination is reddit-hosted media or a
+    reddit permalink aren't external links to preview, so they're skipped;
+    embeddable media (images, gifs, videos, galleries) is handled by
+    ``_post_media`` and takes priority.
+    """
+    if post.get("is_self"):
+        return []
+
+    target = post.get("url_overridden_by_dest") or post.get("url")
+    if not target:
+        return []
+
+    host = urlparse(target).netloc.lower()
+    # reddit's own CDNs/permalinks aren't an off-site destination to preview
+    if not host or host.endswith("redd.it") or host.endswith("reddit.com"):
+        return []
+
+    entry = {"type": "link", "url": target, "domain": post.get("domain") or host}
+    poster = _preview_image(post)
+    if poster:
+        entry["poster"] = poster
+    return [entry]
 
 
 def _post_media(post: dict) -> List[dict]:
@@ -160,6 +194,10 @@ def ingest_reddit_item(item: ItemLoose) -> Optional[ItemLoose]:
         return None
 
     media = _post_media(post)
+    # no embeddable media, but the post links off-site: surface the
+    # destination as a preview card instead of hiding it
+    if not media:
+        media = _external_link_media(post)
 
     # a full-resolution card image beats the RSS thumbnail
     image_url = _preview_image(post)

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -568,10 +568,36 @@ document.addEventListener('scroll', () => {
   requestAnimationFrame(() => { gifScrollTick = false; updateGifPlayback(); });
 }, { passive: true, capture: true });
 
+// Preview card for a "link" media entry: a reddit post that points off-site.
+// Clicking opens the destination directly (stopPropagation) rather than the
+// reader, and it surfaces a link that would otherwise stay buried in the post.
+function linkCard(m) {
+  let host = m.domain || '';
+  if (!host) { try { host = new URL(m.url).hostname.replace(/^www\./, ''); } catch { /* leave blank */ } }
+  return h('a', {
+    class: 'flex items-stretch gap-3 bg-base-100 hover:bg-base-300 transition-colors',
+    href: m.url, target: '_blank', rel: 'noopener',
+    onclick: (e) => e.stopPropagation(),
+  },
+    m.poster
+      ? h('img', {
+          src: m.poster, alt: '', loading: 'lazy',
+          class: 'w-24 sm:w-32 flex-none object-cover bg-base-300',
+          onerror: (e) => e.target.remove(),
+        })
+      : null,
+    h('div', { class: 'flex flex-col justify-center gap-1 min-w-0 py-3 px-3' },
+      h('div', { class: 'flex items-center gap-1.5 text-xs font-medium text-base-content/60' },
+        openInNewTabIcon(), h('span', { class: 'truncate' }, host || 'External link')),
+      h('div', { class: 'text-sm text-primary break-all line-clamp-2' }, m.url)));
+}
+
 // One media entry ({type, url, poster?}) -> element. Gifs autoplay muted
 // and loop like the reddit app; videos get controls, so their clicks must
 // reach the player instead of opening the reader.
 function mediaElement(m, cls = 'w-full max-h-[70vh] object-contain') {
+  // reddit link posts point off-site: show a preview card, not a media frame
+  if (m.type === 'link') return linkCard(m);
   // third-party players (e.g. redgifs) embed as an iframe; their clicks
   // never bubble, so they don't open the reader
   if (m.type === 'embed') {

--- a/src/api/tests/ingest/reddit_test.py
+++ b/src/api/tests/ingest/reddit_test.py
@@ -1,5 +1,10 @@
 from db.item import ItemLoose
-from ingest.item.reddit import _post_media, ingest_reddit_item, is_reddit_post
+from ingest.item.reddit import (
+    _external_link_media,
+    _post_media,
+    ingest_reddit_item,
+    is_reddit_post,
+)
 from ingest.item.rss import _link_media
 
 
@@ -166,6 +171,47 @@ def test_post_media_plain_link_has_no_media():
     assert _post_media(post) == []
 
 
+def test_external_link_media_for_link_post():
+    post = {
+        "url_overridden_by_dest": "https://example.com/article",
+        "domain": "example.com",
+        "preview": {"images": [{"source": {"url": "https://preview.redd.it/img.jpg"}}]},
+    }
+    assert _external_link_media(post) == [
+        {
+            "type": "link",
+            "url": "https://example.com/article",
+            "domain": "example.com",
+            "poster": "https://preview.redd.it/img.jpg",
+        }
+    ]
+
+
+def test_external_link_media_without_preview_falls_back_to_host():
+    post = {"url": "https://news.ycombinator.com/item?id=1"}
+    assert _external_link_media(post) == [
+        {
+            "type": "link",
+            "url": "https://news.ycombinator.com/item?id=1",
+            "domain": "news.ycombinator.com",
+        }
+    ]
+
+
+def test_external_link_media_skips_self_post():
+    post = {"is_self": True, "url": "https://www.reddit.com/r/x/comments/abc/t/"}
+    assert _external_link_media(post) == []
+
+
+def test_external_link_media_skips_reddit_hosted_destinations():
+    # reddit CDN media and permalinks aren't off-site destinations to preview
+    assert _external_link_media({"url": "https://i.redd.it/example.jpg"}) == []
+    assert _external_link_media(
+        {"url": "https://www.reddit.com/r/x/comments/abc/t/"}
+    ) == []
+    assert _external_link_media({}) == []
+
+
 def test_ingest_reddit_item_skips_non_reddit_urls():
     item = ItemLoose(url="https://example.com/article")
     assert ingest_reddit_item(item) is None
@@ -202,6 +248,39 @@ def test_ingest_reddit_item_fetches_post_json(monkeypatch):
     assert result.author == "u/someone"
     assert result.media == [{"type": "gif", "url": "https://i.redd.it/example.gif"}]
     assert result.image_url == "https://preview.redd.it/img.jpg"
+
+
+def test_ingest_reddit_item_adds_link_card_for_link_post(monkeypatch):
+    post = {
+        "title": "An interesting article",
+        "author": "someone",
+        "url_overridden_by_dest": "https://example.com/article",
+        "domain": "example.com",
+        "preview": {"images": [{"source": {"url": "https://preview.redd.it/img.jpg"}}]},
+    }
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return [{"data": {"children": [{"data": post}]}}]
+
+    monkeypatch.setattr(
+        "ingest.item.reddit.reddit_get", lambda url, **kwargs: FakeResponse()
+    )
+
+    item = ItemLoose(url="https://www.reddit.com/r/x/comments/abc123/an_article/")
+    result = ingest_reddit_item(item)
+
+    assert result.media == [
+        {
+            "type": "link",
+            "url": "https://example.com/article",
+            "domain": "example.com",
+            "poster": "https://preview.redd.it/img.jpg",
+        }
+    ]
 
 
 def test_rss_link_media():


### PR DESCRIPTION
## Problem

When a reddit post is itself a link to somewhere else (a "link post"), Aggy never surfaced the destination. The card/reader only ever showed the reddit *comments permalink*, and `stripRedditBoilerplate` even removed the RSS `[link]` anchor — so the actual destination was invisible unless you opened the post on reddit. (Reported example: `https://www.reddit.com/r/howitsmade/s/vYaGlZlUbQ`.)

## Change

**Backend** (`ingest/item/reddit.py`)
- New `_external_link_media(post)` helper extracts the destination from the reddit post JSON (`url_overridden_by_dest` / `url`) as a new `link` media entry `{"type": "link", "url", "domain", "poster"?}`.
- It skips self (text) posts and reddit-hosted URLs (`*.redd.it`, `reddit.com`), and uses reddit's preview image as the card thumbnail when available.
- `ingest_reddit_item` attaches the link entry only when the post has no embeddable media, so images/gifs/videos/galleries still take priority.

**Frontend** (`static/js/app.js`)
- `mediaElement` renders `type: "link"` via a new `linkCard()` — a compact preview (thumbnail + domain + URL) that opens the destination directly (`stopPropagation` so it doesn't just open the reader).
- Works in both the feed card and the reader modal via the existing media pipeline. The title's "open original" icon still opens the reddit post, so both the post and its destination are reachable.

## Tests

Added unit tests in `tests/ingest/reddit_test.py` covering the link-card helper (link post, host fallback, self-post skip, reddit-hosted skip, empty) and the end-to-end `ingest_reddit_item` link path. Existing `_post_media` behavior is unchanged (`_post_media` still returns `[]` for plain links; link handling is separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8rf9z7CDtsesG9hBbxKmo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8rf9z7CDtsesG9hBbxKmo)_