### PR TITLE
Add sort-threshold dividers and a "most certain" feed sort

### DIFF
--- a/src/api/db/feed.py
+++ b/src/api/db/feed.py
@@ -12,9 +12,17 @@ ITEM_SORTS = {
     "predicted": "c.predicted_score DESC NULLS LAST, c.added_at DESC",
     "predicted_asc": "c.predicted_score ASC NULLS LAST, c.added_at DESC",
     "controversial": "c.predicted_confidence ASC NULLS LAST, c.added_at DESC",
+    "confident": "c.predicted_confidence DESC NULLS LAST, c.added_at DESC",
     "newest": "i.date_published DESC NULLS LAST, c.added_at DESC",
     "oldest": "i.date_published ASC NULLS LAST, c.added_at ASC",
 }
+
+# Sorts whose whole point is a strict, monotonic ranking of the model's
+# prediction. The feed's UI marks threshold crossings in these orders with
+# horizontal-rule dividers (e.g. where predicted votes fall from "upvote" to
+# "neutral"), which only reads correctly if the list is truly monotonic — so
+# these sorts skip the round-robin source interleaving the browse sorts use.
+MONOTONIC_SORTS = {"predicted", "predicted_asc", "controversial", "confident"}
 
 
 class Feed(ItemCollection):
@@ -121,9 +129,11 @@ class Feed(ItemCollection):
         - ``text_only=True`` keeps only items with no image or media;
           ``False`` keeps only items that have some; ``None`` keeps all.
 
