### PR TITLE
Add per-source "View" and "Re-scrape" buttons to feed settings

### DIFF
--- a/src/api/ingest/jobs.py
+++ b/src/api/ingest/jobs.py
@@ -2,11 +2,31 @@ import logging
 
 from constants import SOURCE_READ_INTERVAL_MINUTES
 from db.base import get_db_con
+from db.feed import Feed
+from db.item import ItemLoose
 from db.source import Source
 from ingest.source import ingest_source
+from ingest.item.reddit import ingest_reddit_item
+from ingest.item.open_graph import ingest_open_graph_item
+from ingest.item.mercury import ingest_mercury_item
 from db.user import User
 from utils import get_ollama_connection
 from config import config
+
+# Item fields whose text feeds the embedding prompt (see ItemBase.__str__):
+# a change in any of them means the stored embedding is stale.
+_EMBEDDING_TEXT_FIELDS = (
+    "title",
+    "author",
+    "date_published",
+    "domain",
+    "excerpt",
+    "content",
+)
+
+# Item fields re-collected by a re-scrape. A change in any of them is worth
+# persisting, and — for voted items — worth retraining the feed's models on.
+_RESCRAPE_FIELDS = _EMBEDDING_TEXT_FIELDS + ("image_url", "media")
 
 
 def source_ingestion_scheduling_job() -> None:
@@ -83,6 +103,89 @@ def ingest_source_now(source: Source) -> None:
     except Exception as e:
         logging.exception(f"Initial ingest of source '{source.name}' failed: {e}")
         source.mark_ingest_error(str(e))
+
+
+def _feeds_with_votes_on(url_hash: str) -> set:
+    """(user_hash, feed_hash) pairs that have cast a vote on this item."""
+    with get_db_con() as cur:
+        cur.execute(
+            "SELECT DISTINCT user_hash, feed_hash FROM item_states "
+            "WHERE item_url_hash = %s AND score IS NOT NULL",
+            (url_hash,),
+        )
+        return {(row["user_hash"], row["feed_hash"]) for row in cur.fetchall()}
+
+
+def rescrape_source(source: Source) -> None:
+    """Re-scrape a source's existing items for content, images, and preview
+    media, and regenerate embeddings, WITHOUT re-fetching the RSS feed.
+
+    Each item's scrapers (reddit / open graph / mercury) are re-run and merged
+    over the stored item, so gaps get backfilled and better content/media wins
+    while nothing already stored is lost. When an item's re-collected data
+    actually changed and the item carries a vote, the affected feeds are
+    re-ranked so their models retrain on the fresh features.
+    """
+    from ranking.engine import rank_feed  # local import avoids an import cycle
+
+    embedding_model = config.get("OLLAMA_EMBEDDING_MODEL", None)
+    feeds_to_rerank: set = set()
+
+    for item in source.query_items():
+        try:
+            before = {f: getattr(item, f) for f in _RESCRAPE_FIELDS}
+
+            merged = ItemLoose.merge_instances(
+                items=[
+                    item,
+                    ingest_reddit_item(item),
+                    ingest_open_graph_item(item),
+                    ingest_mercury_item(item),
+                ]
+            )
+            # merge_instances doesn't carry embeddings over; keep the existing
+            # ones so a re-scrape never drops them
+            merged.embeddings = item.embeddings
+
+            after = {f: getattr(merged, f) for f in _RESCRAPE_FIELDS}
+            text_changed = any(
+                after[f] != before[f] for f in _EMBEDDING_TEXT_FIELDS
+            )
+
+            embedding_changed = False
+            if text_changed and embedding_model is not None:
+                try:
+                    merged.add_embedding(
+                        model_name=embedding_model, force_refresh=True
+                    )
+                    embedding_changed = merged.embeddings != item.embeddings
+                except Exception as e:
+                    logging.error(f"Error re-embedding item {item.url}: {e}")
+
+            if after == before and not embedding_changed:
+                continue  # nothing changed, leave the row untouched
+
+            merged.update()  # persist (overwrites the existing row)
+
+            # a changed, voted-on item means the models that trained on its old
+            # features are now stale — schedule those feeds to retrain
+            feeds_to_rerank |= _feeds_with_votes_on(item.url_hash)
+        except Exception as e:
+            logging.exception(f"Re-scrape of item {item.url} failed: {e}")
+
+    for user_hash, feed_hash in feeds_to_rerank:
+        feed = Feed.read(user_hash=user_hash, name_hash=feed_hash)
+        if feed is None:
+            continue
+        try:
+            rank_feed(feed)
+        except Exception as e:
+            logging.exception(f"Re-ranking feed {feed.name} after re-scrape failed: {e}")
+
+    logging.info(
+        f"Re-scraped source '{source.name}': "
+        f"{len(feeds_to_rerank)} feed(s) retrained"
+    )
 
 
 def download_embedding_model_job() -> None:

