### PR TITLE
Add toggle-all control for sources in feed filter

### DIFF
--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -292,6 +292,20 @@ async function toggleFilterPanel() {
 // against a stale snapshot of the selection.
 function renderFilterSources() {
   const selected = feedFilters.sources; // null = all
+  // "Toggle all" checks/unchecks every source at once; only shown when the
+  // feed has sources. Checked when all are selected (sources === null).
+  const toggleAllLabel = $('filterSourcesToggleAllLabel');
+  const toggleAll = $('filterSourcesToggleAll');
+  if (toggleAllLabel && toggleAll) {
+    toggleAllLabel.classList.toggle('hidden', !feedSourceList.length);
+    toggleAll.checked = selected === null;
+    toggleAll.onchange = (e) => {
+      // Checking selects all (null); unchecking clears the selection.
+      feedFilters.sources = e.target.checked ? null : [];
+      renderFilterSources();
+      reloadItems();
+    };
+  }
   render($('filterSources'),
     feedSourceList.length
       ? feedSourceList.map((s) =>

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -93,7 +93,13 @@
           </div>
         </div>
         <div>
-          <div class="text-xs text-base-content/60 mb-1">Sources</div>
+          <div class="flex items-center justify-between mb-1">
+            <div class="text-xs text-base-content/60">Sources</div>
+            <label class="label cursor-pointer gap-1.5 py-0 hidden" id="filterSourcesToggleAllLabel">
+              <input type="checkbox" class="checkbox checkbox-xs checkbox-primary" id="filterSourcesToggleAll">
+              <span class="label-text text-xs">Toggle all</span>
+            </label>
+          </div>
           <div class="flex flex-wrap gap-2" id="filterSources"></div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Adds a **"Toggle all"** checkbox to the Sources section of the feed filter panel, so users can select or clear every source in one click instead of toggling each checkbox individually.

## Changes

- `src/api/templates/app.html`: Added a "Toggle all" checkbox in the Sources header row of the filter panel.
- `src/api/static/js/app.js`: Wired the checkbox in `renderFilterSources()`:
  - Checked when all sources are selected (`sources === null`).
  - Checking it selects all sources (`sources = null`); unchecking clears the selection (`sources = []`).
  - Hidden when the feed has no sources.

## Behavior notes

The existing backend already handles the resulting filter states: `sources === null` (or omitted) returns all sources, and an empty selection returns no articles — so no API changes were needed. The toggle stays in sync with individual checkbox changes since both re-render from `feedFilters.sources`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkZMVTJf4QF9YjJhWfdm17)_