-        Results interleave sources within the sort order: each source's best
-        item first (ordered by the sort key), then each source's second-best,
-        and so on, so the feed mixes sources instead of long runs of one.
+        Browse sorts interleave sources within the sort order: each source's
+        best item first (ordered by the sort key), then each source's
+        second-best, and so on, so the feed mixes sources instead of long runs
+        of one. The prediction-ranked sorts (``MONOTONIC_SORTS``) skip that
+        interleaving and return items in strict sort order instead.
         """
         from .item import ItemStrict
 
@@ -177,7 +187,14 @@ class Feed(ItemCollection):
         elif text_only is False:
             sql += f" AND {has_visual}"
 
-        sql = f"SELECT * FROM ({sql}) q ORDER BY q.source_rank, {outer_order}"
+        # Prediction-ranked sorts stay strictly monotonic (see MONOTONIC_SORTS);
+        # the browse sorts interleave sources by round-robin rank first.
+        outer_sort = (
+            outer_order
+            if sort in MONOTONIC_SORTS
+            else f"q.source_rank, {outer_order}"
+        )
+        sql = f"SELECT * FROM ({sql}) q ORDER BY {outer_sort}"
         if limit is not None and limit >= 0:
             sql += " LIMIT %s"
             params = params + (limit,)

--- a/src/api/routers/feed.py
+++ b/src/api/routers/feed.py
@@ -136,7 +136,8 @@ def get_feed_items(
     limit: Union[int, None] = None,
     sort: str = Query(
         "best",
-        description="best, predicted, predicted_asc, controversial, newest, oldest",
+        description="best, predicted, predicted_asc, controversial, "
+        "confident, newest, oldest",
     ),
     include_read: bool = True,
     sources: Optional[str] = Query(

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -9,6 +9,7 @@ const sdk = new AggySDK();
 const PAGE_SIZE = 20;
 let currentFeed = null;
 let itemSkip = 0;
+let lastItemBand = null; // sort-band of the last rendered item, for threshold dividers
 // filter/sort state for the current feed; sources: null means "all sources"
 const defaultFilters = () => ({ sort: 'predicted', includeRead: false, textOnly: '', sources: null });
 let feedFilters = defaultFilters();
@@ -393,10 +394,91 @@ async function handleRerank() {
 // ---------- items ----------
 let itemsRequestSeq = 0; // discards out-of-order responses
 
+// Threshold dividers: as you scroll a ranked feed, mark where the model's
+// verdict crosses a meaningful line so a run of cards reads as labeled bands.
+//
+// For the predicted sorts, votes live on a -1..1 scale (down / neutral / up),
+// so the midpoints +0.5 and -0.5 split "more likely an upvote" from "more
+// likely neutral" from "more likely a downvote". For the confidence sorts we
+// split the 0..1 confidence range into thirds. Each `band` maps an item to a
+// zone; `labels` gives the divider text shown when entering that zone from the
+// one above it (the very first zone in view never gets a divider).
+function predictionBand(item) {
+  const s = item.item_predicted_score;
+  if (s == null) return null;
+  if (s >= 0.5) return 'up';
+  if (s >= -0.5) return 'neutral';
+  return 'down';
+}
+
+function confidenceBand(item) {
+  const c = item.item_predicted_confidence;
+  if (c == null) return null;
+  if (c >= 2 / 3) return 'high';
+  if (c >= 1 / 3) return 'mid';
+  return 'low';
+}
+
+const SORT_BANDS = {
+  predicted: {
+    band: predictionBand,
+    labels: {
+      neutral: 'More likely neutral than an upvote',
+      down: 'More likely a downvote than neutral',
+    },
+  },
+  predicted_asc: {
+    band: predictionBand,
+    labels: {
+      neutral: 'More likely neutral than a downvote',
+      up: 'More likely an upvote than neutral',
+    },
+  },
+  controversial: {
+    band: confidenceBand,
+    labels: {
+      mid: 'Middle third — model moderately unsure',
+      high: 'Least controversial — model most confident',
+    },
+  },
+  confident: {
+    band: confidenceBand,
+    labels: {
+      mid: 'Model moderately confident',
+      low: 'Model least confident',
+    },
+  },
+};
+
+// Horizontal rule with a centered note, marking a threshold in the sort order.
+function sortDivider(text) {
+  return h('div', { class: 'flex items-center gap-3 my-1 text-xs text-base-content/40 select-none' },
+    h('div', { class: 'flex-1 border-t border-base-300' }),
+    h('span', { class: 'whitespace-nowrap uppercase tracking-wide' }, text),
+    h('div', { class: 'flex-1 border-t border-base-300' }));
+}
+
+// Append `item`'s card to `list`, first inserting a threshold divider when the
+// item's sort-band differs from the previous card's. `lastItemBand` carries the
+// band across paginated loads so dividers land correctly on infinite scroll.
+function appendItemWithDivider(list, item) {
+  const cfg = SORT_BANDS[feedFilters.sort];
+  if (cfg) {
+    const band = cfg.band(item);
+    if (band) {
+      if (lastItemBand && band !== lastItemBand && cfg.labels[band]) {
+        list.append(sortDivider(cfg.labels[band]));
+      }
+      lastItemBand = band;
+    }
+  }
+  list.append(itemCard(item));
+}
+
 async function loadFeedItems() {
   const seq = ++itemsRequestSeq;
   const list = $('itemList');
-  if (itemSkip === 0) render(list, spinner());
+  if (itemSkip === 0) { render(list, spinner()); lastItemBand = null; }
   // hide while loading so the infinite-scroll observer can't double-fire
   $('loadMoreBtn').classList.add('hidden');
 
@@ -421,7 +503,7 @@ async function loadFeedItems() {
       return;
     }
 
-    items.forEach((item) => list.append(itemCard(item)));
+    items.forEach((item) => appendItemWithDivider(list, item));
     $('loadMoreBtn').classList.toggle('hidden', items.length < PAGE_SIZE);
   } catch (err) {
     if (seq !== itemsRequestSeq) return;

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -72,6 +72,7 @@
               <option value="predicted">Predicted best</option>
               <option value="predicted_asc">Predicted worst</option>
               <option value="controversial">Controversial (model unsure)</option>
+              <option value="confident">Most certain (model sure)</option>
               <option value="newest">Newest</option>
               <option value="oldest">Oldest</option>
             </select>

--- a/src/api/tests/db/feed_test.py
+++ b/src/api/tests/db/feed_test.py
@@ -308,6 +308,46 @@ def test_query_items_interleaves_sources(unique_feed, unique_item_strict):
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
+def test_query_items_predicted_sort_is_monotonic(unique_feed, unique_item_strict):
+    """Prediction sorts return strict sort order, not interleaved by source, so
+    the feed's threshold dividers land on a monotonic ranking."""
+    unique_feed.create()
+    source_a = _make_source(unique_feed, "source-a")
+    source_b = _make_source(unique_feed, "source-b")
+
+    # every source-a item is predicted higher than every source-b item; the
+    # interleaved browse sort would zig-zag between sources, but a prediction
+    # sort must keep the scores strictly descending
+    items = [
+        _add_item(unique_feed, source_a, unique_item_strict, "http://example.com/a1", 0),
+        _add_item(unique_feed, source_a, unique_item_strict, "http://example.com/a2", 0),
+        _add_item(unique_feed, source_b, unique_item_strict, "http://example.com/b1", 0),
+        _add_item(unique_feed, source_b, unique_item_strict, "http://example.com/b2", 0),
+    ]
+    predictions = {
+        items[0].url_hash: 0.9,
+        items[1].url_hash: 0.6,
+        items[2].url_hash: -0.2,
+        items[3].url_hash: -0.7,
+    }
+    with unique_feed.db_con() as cur:
+        for url_hash, score in predictions.items():
+            cur.execute(
+                "UPDATE feed_items SET predicted_score = %s, "
+                "predicted_confidence = %s WHERE user_hash = %s "
+                "AND feed_hash = %s AND item_url_hash = %s",
+                (score, abs(score), unique_feed.user_hash,
+                 unique_feed.name_hash, url_hash),
+            )
+
+    results = unique_feed.query_items_with_sources(sort="predicted")
+    scores = [meta["predicted_score"] for _, meta in results]
+    assert scores == sorted(scores, reverse=True)
+    names = [meta["source_name"] for _, meta in results]
+    assert names == ["source-a", "source-a", "source-b", "source-b"]
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_query_items_source_filter(unique_feed, unique_item_strict):
     """source_hashes restricts results to the selected sources."""
     unique_feed.create()