--- a/src/api/routers/source.py
+++ b/src/api/routers/source.py
@@ -6,7 +6,7 @@ from db.feed import Feed
 from db.source import Source
 from db.source_template import SourceTemplate
 from db.user import User
-from ingest.jobs import ingest_source_now
+from ingest.jobs import ingest_source_now, rescrape_source
 from route_models.item import ItemResponse
 from route_models.acknowledge import AcknowledgeResponse
 from route_models.source import SourceRouteModel
@@ -119,6 +119,32 @@ def update_source(
         background_tasks.add_task(ingest_source_now, source)
 
     return SourceRouteModel.from_db_model(source)
+
+
+@source_router.post(
+    "/rescrape",
+    summary="Re-scrape a source's items for content, media, and embeddings",
+    response_model=AcknowledgeResponse,
+)
+def rescrape_source_route(
+    feed_name_hash: str,
+    source_name_hash: str,
+    background_tasks: BackgroundTasks,
+    user: User = Depends(authenticate),
+) -> AcknowledgeResponse:
+    try:
+        source = Source.read(
+            user_hash=user.name_hash,
+            feed_hash=feed_name_hash,
+            source_hash=source_name_hash,
+        )
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Source not found")
+
+    # Re-collect images/content/media and regenerate embeddings in the
+    # background; this does NOT re-fetch the RSS feed for new items.
+    background_tasks.add_task(rescrape_source, source)
+    return AcknowledgeResponse()
 
 
 @source_router.get(

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -941,12 +941,53 @@ function sourceRow(source) {
     h('div', { class: 'flex gap-1 flex-shrink-0' },
       h('button', {
         class: 'btn btn-ghost btn-xs',
+        title: 'Show only this source in the feed',
+        onclick: () => viewSourceInFeed(source),
+      }, 'View'),
+      h('button', {
+        class: 'btn btn-ghost btn-xs',
+        title: 'Re-collect images, content and previews for this source',
+        onclick: (e) => rescrapeSource(source, e.currentTarget),
+      }, 'Re-scrape'),
+      h('button', {
+        class: 'btn btn-ghost btn-xs',
         onclick: () => openEditSourceModal(source),
       }, 'Edit'),
       h('button', {
         class: 'btn btn-ghost btn-xs text-error',
         onclick: () => confirmDeleteSource(source),
       }, 'Remove')));
+}
+
+// Jump to the article list showing only this source, by seeding the source
+// filter with just this one and switching back to the items tab.
+function viewSourceInFeed(source) {
+  feedFilters.sources = [source.source_name_hash];
+  syncFilterControls();
+  renderFilterSources();
+  itemSkip = 0;
+  switchFeedTab('items');
+  loadFeedItems();
+}
+
+// Ask the API to re-collect content/images/previews (and regenerate
+// embeddings) for this source's existing items, without re-ingesting the feed.
+async function rescrapeSource(source, btn) {
+  btn.disabled = true;
+  const original = btn.textContent;
+  btn.textContent = 'Re-scraping…';
+  try {
+    await sdk.sourceRescrape({
+      feed_name_hash: currentFeed.feed_name_hash,
+      source_name_hash: source.source_name_hash,
+    });
+    toast(`Re-scraping "${source.source_name}" — this runs in the background`);
+  } catch (err) {
+    toast(err.message, 'alert-error');
+  } finally {
+    btn.disabled = false;
+    btn.textContent = original;
+  }
 }
 
 async function openEditSourceModal(source) {

--- a/src/api/static/js/sdk.js
+++ b/src/api/static/js/sdk.js
@@ -150,6 +150,11 @@ class AggySDK {
     return this._request("GET", "/source/items", { query: { feed_name_hash, source_name_hash, skip, limit } });
   }
 
+  /** Re-scrape a source's items for content, media, and embeddings */
+  async sourceRescrape({ feed_name_hash, source_name_hash }) {
+    return this._request("POST", "/source/rescrape", { query: { feed_name_hash, source_name_hash } });
+  }
+
   /** Update a source's name, URL, or template parameters */
   async sourceUpdate({ body }) {
     return this._request("POST", "/source/update", { body });

--- a/src/api/tests/ingest/jobs_test.py
+++ b/src/api/tests/ingest/jobs_test.py
@@ -1,0 +1,55 @@
+from db.item import ItemLoose, ItemStrict
+from ingest import jobs
+
+
+def test_rescrape_source_updates_changed_item_and_retrains(
+    monkeypatch, existing_source, existing_item_strict, existing_item_state
+):
+    """A re-scrape that turns up new content persists it and, because the item
+    carries a vote, retrains the feed that voted on it."""
+    longer_content = existing_item_strict.content + " with a lot more detail now"
+
+    # open graph turns up richer content; the other scrapers find nothing
+    monkeypatch.setattr(jobs, "ingest_reddit_item", lambda item: None)
+    monkeypatch.setattr(
+        jobs,
+        "ingest_open_graph_item",
+        lambda item: ItemLoose(url=item.url, content=longer_content),
+    )
+    monkeypatch.setattr(jobs, "ingest_mercury_item", lambda item: None)
+    # no embedding model configured, so no ollama round-trip
+    monkeypatch.setattr(jobs.config, "get", lambda key, default=None: default)
+
+    ranked = []
+    monkeypatch.setattr(
+        "ranking.engine.rank_feed", lambda feed: ranked.append(feed.name_hash)
+    )
+
+    jobs.rescrape_source(existing_source)
+
+    # the richer content was written back
+    stored = ItemStrict.read(url_hash=existing_item_strict.url_hash)
+    assert longer_content in stored.content
+
+    # the feed holding the vote was retrained exactly once
+    assert ranked == [existing_item_state.feed_hash]
+
+
+def test_rescrape_source_skips_unchanged_item(
+    monkeypatch, existing_source, existing_item_strict, existing_item_state
+):
+    """When re-scraping turns up nothing new, the item is left alone and no
+    retraining is triggered."""
+    monkeypatch.setattr(jobs, "ingest_reddit_item", lambda item: None)
+    monkeypatch.setattr(jobs, "ingest_open_graph_item", lambda item: None)
+    monkeypatch.setattr(jobs, "ingest_mercury_item", lambda item: None)
+    monkeypatch.setattr(jobs.config, "get", lambda key, default=None: default)
+
+    ranked = []
+    monkeypatch.setattr(
+        "ranking.engine.rank_feed", lambda feed: ranked.append(feed.name_hash)
+    )
+
+    jobs.rescrape_source(existing_source)
+
+    assert ranked == []

--- a/src/api/tests/routers/source_test.py
+++ b/src/api/tests/routers/source_test.py
@@ -111,6 +111,36 @@ def test_delete_source(client, existing_feed, existing_source, token):
     assert response.json() == {"detail": "Source not found"}
 
 
+def test_rescrape_source(client, existing_feed, existing_source, token):
+    args = build_api_request_args(
+        path="/source/rescrape",
+        params={
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name_hash": existing_source.name_hash,
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+    assert response.status_code == 200
+    assert response.json() == {"message": "success"}
+
+
+def test_rescrape_source_not_found(client, existing_feed, token):
+    args = build_api_request_args(
+        path="/source/rescrape",
+        params={
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name_hash": "does-not-exist",
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Source not found"}
+
+
 def test_create_duplicate_source_conflict(client, existing_feed, existing_source, token):
     args = build_api_request_args(
         path="/source/create",


### PR DESCRIPTION
## Summary

Adds two per-source actions to the sources/settings tab of a feed:

- **View** — jumps to the article list filtered to only that source. It seeds the feed's existing source filter with the single source hash and switches back to the items tab.
- **Re-scrape** — triggers a new `POST /source/rescrape` endpoint that re-collects images, content text and preview media for the source's *existing* items and regenerates embeddings, **without** re-fetching the RSS feed for new entries.

## How re-scrape works

The endpoint schedules a background job (`rescrape_source`) that, for each existing item in the source:

1. Re-runs the reddit / open graph / mercury scrapers and merges the results *over* the stored item, so gaps get backfilled and richer content/media wins while nothing already stored is lost.
2. Preserves existing embeddings across the merge, and regenerates the embedding (force refresh) when the item's embedding text actually changed.
3. Persists the item only when its re-collected data (content, excerpt, image, media, …) or embedding actually changed.
4. When a changed item carries a vote, collects the feeds that voted on it and re-ranks them via `rank_feed`, so the vote-prediction models retrain on the fresh features.

## Changes

- `routers/source.py`: new `POST /source/rescrape` endpoint (404s on unknown source, queues the background job otherwise).
- `ingest/jobs.py`: `rescrape_source` job plus a `_feeds_with_votes_on` helper and change-detection constants.
- `static/js/app.js`: `View` / `Re-scrape` buttons on each source row, with `viewSourceInFeed` and `rescrapeSource` handlers.
- `static/js/sdk.js`: regenerated with the new `sourceRescrape` method.
- Tests: router tests for the new endpoint (success + not-found) and job-level tests covering the "changed item retrains a voted feed" and "unchanged item is left alone" paths.

## Testing

- `python -m py_compile` and `node --check` pass on all changed files.
- Full dependency install / test-suite run was not possible in this environment (native wheel build failure for `sgmllib3k`); the SDK was hand-updated to match the deterministic generator output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDdP8w5eKHAJDfaNELXmAH

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDdP8w5eKHAJDfaNELXmAH)_