--- a/src/api/tests/routers/ranking_test.py
+++ b/src/api/tests/routers/ranking_test.py
@@ -178,6 +178,13 @@ def test_rerank_and_stats(
     assert scores == sorted(scores, reverse=True)
     worst_first = _get_items(client, token, existing_feed, sort="predicted_asc")
     assert [i["item_predicted_score"] for i in worst_first] == sorted(scores)
+    # the confidence sorts order by how sure the model is, either direction
+    confident = _get_items(client, token, existing_feed, sort="confident")
+    confs = [i["item_predicted_confidence"] for i in confident]
+    assert all(c is not None for c in confs)
+    assert confs == sorted(confs, reverse=True)
+    controversial = _get_items(client, token, existing_feed, sort="controversial")
+    assert [i["item_predicted_confidence"] for i in controversial] == sorted(confs)
     # unvoted items get a prediction consistent with their cluster
     unvoted = {str(items[4].url): 1, str(items[5].url): -1}
     for entry in ranked:


### PR DESCRIPTION
## What & why

As you scroll a ranked feed, it's now easy to see where the model's verdict crosses a meaningful line. Runs of cards read as labeled bands separated by horizontal-rule dividers, and there's a new sort for reviewing the model's most-confident calls.

## Changes

**Threshold dividers (feed UI).** In the prediction-ranked sorts the item list inserts a divider whenever the current card falls into a new band:

- **Predicted best / worst** — votes live on a `-1..1` scale (down / neutral / up), so the midpoints `+0.5` and `-0.5` split the bands. In *Predicted best* the dividers read:
  - *"More likely neutral than an upvote"* (crossing below `+0.5`)
  - *"More likely a downvote than neutral"* (crossing below `-0.5`)

  *Predicted worst* shows the mirror-image labels as scores climb.
- **Controversial / Most certain** — the `0..1` confidence range is split into thirds, with dividers marking the boundaries.

The very first band in view never gets a divider (nothing above it), and the band is tracked across paginated loads so dividers land correctly on infinite scroll.

**New "Most certain" sort.** Adds a `confident` sort (`predicted_confidence DESC`) that surfaces the predictions the model is most sure about, regardless of whether they're up, neutral, or down — helpful for reviewing/training the model. Exposed in the sort dropdown as *"Most certain (model sure)"*.

**Monotonic ordering for prediction sorts.** The prediction-ranked sorts (`predicted`, `predicted_asc`, `controversial`, `confident`) now return a strictly monotonic order instead of the round-robin source interleaving used by the browse sorts. Interleaving would make predicted scores zig-zag between sources, which would render the threshold dividers meaningless. Browse sorts (`best`, `newest`, `oldest`) keep interleaving.

## Files

- `db/feed.py` — add `confident` to `ITEM_SORTS`; add `MONOTONIC_SORTS`; skip source interleaving for those sorts.
- `routers/feed.py` — document the new sort value.
- `static/js/app.js` — band helpers, `sortDivider`, divider insertion across pages.
- `templates/app.html` — new sort dropdown option.

## Testing

Ran the feed/ranking suites against a local Postgres with the repo migrations applied:

- New `test_query_items_predicted_sort_is_monotonic` — confirms prediction sorts return strict descending order and do not interleave sources.
- Extended `test_rerank_and_stats` — asserts the `confident` sort orders by confidence descending and `controversial` ascending.
- Existing interleave / bad-sort / predicted-order tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM67XiQVvibpK2u13xFZti)_