### PR TITLE
Add bulk subscription import from Reddit, YouTube, Bluesky, and OPML

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Aggy uses **content embeddings** to understand the types of content you enjoy. A
 ### Available now:
 
 - **RSS source support** with predefined templates for faster setup
+- **Bulk subscription import** from Reddit, YouTube, Bluesky, and any OPML export (Feedly, Inoreader, podcast apps), with per-source feed assignment
 - **Embedding generation** for text to improve content relevance
 
 ### In the works:

--- a/src/api/builtin_templates.py
+++ b/src/api/builtin_templates.py
@@ -27,6 +27,43 @@ BUILTIN_TEMPLATES = [
         },
     ),
     SourceTemplate(
+        name="YouTube Channel",
+        url="https://www.youtube.com",
+        url_template="https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}",
+        description=(
+            "A YouTube channel's latest uploads via YouTube's native RSS "
+            "feed. Needs the channel ID (starts with UC); the bulk importer "
+            "can resolve @handles and channel URLs to IDs for you."
+        ),
+        parameters={
+            "channel_id": SourceTemplateParameter(
+                name="Channel ID",
+                title="Channel ID (starts with UC)",
+                required=True,
+                type="text",
+                example="UCXuqSBlHAE6Xw-yeJA0Tunw",
+            ),
+        },
+    ),
+    SourceTemplate(
+        name="Bluesky User",
+        url="https://bsky.app",
+        url_template="https://bsky.app/profile/{handle}/rss",
+        description=(
+            "Posts from a Bluesky account via Bluesky's native RSS feed, "
+            "fetched directly without rss-bridge."
+        ),
+        parameters={
+            "handle": SourceTemplateParameter(
+                name="Handle",
+                title="Bluesky handle (without @)",
+                required=True,
+                type="text",
+                example="jay.bsky.team",
+            ),
+        },
+    ),
+    SourceTemplate(
         name="Reddit User",
         url="https://www.reddit.com",
         url_template="https://www.reddit.com/user/{username}/.rss",
@@ -45,6 +82,14 @@ BUILTIN_TEMPLATES = [
         },
     ),
 ]
+
+
+def builtin_template(name: str) -> SourceTemplate:
+    """Look up a built-in template by its (context-free) name."""
+    for template in BUILTIN_TEMPLATES:
+        if template.name == name:
+            return template
+    raise KeyError(f"No builtin template named {name}")
 
 
 def create_builtin_source_templates() -> None:

--- a/src/api/bulk_import.py
+++ b/src/api/bulk_import.py
@@ -1,0 +1,355 @@
+"""Parsers that turn subscription exports into source candidates.
+
+Each platform parser accepts whatever the user can realistically get their
+hands on — a data-export file, a pasted list of names/URLs, or (for
+platforms with a public follows API) just a username — and normalizes it
+into ``SourceCandidate`` rows the review UI can assign to feeds.
+
+Candidates reference the built-in source templates where one exists, so
+imported sources stay editable through the normal template UI.
+"""
+
+import csv
+import io
+import logging
+import re
+import xml.etree.ElementTree as ET
+from typing import Callable, List, Optional, Tuple
+
+import httpx
+from pydantic import BaseModel
+
+from builtin_templates import builtin_template
+
+# Bound the work a single parse request can do: resolving a YouTube handle
+# costs an HTTP request to youtube.com, and Bluesky follows are paginated
+# 100 at a time.
+MAX_YOUTUBE_RESOLUTIONS = 50
+MAX_BLUESKY_FOLLOWS = 1000
+HTTP_TIMEOUT_SECONDS = 10
+
+BLUESKY_FOLLOWS_API = "https://public.api.bsky.app/xrpc/app.bsky.graph.getFollows"
+
+
+class SourceCandidate(BaseModel):
+    """One potential source detected in the user's subscription data."""
+
+    name: str
+    url: Optional[str] = None  # None when the entry couldn't be resolved
+    # OPML folder (or other grouping) the entry came from, as a hint for
+    # which feed it belongs in.
+    group: Optional[str] = None
+    template_name_hash: Optional[str] = None
+    template_parameters: Optional[dict] = None
+    error: Optional[str] = None
+
+
+def _tokenize(text: str) -> List[str]:
+    """Split pasted text into entry tokens (newlines, commas, whitespace)."""
+    return [t for t in re.split(r"[\s,]+", text or "") if t]
+
+
+def _dedupe(candidates: List[SourceCandidate]) -> List[SourceCandidate]:
+    """Drop candidates that repeat an earlier candidate's URL or name."""
+    seen_urls: set = set()
+    seen_names: set = set()
+    out = []
+    for c in candidates:
+        url_key = c.url or f"error:{c.name}"
+        if url_key in seen_urls:
+            continue
+        seen_urls.add(url_key)
+        # source names must be unique within a feed; disambiguate repeats
+        if c.name in seen_names:
+            suffix = 2
+            while f"{c.name} ({suffix})" in seen_names:
+                suffix += 1
+            c.name = f"{c.name} ({suffix})"
+        seen_names.add(c.name)
+        out.append(c)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Reddit
+# ---------------------------------------------------------------------------
+
+# Subreddit names: letters/digits/underscores, 2-21 chars.
+_SUBREDDIT_RE = re.compile(r"^[A-Za-z0-9_]{2,21}$")
+_SUBREDDIT_URL_RE = re.compile(r"reddit\.com/r/([A-Za-z0-9_]{2,21})", re.IGNORECASE)
+
+
+def parse_reddit(text: str) -> Tuple[List[SourceCandidate], List[str]]:
+    """Parse a Reddit GDPR export (subscribed_subreddits.csv) or a pasted
+    list of subreddit names/URLs into subreddit source candidates."""
+    template = builtin_template("Reddit Subreddit")
+    names: List[str] = []
+    skipped: List[str] = []
+
+    for token in _tokenize(text):
+        m = _SUBREDDIT_URL_RE.search(token)
+        if m:
+            names.append(m.group(1))
+            continue
+        # bare names, r/name, /r/name — also covers the export's CSV rows
+        bare = re.sub(r"^/?(r/)?", "", token, flags=re.IGNORECASE).rstrip("/")
+        if _SUBREDDIT_RE.match(bare):
+            # the export file's header row
+            if bare.lower() == "subreddit":
+                continue
+            names.append(bare)
+        else:
+            skipped.append(token)
+
+    candidates = [
+        SourceCandidate(
+            name=f"r/{name}",
+            url=template.create_rss_url(subreddit=name),
+            template_name_hash=template.name_hash,
+            template_parameters={"subreddit": name},
+        )
+        for name in names
+    ]
+    warnings = []
+    if skipped:
+        shown = ", ".join(skipped[:5])
+        more = f" (and {len(skipped) - 5} more)" if len(skipped) > 5 else ""
+        warnings.append(f"Skipped {len(skipped)} unrecognized entries: {shown}{more}")
+    return _dedupe(candidates), warnings
+
+
+# ---------------------------------------------------------------------------
+# YouTube
+# ---------------------------------------------------------------------------
+
+_CHANNEL_ID_RE = re.compile(r"^UC[0-9A-Za-z_-]{22}$")
+_CHANNEL_URL_RE = re.compile(
+    r"youtube\.com/channel/(UC[0-9A-Za-z_-]{22})", re.IGNORECASE
+)
+# /@handle, /c/name and /user/name URLs (and bare @handles) all need a page
+# fetch to find the channel id.
+_HANDLE_URL_RE = re.compile(
+    r"youtube\.com/(@[\w.-]+|c/[\w.-]+|user/[\w.-]+)", re.IGNORECASE
+)
+_HANDLE_RE = re.compile(r"^@[\w.-]+$")
+
+_PAGE_CHANNEL_ID_RE = re.compile(r'"channelId":"(UC[0-9A-Za-z_-]{22})"')
+_PAGE_TITLE_RE = re.compile(r'<meta property="og:title" content="([^"]*)"')
+
+
+def _youtube_candidate(channel_id: str, title: str) -> SourceCandidate:
+    template = builtin_template("YouTube Channel")
+    return SourceCandidate(
+        name=title,
+        url=template.create_rss_url(channel_id=channel_id),
+        template_name_hash=template.name_hash,
+        template_parameters={"channel_id": channel_id},
+    )
+
+
+def resolve_youtube_channel(page_url: str) -> Tuple[str, str]:
+    """Fetch a YouTube channel page and return (channel_id, title).
+
+    Raises on network errors or when no channel id is present (deleted or
+    mistyped channels)."""
+    resp = httpx.get(
+        page_url,
+        timeout=HTTP_TIMEOUT_SECONDS,
+        follow_redirects=True,
+        headers={"User-Agent": "aggy-subscription-import"},
+    )
+    resp.raise_for_status()
+    id_match = _PAGE_CHANNEL_ID_RE.search(resp.text)
+    if not id_match:
+        raise ValueError("no channel id found on page")
+    title_match = _PAGE_TITLE_RE.search(resp.text)
+    title = title_match.group(1) if title_match else ""
+    return id_match.group(1), title
+
+
+def _parse_youtube_takeout_csv(text: str) -> List[SourceCandidate]:
+    reader = csv.DictReader(io.StringIO(text))
+    # Takeout headers: "Channel Id", "Channel Url", "Channel Title"
+    fields = {(f or "").strip().lower(): f for f in (reader.fieldnames or [])}
+    id_field = fields.get("channel id")
+    title_field = fields.get("channel title")
+    candidates = []
+    for row in reader:
+        channel_id = (row.get(id_field) or "").strip()
+        if not _CHANNEL_ID_RE.match(channel_id):
+            continue
+        title = (row.get(title_field) or "").strip() if title_field else ""
+        candidates.append(_youtube_candidate(channel_id, title or channel_id))
+    return candidates
+
+
+def parse_youtube(
+    text: str,
+    resolver: Callable[[str], Tuple[str, str]] = resolve_youtube_channel,
+) -> Tuple[List[SourceCandidate], List[str]]:
+    """Parse a Google Takeout subscriptions.csv or pasted channel
+    URLs/handles/IDs into YouTube channel source candidates.
+
+    ``resolver`` fetches a channel page to turn handles into channel IDs;
+    injectable so tests never touch the network."""
+    first_line = (text or "").strip().splitlines()[0:1]
+    if first_line and "channel id" in first_line[0].lower():
+        return _dedupe(_parse_youtube_takeout_csv(text)), []
+
+    candidates: List[SourceCandidate] = []
+    warnings: List[str] = []
+    skipped: List[str] = []
+    to_resolve: List[Tuple[str, str]] = []  # (display label, page url)
+
+    for token in _tokenize(text):
+        id_url = _CHANNEL_URL_RE.search(token)
+        if id_url:
+            channel_id = id_url.group(1)
+            candidates.append(_youtube_candidate(channel_id, channel_id))
+            continue
+        if _CHANNEL_ID_RE.match(token):
+            candidates.append(_youtube_candidate(token, token))
+            continue
+        handle_url = _HANDLE_URL_RE.search(token)
+        if handle_url:
+            path = handle_url.group(1)
+            to_resolve.append((path, f"https://www.youtube.com/{path}"))
+            continue
+        if _HANDLE_RE.match(token):
+            to_resolve.append((token, f"https://www.youtube.com/{token}"))
+            continue
+        skipped.append(token)
+
+    if len(to_resolve) > MAX_YOUTUBE_RESOLUTIONS:
+        warnings.append(
+            f"Only the first {MAX_YOUTUBE_RESOLUTIONS} handles/custom URLs were "
+            f"looked up ({len(to_resolve)} given). Channel IDs and Takeout CSV "
+            "imports have no limit."
+        )
+        to_resolve = to_resolve[:MAX_YOUTUBE_RESOLUTIONS]
+
+    for label, page_url in to_resolve:
+        try:
+            channel_id, title = resolver(page_url)
+            candidates.append(_youtube_candidate(channel_id, title or label))
+        except Exception as e:
+            logging.info(f"youtube channel resolution failed for {page_url}: {e}")
+            candidates.append(
+                SourceCandidate(name=label, error="Couldn't find this channel")
+            )
+
+    if skipped:
+        shown = ", ".join(skipped[:5])
+        more = f" (and {len(skipped) - 5} more)" if len(skipped) > 5 else ""
+        warnings.append(f"Skipped {len(skipped)} unrecognized entries: {shown}{more}")
+    return _dedupe(candidates), warnings
+
+
+# ---------------------------------------------------------------------------
+# OPML (any RSS reader / podcast app export)
+# ---------------------------------------------------------------------------
+
+
+def parse_opml(text: str) -> Tuple[List[SourceCandidate], List[str]]:
+    """Parse an OPML export into source candidates, keeping the folder each
+    feed was filed under as a grouping hint."""
+    try:
+        root = ET.fromstring(text or "")
+    except ET.ParseError as e:
+        raise ValueError(f"Not a valid OPML file: {e}")
+
+    candidates: List[SourceCandidate] = []
+
+    def walk(outline, group: Optional[str]):
+        for child in outline.findall("outline"):
+            xml_url = child.get("xmlUrl")
+            title = (child.get("title") or child.get("text") or "").strip()
+            if xml_url:
+                candidates.append(
+                    SourceCandidate(
+                        name=title or xml_url,
+                        url=xml_url,
+                        group=group,
+                    )
+                )
+            else:
+                # a folder: its title groups everything nested below it
+                walk(child, title or group)
+
+    body = root.find("body")
+    if body is None:
+        raise ValueError("Not a valid OPML file: missing <body>")
+    walk(body, None)
+
+    warnings = []
+    if not candidates:
+        warnings.append("No feeds found in this OPML file")
+    return _dedupe(candidates), warnings
+
+
+# ---------------------------------------------------------------------------
+# Bluesky
+# ---------------------------------------------------------------------------
+
+_BSKY_PROFILE_URL_RE = re.compile(r"bsky\.app/profile/([^/\s?]+)", re.IGNORECASE)
+
+
+def normalize_bluesky_handle(raw: str) -> str:
+    """Accept '@handle', a bsky.app profile URL, or a bare handle; bare
+    names get the default .bsky.social suffix."""
+    handle = (raw or "").strip()
+    m = _BSKY_PROFILE_URL_RE.search(handle)
+    if m:
+        handle = m.group(1)
+    handle = handle.lstrip("@").rstrip("/")
+    if handle and "." not in handle:
+        handle = f"{handle}.bsky.social"
+    return handle
+
+
+def fetch_bluesky_follows(handle: str) -> Tuple[List[SourceCandidate], List[str]]:
+    """List every account ``handle`` follows via Bluesky's public (no-auth)
+    API; each becomes a candidate pointing at the account's native RSS."""
+    handle = normalize_bluesky_handle(handle)
+    if not handle:
+        raise ValueError("Enter a Bluesky handle, e.g. jay.bsky.team")
+
+    template = builtin_template("Bluesky User")
+    candidates: List[SourceCandidate] = []
+    warnings: List[str] = []
+    cursor = None
+
+    with httpx.Client(timeout=HTTP_TIMEOUT_SECONDS) as client:
+        while len(candidates) < MAX_BLUESKY_FOLLOWS:
+            params = {"actor": handle, "limit": 100}
+            if cursor:
+                params["cursor"] = cursor
+            resp = client.get(BLUESKY_FOLLOWS_API, params=params)
+            if resp.status_code == 400:
+                detail = resp.json().get("message", "unknown account")
+                raise ValueError(f"Bluesky couldn't find that account: {detail}")
+            resp.raise_for_status()
+            data = resp.json()
+            for follow in data.get("follows", []):
+                follow_handle = follow.get("handle", "")
+                # accounts deleted/deactivated since being followed
+                if not follow_handle or follow_handle == "handle.invalid":
+                    continue
+                display = (follow.get("displayName") or "").strip()
+                candidates.append(
+                    SourceCandidate(
+                        name=display or follow_handle,
+                        url=template.create_rss_url(handle=follow_handle),
+                        template_name_hash=template.name_hash,
+                        template_parameters={"handle": follow_handle},
+                    )
+                )
+            cursor = data.get("cursor")
+            if not cursor:
+                break
+        else:
+            warnings.append(f"Stopped after the first {MAX_BLUESKY_FOLLOWS} follows")
+
+    if not candidates:
+        warnings.append(f"@{handle} doesn't follow any accounts")
+    return _dedupe(candidates), warnings

--- a/src/api/generate_sdk.py
+++ b/src/api/generate_sdk.py
@@ -9,6 +9,7 @@ Usage:
     python generate_sdk.py          # write static/js/sdk.js
     python generate_sdk.py --check  # exit 1 if sdk.js is stale
 """
+
 import json
 import re
 import sys
@@ -24,6 +25,7 @@ def build_app():
     from routers.feed import feed_router
     from routers.source_template import source_template_router
     from routers.source import source_router
+    from routers.bulk_import import bulk_import_router
     from routers.item import item_router
 
     app = FastAPI()
@@ -34,6 +36,7 @@ def build_app():
         source_template_router, prefix="/source_template", tags=["Source Templates"]
     )
     app.include_router(source_router, prefix="/source", tags=["Sources"])
+    app.include_router(bulk_import_router, prefix="/import", tags=["Bulk Import"])
     app.include_router(item_router, prefix="/item", tags=["Items"])
     return app
 
@@ -117,9 +120,7 @@ def generate_sdk(spec):
 
             js_path = path
             for p in path_params:
-                js_path = js_path.replace(
-                    "{" + p["name"] + "}", "${" + p["name"] + "}"
-                )
+                js_path = js_path.replace("{" + p["name"] + "}", "${" + p["name"] + "}")
             uses_template = "${" in js_path
             path_expr = f"`{js_path}`" if uses_template else json.dumps(js_path)
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -27,6 +27,7 @@ from routers.auth import auth_router
 from routers.feed import feed_router
 from routers.source_template import source_template_router
 from routers.source import source_router
+from routers.bulk_import import bulk_import_router
 from routers.item import item_router
 from routers.web import web_router
 from bridge.jobs import rss_bridge_get_templates_job
@@ -124,6 +125,7 @@ app.include_router(
     source_template_router, prefix="/source_template", tags=["Source Templates"]
 )
 app.include_router(source_router, prefix="/source", tags=["Sources"])
+app.include_router(bulk_import_router, prefix="/import", tags=["Bulk Import"])
 app.include_router(item_router, prefix="/item", tags=["Items"])
 app.include_router(web_router)
 

--- a/src/api/route_models/bulk_import.py
+++ b/src/api/route_models/bulk_import.py
@@ -1,0 +1,90 @@
+from enum import Enum
+from typing import Dict, List, Optional
+
+from .base import BaseRouteModel
+
+
+class ImportPlatform(str, Enum):
+    reddit = "reddit"
+    youtube = "youtube"
+    opml = "opml"
+    bluesky = "bluesky"
+
+
+class ImportParseRequest(BaseRouteModel):
+    platform: ImportPlatform
+    # Export-file content or pasted text (reddit/youtube/opml).
+    data: Optional[str] = None
+    # Account handle (bluesky).
+    username: Optional[str] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "platform": "reddit",
+                "data": "r/selfhosted\nr/alligators",
+            }
+        }
+    }
+
+
+class ImportCandidateResponse(BaseRouteModel):
+    name: str
+    url: Optional[str] = None
+    group: Optional[str] = None
+    template_name_hash: Optional[str] = None
+    template_parameters: Optional[Dict[str, str]] = None
+    error: Optional[str] = None
+
+
+class ImportParseResponse(BaseRouteModel):
+    candidates: List[ImportCandidateResponse]
+    warnings: List[str] = []
+
+
+class BulkSourceRequest(BaseRouteModel):
+    feed_name_hash: str
+    source_name: str
+    # Either a raw URL or a template reference (template wins when both set).
+    source_url: Optional[str] = None
+    template_name_hash: Optional[str] = None
+    template_parameters: Optional[Dict[str, str]] = None
+
+
+class BulkCreateRequest(BaseRouteModel):
+    sources: List[BulkSourceRequest]
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "sources": [
+                    {
+                        "feed_name_hash": "feed_hash_456",
+                        "source_name": "r/selfhosted",
+                        "template_name_hash": "template_hash_123",
+                        "template_parameters": {"subreddit": "selfhosted"},
+                    }
+                ]
+            }
+        }
+    }
+
+
+class BulkCreateResultStatus(str, Enum):
+    created = "created"
+    duplicate = "duplicate"
+    error = "error"
+
+
+class BulkCreateResult(BaseRouteModel):
+    source_name: str
+    feed_name_hash: str
+    status: BulkCreateResultStatus
+    detail: Optional[str] = None
+
+
+class BulkCreateResponse(BaseRouteModel):
+    results: List[BulkCreateResult]
+    created: int
+    duplicates: int
+    errors: int

--- a/src/api/routers/bulk_import.py
+++ b/src/api/routers/bulk_import.py
@@ -1,0 +1,171 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+import bulk_import
+from db.feed import Feed
+from db.source import Source
+from db.source_template import SourceTemplate
+from db.user import User
+from route_models.bulk_import import (
+    BulkCreateRequest,
+    BulkCreateResponse,
+    BulkCreateResult,
+    BulkCreateResultStatus,
+    ImportCandidateResponse,
+    ImportParseRequest,
+    ImportParseResponse,
+    ImportPlatform,
+)
+from routers.auth import authenticate
+
+bulk_import_router = APIRouter()
+
+# One import request creates at most this many sources; the UI never sends
+# more rows than parse returned, so this only guards hand-crafted requests.
+MAX_BULK_SOURCES = 2000
+
+
+@bulk_import_router.post(
+    "/parse",
+    summary="Parse subscription data (export file, pasted list, or username) "
+    "into source candidates",
+    response_model=ImportParseResponse,
+)
+def parse_subscriptions(
+    request: ImportParseRequest,
+    user: User = Depends(authenticate),
+) -> ImportParseResponse:
+    try:
+        if request.platform == ImportPlatform.bluesky:
+            if not (request.username or "").strip():
+                raise ValueError("Enter a Bluesky handle, e.g. jay.bsky.team")
+            candidates, warnings = bulk_import.fetch_bluesky_follows(request.username)
+        else:
+            if not (request.data or "").strip():
+                raise ValueError("Upload an export file or paste your subscriptions")
+            if request.platform == ImportPlatform.reddit:
+                candidates, warnings = bulk_import.parse_reddit(request.data)
+            elif request.platform == ImportPlatform.youtube:
+                candidates, warnings = bulk_import.parse_youtube(request.data)
+            else:
+                candidates, warnings = bulk_import.parse_opml(request.data)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception:
+        raise HTTPException(
+            status_code=502,
+            detail="Couldn't reach the platform to look up subscriptions; try again",
+        )
+
+    if not candidates:
+        raise HTTPException(
+            status_code=422, detail="No sources found in the provided data"
+        )
+
+    return ImportParseResponse(
+        candidates=[ImportCandidateResponse(**c.model_dump()) for c in candidates],
+        warnings=warnings,
+    )
+
+
+@bulk_import_router.post(
+    "/create",
+    summary="Create many sources at once, each in its chosen feed",
+    response_model=BulkCreateResponse,
+)
+def bulk_create_sources(
+    request: BulkCreateRequest,
+    user: User = Depends(authenticate),
+) -> BulkCreateResponse:
+    if len(request.sources) > MAX_BULK_SOURCES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"At most {MAX_BULK_SOURCES} sources per import",
+        )
+
+    feeds: dict = {}  # feed_name_hash -> Feed (or None when missing)
+    templates: dict = {}  # template_name_hash -> SourceTemplate (or None)
+    results = []
+
+    def result(row, status, detail=None):
+        results.append(
+            BulkCreateResult(
+                source_name=row.source_name,
+                feed_name_hash=row.feed_name_hash,
+                status=status,
+                detail=detail,
+            )
+        )
+
+    for row in request.sources:
+        if row.feed_name_hash not in feeds:
+            feeds[row.feed_name_hash] = Feed.read(
+                user_hash=user.name_hash, name_hash=row.feed_name_hash
+            )
+        feed = feeds[row.feed_name_hash]
+        if feed is None:
+            result(row, BulkCreateResultStatus.error, "Feed not found")
+            continue
+
+        name = (row.source_name or "").strip()
+        if not name:
+            result(row, BulkCreateResultStatus.error, "Source name cannot be empty")
+            continue
+
+        template = None
+        if row.template_name_hash:
+            if row.template_name_hash not in templates:
+                templates[row.template_name_hash] = SourceTemplate.read(
+                    name_hash=row.template_name_hash
+                )
+            template = templates[row.template_name_hash]
+            if template is None:
+                result(row, BulkCreateResultStatus.error, "Source template not found")
+                continue
+
+        try:
+            if template:
+                url = template.create_rss_url(**(row.template_parameters or {}))
+            elif row.source_url:
+                url = row.source_url
+            else:
+                result(row, BulkCreateResultStatus.error, "Source has no URL")
+                continue
+
+            source = Source(
+                user_hash=user.name_hash,
+                feed_hash=row.feed_name_hash,
+                name=name,
+                url=url,
+                template_name_hash=template.name_hash if template else None,
+                template_parameters=row.template_parameters if template else None,
+            )
+        except Exception as e:
+            result(row, BulkCreateResultStatus.error, str(e))
+            continue
+
+        if source.exists():
+            result(
+                row,
+                BulkCreateResultStatus.duplicate,
+                "A source with this name already exists in the feed",
+            )
+            continue
+
+        try:
+            # New sources are created due for ingestion, so the scheduler
+            # drains a large import gradually instead of fetching hundreds
+            # of feeds at once.
+            feed.add_source(source)
+            result(row, BulkCreateResultStatus.created)
+        except Exception as e:
+            result(row, BulkCreateResultStatus.error, str(e))
+
+    counts = {status: 0 for status in BulkCreateResultStatus}
+    for r in results:
+        counts[r.status] += 1
+    return BulkCreateResponse(
+        results=results,
+        created=counts[BulkCreateResultStatus.created],
+        duplicates=counts[BulkCreateResultStatus.duplicate],
+        errors=counts[BulkCreateResultStatus.error],
+    )

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -47,6 +47,18 @@ function bindControls() {
   $('newFeedBtn').onclick = () => showModal('createFeedModal');
   $('createFeedForm').onsubmit = handleCreateFeed;
 
+  $('importBtn').onclick = openImportModal;
+  $('importParseBtn').onclick = handleImportParse;
+  $('importBackBtn').onclick = () => setImportStep('input');
+  $('importCreateBtn').onclick = handleImportCreate;
+  $('importSelectAll').onchange = (e) => {
+    importState.candidates.forEach((c) => { if (!c.error) c.selected = e.target.checked; });
+    renderImportCandidates();
+  };
+  $('importAssignApplyBtn').onclick = applyImportFeedToSelected;
+  $('importNewFeedBtn').onclick = createImportFeed;
+  $('importGroupFeedsBtn').onclick = createImportFeedsFromGroups;
+
   $('deleteFeedBtn').onclick = confirmDeleteFeed;
   $('renameFeedBtn').onclick = openRenameFeed;
   $('renameFeedForm').onsubmit = handleRenameFeed;
@@ -133,11 +145,13 @@ function onboardingWelcome() {
         step(1, 'Create a feed', 'A feed is a topic bucket, like "Technology" or "Sports".', true),
         step(2, 'Add sources', 'Point the feed at websites via templates or RSS URLs.', false),
         step(3, 'Read & vote', 'Articles roll in; upvote and downvote to tune your ranking.', false)),
-      h('div', { class: 'card-actions' },
+      h('div', { class: 'card-actions flex-col gap-2' },
         h('button', {
           class: 'btn btn-primary w-full',
           onclick: () => { onboardingContinue = true; showModal('createFeedModal'); $('newFeedName').focus(); },
-        }, 'Create your first feed'))));
+        }, 'Create your first feed'),
+        h('button', { class: 'btn btn-ghost btn-sm w-full', onclick: openImportModal },
+          'or import your Reddit / YouTube / Bluesky subscriptions'))));
 }
 
 function feedCard(feed) {
@@ -1224,6 +1238,300 @@ async function handleCreateManualSource(e) {
   } catch (err) {
     toast(err.message, 'alert-error');
   }
+}
+
+// ---------- bulk import ----------
+
+// Wizard for onboarding many sources at once: pick a platform and provide
+// subscription data (export file, pasted list, or username), review the
+// detected sources and assign each to a feed, then import.
+
+const IMPORT_PLATFORMS = {
+  reddit: {
+    label: 'Reddit',
+    help: 'Upload subscribed_subreddits.csv from your Reddit data export '
+      + '(reddit.com → Settings → Request data), or paste subreddit names or links below.',
+    fileAccept: '.csv,text/csv',
+    textPlaceholder: 'r/selfhosted\nr/alligators\nhttps://www.reddit.com/r/aquariums',
+  },
+  youtube: {
+    label: 'YouTube',
+    help: 'Upload subscriptions.csv from Google Takeout (takeout.google.com → '
+      + 'deselect all → YouTube → subscriptions only), or paste channel links or @handles below.',
+    fileAccept: '.csv,text/csv',
+    textPlaceholder: '@veritasium\nhttps://www.youtube.com/@kurzgesagt\nUCXuqSBlHAE6Xw-yeJA0Tunw',
+  },
+  bluesky: {
+    label: 'Bluesky',
+    help: 'Enter a Bluesky handle — every account it follows is fetched via '
+      + "Bluesky's public API, no login needed.",
+    username: true,
+  },
+  opml: {
+    label: 'RSS / OPML',
+    help: 'Upload the OPML file exported by your RSS reader or podcast app '
+      + '(Feedly, Inoreader, NewsBlur, AntennaPod, ...). Folders can become feeds.',
+    fileAccept: '.opml,.xml,text/xml,text/x-opml',
+    textPlaceholder: 'or paste OPML here',
+  },
+};
+
+let importState = { platform: 'reddit', candidates: [], feeds: [] };
+
+function openImportModal() {
+  importState = { platform: importState.platform, candidates: [], feeds: [] };
+  selectImportPlatform(importState.platform);
+  setImportStep('input');
+  showModal('importModal');
+  // feeds populate the per-row dropdowns on the review step
+  sdk.feedList().then((feeds) => { importState.feeds = feeds; }).catch(() => {});
+}
+
+function setImportStep(step) {
+  $('importStepInput').classList.toggle('hidden', step !== 'input');
+  $('importStepReview').classList.toggle('hidden', step !== 'review');
+  $('importStepResults').classList.toggle('hidden', step !== 'results');
+}
+
+function selectImportPlatform(platform) {
+  importState.platform = platform;
+  const cfg = IMPORT_PLATFORMS[platform];
+  render($('importPlatformTabs'),
+    Object.entries(IMPORT_PLATFORMS).map(([key, p]) =>
+      h('a', {
+        role: 'tab',
+        class: `tab${key === platform ? ' tab-active' : ''}`,
+        onclick: () => selectImportPlatform(key),
+      }, p.label)));
+  $('importHelp').textContent = cfg.help;
+  $('importFileControl').classList.toggle('hidden', !cfg.fileAccept);
+  $('importTextControl').classList.toggle('hidden', !cfg.textPlaceholder);
+  $('importUsernameControl').classList.toggle('hidden', !cfg.username);
+  if (cfg.fileAccept) $('importFile').setAttribute('accept', cfg.fileAccept);
+  $('importFile').value = '';
+  $('importText').value = '';
+  $('importText').placeholder = cfg.textPlaceholder || '';
+}
+
+const readFileText = (file) => new Promise((resolve, reject) => {
+  const reader = new FileReader();
+  reader.onload = () => resolve(reader.result);
+  reader.onerror = () => reject(new Error(`Couldn't read ${file.name}`));
+  reader.readAsText(file);
+});
+
+async function handleImportParse() {
+  const cfg = IMPORT_PLATFORMS[importState.platform];
+  const body = { platform: importState.platform };
+  if (cfg.username) {
+    body.username = $('importUsername').value.trim();
+    if (!body.username) { toast('Enter a handle first', 'alert-error'); return; }
+  } else {
+    // file and pasted text are combined so users can top up an export
+    const parts = [];
+    const file = $('importFile').files[0];
+    try {
+      if (file) parts.push(await readFileText(file));
+    } catch (err) {
+      toast(err.message, 'alert-error');
+      return;
+    }
+    if ($('importText').value.trim()) parts.push($('importText').value);
+    body.data = parts.join('\n');
+    if (!body.data.trim()) { toast('Upload a file or paste your subscriptions first', 'alert-error'); return; }
+  }
+
+  const btn = $('importParseBtn');
+  btn.disabled = true;
+  btn.textContent = 'Looking up…';
+  try {
+    const parsed = await sdk.importParse({ body });
+    // rows keep UI state (selected + target feed) alongside the candidate
+    const defaultFeed = importState.feeds.length === 1 ? importState.feeds[0].feed_name_hash : '';
+    importState.candidates = parsed.candidates.map((c) => ({
+      ...c,
+      selected: !c.error,
+      feedHash: defaultFeed,
+    }));
+    render($('importWarnings'), (parsed.warnings || []).map((w) =>
+      h('div', { class: 'text-xs text-warning' }, w)));
+    $('importGroupFeedsBtn').classList.toggle('hidden',
+      !importState.candidates.some((c) => c.group));
+    $('importSelectAll').checked = true;
+    renderImportFeedOptions();
+    renderImportCandidates();
+    setImportStep('review');
+  } catch (err) {
+    toast(err.message, 'alert-error');
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Find sources';
+  }
+}
+
+// The bulk-assign dropdown mirrors the per-row feed dropdowns.
+function renderImportFeedOptions() {
+  render($('importAssignFeed'),
+    h('option', { value: '' }, 'Pick a feed…'),
+    importState.feeds.map((f) => h('option', { value: f.feed_name_hash }, f.feed_name)));
+}
+
+function importFeedSelect(row) {
+  return h('select', {
+    class: `select select-bordered select-xs${row.feedHash ? '' : ' select-warning'}`,
+    onchange: (e) => { row.feedHash = e.target.value; renderImportCandidates(); },
+  },
+    h('option', { value: '', selected: !row.feedHash }, 'Pick a feed…'),
+    importState.feeds.map((f) =>
+      h('option', { value: f.feed_name_hash, selected: row.feedHash === f.feed_name_hash }, f.feed_name)));
+}
+
+function renderImportCandidates() {
+  const rows = importState.candidates;
+  const selected = rows.filter((r) => r.selected);
+  $('importSelectedCount').textContent =
+    `${selected.length} of ${rows.length} selected`;
+  $('importCreateBtn').disabled = !selected.length || selected.some((r) => !r.feedHash);
+  $('importCreateBtn').textContent = selected.length
+    ? `Import ${selected.length} source${selected.length === 1 ? '' : 's'}`
+    : 'Import';
+
+  render($('importCandidateList'), rows.map((row) =>
+    h('div', { class: `flex items-center gap-2 px-3 py-2 border-b border-base-300 last:border-b-0${row.error ? ' opacity-50' : ''}` },
+      h('input', {
+        type: 'checkbox', class: 'checkbox checkbox-sm checkbox-primary flex-shrink-0',
+        checked: row.selected, disabled: !!row.error,
+        onchange: (e) => { row.selected = e.target.checked; renderImportCandidates(); },
+      }),
+      h('div', { class: 'flex-1 min-w-0' },
+        h('input', {
+          type: 'text', class: 'input input-ghost input-xs w-full font-medium px-0',
+          value: row.name, title: 'Source name (editable)',
+          onchange: (e) => { row.name = e.target.value.trim() || row.name; },
+        }),
+        h('div', { class: `text-xs truncate ${row.error ? 'text-error' : 'text-base-content/40'}` },
+          row.error || [row.group, row.url].filter(Boolean).join(' · '))),
+      row.error ? null : importFeedSelect(row))));
+}
+
+function applyImportFeedToSelected() {
+  const feedHash = $('importAssignFeed').value;
+  if (!feedHash) { toast('Pick a feed to assign first', 'alert-error'); return; }
+  importState.candidates.forEach((row) => { if (row.selected) row.feedHash = feedHash; });
+  renderImportCandidates();
+}
+
+// Inline feed creation so the wizard works before any feed exists. The new
+// feed is assigned to the selected rows right away.
+async function createImportFeed() {
+  const name = prompt('Name for the new feed:');
+  if (!name || !name.trim()) return;
+  try {
+    const feed = await sdk.feedCreate({ feed_name: name.trim() });
+    if (!importState.feeds.some((f) => f.feed_name_hash === feed.feed_name_hash)) {
+      importState.feeds.push(feed);
+    }
+    renderImportFeedOptions();
+    $('importAssignFeed').value = feed.feed_name_hash;
+    importState.candidates.forEach((row) => { if (row.selected) row.feedHash = feed.feed_name_hash; });
+    renderImportCandidates();
+    toast(`Feed "${feed.feed_name}" created and assigned to selected sources`);
+  } catch (err) {
+    toast(err.message, 'alert-error');
+  }
+}
+
+// OPML folders map naturally onto Aggy feeds: create a feed per folder and
+// assign each source to its folder's feed.
+async function createImportFeedsFromGroups() {
+  const groups = [...new Set(importState.candidates.map((c) => c.group).filter(Boolean))];
+  if (!groups.length) return;
+  const btn = $('importGroupFeedsBtn');
+  btn.disabled = true;
+  try {
+    for (const group of groups) {
+      // feed/create returns the existing feed when the name is already taken
+      const feed = await sdk.feedCreate({ feed_name: group });
+      if (!importState.feeds.some((f) => f.feed_name_hash === feed.feed_name_hash)) {
+        importState.feeds.push(feed);
+      }
+      importState.candidates.forEach((row) => {
+        if (row.group === group) row.feedHash = feed.feed_name_hash;
+      });
+    }
+    renderImportFeedOptions();
+    renderImportCandidates();
+    toast(`Assigned sources to ${groups.length} feed${groups.length === 1 ? '' : 's'} from folders`);
+  } catch (err) {
+    toast(err.message, 'alert-error');
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+async function handleImportCreate() {
+  const rows = importState.candidates.filter((r) => r.selected);
+  if (!rows.length) return;
+  if (rows.some((r) => !r.feedHash)) {
+    toast('Every selected source needs a feed', 'alert-error');
+    return;
+  }
+
+  const btn = $('importCreateBtn');
+  btn.disabled = true;
+  btn.textContent = 'Importing…';
+  try {
+    const response = await sdk.importCreate({
+      body: {
+        sources: rows.map((r) => ({
+          feed_name_hash: r.feedHash,
+          source_name: r.name,
+          source_url: r.url,
+          template_name_hash: r.template_name_hash,
+          template_parameters: r.template_parameters,
+        })),
+      },
+    });
+    renderImportResults(response);
+    setImportStep('results');
+    loadFeeds();
+  } catch (err) {
+    toast(err.message, 'alert-error');
+  } finally {
+    btn.disabled = false;
+    renderImportCandidates();
+  }
+}
+
+function renderImportResults(response) {
+  const failed = response.results.filter((r) => r.status !== 'created');
+  const feedName = (hash) =>
+    (importState.feeds.find((f) => f.feed_name_hash === hash) || {}).feed_name || '';
+  render($('importResultsBody'),
+    h('div', { class: 'stats stats-horizontal shadow-none border border-base-300 w-full mb-3' },
+      h('div', { class: 'stat py-2' },
+        h('div', { class: 'stat-title text-xs' }, 'Imported'),
+        h('div', { class: 'stat-value text-lg text-success' }, String(response.created))),
+      h('div', { class: 'stat py-2' },
+        h('div', { class: 'stat-title text-xs' }, 'Already existed'),
+        h('div', { class: 'stat-value text-lg' }, String(response.duplicates))),
+      h('div', { class: 'stat py-2' },
+        h('div', { class: 'stat-title text-xs' }, 'Failed'),
+        h('div', { class: 'stat-value text-lg text-error' }, String(response.errors)))),
+    response.created
+      ? h('p', { class: 'text-xs text-base-content/60 mb-3' },
+          'Articles will roll in over the next hour or so as each new source is checked for the first time.')
+      : null,
+    failed.length
+      ? h('div', { class: 'max-h-[40vh] overflow-y-auto border border-base-300 rounded-lg' },
+          failed.map((r) =>
+            h('div', { class: 'px-3 py-2 border-b border-base-300 last:border-b-0' },
+              h('div', { class: 'text-sm font-medium' },
+                r.source_name,
+                h('span', { class: 'text-base-content/40 font-normal' }, ` → ${feedName(r.feed_name_hash)}`)),
+              h('div', { class: `text-xs ${r.status === 'error' ? 'text-error' : 'text-base-content/50'}` },
+                r.detail || r.status))))
+      : null);
 }
 
 // ---------- source templates ----------

--- a/src/api/static/js/sdk.js
+++ b/src/api/static/js/sdk.js
@@ -125,6 +125,16 @@ class AggySDK {
     return this._request("GET", "/health");
   }
 
+  /** Create many sources at once, each in its chosen feed */
+  async importCreate({ body }) {
+    return this._request("POST", "/import/create", { body });
+  }
+
+  /** Parse subscription data (export file, pasted list, or username) into source candidates */
+  async importParse({ body }) {
+    return this._request("POST", "/import/parse", { body });
+  }
+
   /** Get State */
   async itemGetState({ feed_hash, item_url_hash }) {
     return this._request("GET", "/item/get_state", { query: { feed_hash, item_url_hash } });

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -26,7 +26,10 @@
         <h1 class="text-2xl font-bold">Your Feeds</h1>
         <p class="text-sm text-base-content/60 mt-1">Curated content, ranked by relevance</p>
       </div>
-      <button class="btn btn-primary btn-sm" id="newFeedBtn">+ New Feed</button>
+      <div class="flex gap-2">
+        <button class="btn btn-ghost btn-sm" id="importBtn">Import</button>
+        <button class="btn btn-primary btn-sm" id="newFeedBtn">+ New Feed</button>
+      </div>
     </div>
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" id="feedGrid"></div>
   </div>
@@ -293,6 +296,68 @@
     <div class="modal-action">
       <button type="button" class="btn btn-ghost" data-close-modal>Cancel</button>
       <button class="btn btn-primary" id="editSourceSaveBtn">Save Changes</button>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
+
+<!-- Import Subscriptions Modal -->
+<dialog class="modal" id="importModal">
+  <div class="modal-box max-w-3xl">
+    <form method="dialog"><button class="btn btn-sm btn-circle btn-ghost absolute right-4 top-4">✕</button></form>
+    <h3 class="text-lg font-bold mb-1">Import Subscriptions</h3>
+    <p class="text-xs text-base-content/60 mb-4">
+      Bring your subscriptions over in bulk, then pick which feed each source goes to.
+    </p>
+
+    <!-- Step 1: platform & data -->
+    <div id="importStepInput">
+      <div role="tablist" class="tabs tabs-boxed mb-3" id="importPlatformTabs"></div>
+      <p class="text-xs text-base-content/60 mb-3" id="importHelp"></p>
+      <div class="form-control mb-3" id="importFileControl">
+        <input type="file" class="file-input file-input-bordered w-full" id="importFile">
+      </div>
+      <div class="form-control mb-3" id="importTextControl">
+        <textarea class="textarea textarea-bordered w-full" rows="4" id="importText"></textarea>
+      </div>
+      <div class="form-control mb-3 hidden" id="importUsernameControl">
+        <input type="text" class="input input-bordered w-full" id="importUsername" placeholder="you.bsky.social">
+      </div>
+      <div class="modal-action">
+        <button type="button" class="btn btn-ghost" data-close-modal>Cancel</button>
+        <button class="btn btn-primary" id="importParseBtn">Find sources</button>
+      </div>
+    </div>
+
+    <!-- Step 2: review & assign feeds -->
+    <div id="importStepReview" class="hidden">
+      <div class="flex flex-wrap items-center gap-2 mb-3">
+        <span class="text-xs text-base-content/60">Assign selected to</span>
+        <select class="select select-bordered select-sm" id="importAssignFeed"></select>
+        <button class="btn btn-sm" id="importAssignApplyBtn">Apply</button>
+        <button class="btn btn-sm btn-ghost" id="importNewFeedBtn">+ New feed</button>
+        <button class="btn btn-sm btn-ghost hidden" id="importGroupFeedsBtn"
+          title="Create a feed for each folder in the import and assign its sources to it">
+          Use folders as feeds</button>
+      </div>
+      <label class="label cursor-pointer justify-start gap-2 py-1">
+        <input type="checkbox" class="checkbox checkbox-sm checkbox-primary" id="importSelectAll" checked>
+        <span class="label-text text-xs" id="importSelectedCount"></span>
+      </label>
+      <div class="max-h-[45vh] overflow-y-auto border border-base-300 rounded-lg" id="importCandidateList"></div>
+      <div id="importWarnings" class="mt-2 flex flex-col gap-1"></div>
+      <div class="modal-action">
+        <button class="btn btn-ghost" id="importBackBtn">Back</button>
+        <button class="btn btn-primary" id="importCreateBtn">Import</button>
+      </div>
+    </div>
+
+    <!-- Step 3: results -->
+    <div id="importStepResults" class="hidden">
+      <div id="importResultsBody"></div>
+      <div class="modal-action">
+        <button type="button" class="btn btn-primary" data-close-modal>Done</button>
+      </div>
     </div>
   </div>
   <form method="dialog" class="modal-backdrop"><button>close</button></form>

--- a/src/api/tests/bulk_import_test.py
+++ b/src/api/tests/bulk_import_test.py
@@ -1,0 +1,225 @@
+import pytest
+
+import bulk_import
+from bulk_import import (
+    fetch_bluesky_follows,
+    normalize_bluesky_handle,
+    parse_opml,
+    parse_reddit,
+    parse_youtube,
+)
+
+
+# ---------------------------------------------------------------------------
+# reddit
+# ---------------------------------------------------------------------------
+
+
+def test_parse_reddit_export_csv():
+    candidates, warnings = parse_reddit("subreddit\nselfhosted\nalligators\n")
+
+    assert warnings == []
+    assert [c.name for c in candidates] == ["r/selfhosted", "r/alligators"]
+    assert candidates[0].url == "https://www.reddit.com/r/selfhosted/top.rss?t=day"
+    assert candidates[0].template_parameters == {"subreddit": "selfhosted"}
+    assert candidates[0].template_name_hash
+
+
+def test_parse_reddit_pasted_mixed_formats():
+    text = "r/foo, /r/bar\nhttps://www.reddit.com/r/baz/ https://old.reddit.com/r/qux"
+    candidates, warnings = parse_reddit(text)
+
+    assert [c.name for c in candidates] == ["r/foo", "r/bar", "r/baz", "r/qux"]
+    assert warnings == []
+
+
+def test_parse_reddit_dedupes_and_warns_on_junk():
+    candidates, warnings = parse_reddit("r/foo\nfoo\n!!!")
+
+    assert [c.name for c in candidates] == ["r/foo"]
+    assert len(warnings) == 1
+    assert "!!!" in warnings[0]
+
+
+# ---------------------------------------------------------------------------
+# youtube
+# ---------------------------------------------------------------------------
+
+CHANNEL_ID = "UCXuqSBlHAE6Xw-yeJA0Tunw"
+OTHER_CHANNEL_ID = "UCsXVk37bltHxD1rDPwtNM8Q"
+
+TAKEOUT_CSV = (
+    "Channel Id,Channel Url,Channel Title\n"
+    f"{CHANNEL_ID},http://www.youtube.com/channel/{CHANNEL_ID},Linus Tech Tips\n"
+    f"{OTHER_CHANNEL_ID},http://www.youtube.com/channel/{OTHER_CHANNEL_ID},Kurzgesagt\n"
+)
+
+
+def test_parse_youtube_takeout_csv():
+    candidates, warnings = parse_youtube(TAKEOUT_CSV, resolver=None)
+
+    assert warnings == []
+    assert [c.name for c in candidates] == ["Linus Tech Tips", "Kurzgesagt"]
+    assert candidates[0].url == (
+        f"https://www.youtube.com/feeds/videos.xml?channel_id={CHANNEL_ID}"
+    )
+    assert candidates[0].template_parameters == {"channel_id": CHANNEL_ID}
+
+
+def test_parse_youtube_pasted_ids_and_urls_need_no_resolution():
+    text = f"https://www.youtube.com/channel/{CHANNEL_ID}\n{OTHER_CHANNEL_ID}"
+    candidates, warnings = parse_youtube(text, resolver=None)
+
+    assert warnings == []
+    assert [c.template_parameters["channel_id"] for c in candidates] == [
+        CHANNEL_ID,
+        OTHER_CHANNEL_ID,
+    ]
+
+
+def test_parse_youtube_resolves_handles():
+    resolved = []
+
+    def resolver(page_url):
+        resolved.append(page_url)
+        return CHANNEL_ID, "Veritasium"
+
+    candidates, warnings = parse_youtube(
+        "@veritasium https://www.youtube.com/@veritasium", resolver=resolver
+    )
+
+    # the handle and its URL form resolve to the same channel and dedupe
+    assert resolved == [
+        "https://www.youtube.com/@veritasium",
+        "https://www.youtube.com/@veritasium",
+    ]
+    assert len(candidates) == 1
+    assert candidates[0].name == "Veritasium"
+    assert candidates[0].template_parameters == {"channel_id": CHANNEL_ID}
+
+
+def test_parse_youtube_marks_failed_resolutions():
+    def resolver(page_url):
+        raise ValueError("no channel id found on page")
+
+    candidates, _ = parse_youtube("@doesnotexist", resolver=resolver)
+
+    assert len(candidates) == 1
+    assert candidates[0].url is None
+    assert candidates[0].error
+
+
+# ---------------------------------------------------------------------------
+# opml
+# ---------------------------------------------------------------------------
+
+OPML = """<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>Subscriptions</title></head>
+  <body>
+    <outline text="Tech">
+      <outline text="Hacker News" xmlUrl="https://news.ycombinator.com/rss"/>
+      <outline text="Lobsters" title="Lobsters!" xmlUrl="https://lobste.rs/rss"/>
+    </outline>
+    <outline text="No Folder" xmlUrl="https://example.com/feed.xml"/>
+  </body>
+</opml>
+"""
+
+
+def test_parse_opml_keeps_folder_groups():
+    candidates, warnings = parse_opml(OPML)
+
+    assert warnings == []
+    assert [(c.name, c.group) for c in candidates] == [
+        ("Hacker News", "Tech"),
+        ("Lobsters!", "Tech"),
+        ("No Folder", None),
+    ]
+    assert candidates[0].url == "https://news.ycombinator.com/rss"
+
+
+def test_parse_opml_rejects_invalid_xml():
+    with pytest.raises(ValueError):
+        parse_opml("this is not opml")
+
+
+# ---------------------------------------------------------------------------
+# bluesky
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_bluesky_handle():
+    assert normalize_bluesky_handle("@jay.bsky.team") == "jay.bsky.team"
+    assert normalize_bluesky_handle("jay") == "jay.bsky.social"
+    assert (
+        normalize_bluesky_handle("https://bsky.app/profile/jay.bsky.team")
+        == "jay.bsky.team"
+    )
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+        self.status_code = 200
+
+    def json(self):
+        return self.payload
+
+    def raise_for_status(self):
+        pass
+
+
+class _FakeClient:
+    """Stands in for httpx.Client, returning canned paginated responses."""
+
+    def __init__(self, pages):
+        self.pages = list(pages)
+        self.requests = []
+
+    def __call__(self, **kwargs):  # httpx.Client(...) -> self
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def get(self, url, params=None):
+        self.requests.append(params)
+        return _FakeResponse(self.pages.pop(0))
+
+
+def test_fetch_bluesky_follows_paginates(monkeypatch):
+    pages = [
+        {
+            "cursor": "page2",
+            "follows": [
+                {"handle": "alice.bsky.social", "displayName": "Alice"},
+                {"handle": "handle.invalid", "displayName": "Deleted"},
+            ],
+        },
+        {
+            "follows": [{"handle": "bob.example.com", "displayName": ""}],
+        },
+    ]
+    fake = _FakeClient(pages)
+    monkeypatch.setattr(bulk_import.httpx, "Client", fake)
+
+    candidates, warnings = fetch_bluesky_follows("@me.bsky.social")
+
+    assert warnings == []
+    assert fake.requests[0]["actor"] == "me.bsky.social"
+    assert fake.requests[1]["cursor"] == "page2"
+    # deleted accounts are skipped; missing display names fall back to handle
+    assert [(c.name, c.url) for c in candidates] == [
+        ("Alice", "https://bsky.app/profile/alice.bsky.social/rss"),
+        ("bob.example.com", "https://bsky.app/profile/bob.example.com/rss"),
+    ]
+    assert candidates[0].template_parameters == {"handle": "alice.bsky.social"}
+
+
+def test_fetch_bluesky_follows_rejects_empty_handle():
+    with pytest.raises(ValueError):
+        fetch_bluesky_follows("   ")

--- a/src/api/tests/routers/bulk_import_test.py
+++ b/src/api/tests/routers/bulk_import_test.py
@@ -1,0 +1,176 @@
+from builtin_templates import builtin_template, create_builtin_source_templates
+from tests.testing_utils import build_api_request_args
+
+
+def parse_args(data, token):
+    return build_api_request_args(path="/import/parse", data=data, token=token)
+
+
+def create_args(sources, token):
+    return build_api_request_args(
+        path="/import/create", data={"sources": sources}, token=token
+    )
+
+
+def test_parse_requires_auth(client):
+    response = client.post(
+        "/import/parse", json={"platform": "reddit", "data": "r/selfhosted"}
+    )
+
+    assert response.status_code == 401
+
+
+def test_parse_reddit(client, token):
+    args = parse_args(
+        {"platform": "reddit", "data": "r/selfhosted\nr/alligators"}, token
+    )
+
+    response = client.post(**args)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [c["name"] for c in body["candidates"]] == ["r/selfhosted", "r/alligators"]
+    assert body["candidates"][0]["template_parameters"] == {"subreddit": "selfhosted"}
+
+
+def test_parse_opml_with_groups(client, token):
+    opml = (
+        '<opml version="2.0"><body><outline text="Tech">'
+        '<outline text="HN" xmlUrl="https://news.ycombinator.com/rss"/>'
+        "</outline></body></opml>"
+    )
+    args = parse_args({"platform": "opml", "data": opml}, token)
+
+    response = client.post(**args)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["candidates"] == [
+        {
+            "name": "HN",
+            "url": "https://news.ycombinator.com/rss",
+            "group": "Tech",
+            "template_name_hash": None,
+            "template_parameters": None,
+            "error": None,
+        }
+    ]
+
+
+def test_parse_empty_data_rejected(client, token):
+    args = parse_args({"platform": "reddit", "data": "   "}, token)
+
+    response = client.post(**args)
+
+    assert response.status_code == 422
+
+
+def test_parse_no_candidates_rejected(client, token):
+    args = parse_args({"platform": "reddit", "data": "!!!"}, token)
+
+    response = client.post(**args)
+
+    assert response.status_code == 422
+
+
+def test_parse_bluesky_requires_username(client, token):
+    args = parse_args({"platform": "bluesky"}, token)
+
+    response = client.post(**args)
+
+    assert response.status_code == 422
+
+
+def test_bulk_create_raw_urls(client, existing_feed, token):
+    sources = [
+        {
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name": "HN",
+            "source_url": "https://news.ycombinator.com/rss",
+        },
+        {
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name": "Lobsters",
+            "source_url": "https://lobste.rs/rss",
+        },
+    ]
+
+    response = client.post(**create_args(sources, token))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["created"] == 2
+    assert body["duplicates"] == 0
+    assert body["errors"] == 0
+    assert {r["status"] for r in body["results"]} == {"created"}
+
+    # importing the same rows again reports duplicates instead of failing
+    response = client.post(**create_args(sources, token))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["created"] == 0
+    assert body["duplicates"] == 2
+
+
+def test_bulk_create_from_template(client, existing_feed, token):
+    create_builtin_source_templates()
+    template = builtin_template("Reddit Subreddit")
+    sources = [
+        {
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name": "r/selfhosted",
+            "template_name_hash": template.name_hash,
+            "template_parameters": {"subreddit": "selfhosted"},
+        }
+    ]
+
+    response = client.post(**create_args(sources, token))
+
+    assert response.status_code == 200
+    assert response.json()["created"] == 1
+
+    created = existing_feed.sources[0]
+    assert str(created.url) == "https://www.reddit.com/r/selfhosted/top.rss?t=day"
+
+
+def test_bulk_create_reports_per_row_errors(client, existing_feed, token):
+    sources = [
+        {
+            "feed_name_hash": "not_a_feed",
+            "source_name": "HN",
+            "source_url": "https://news.ycombinator.com/rss",
+        },
+        {
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name": "No URL",
+        },
+        {
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name": "Bad URL",
+            "source_url": "not a url",
+        },
+        {
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name": "Good",
+            "source_url": "https://example.com/feed.xml",
+        },
+    ]
+
+    response = client.post(**create_args(sources, token))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["created"] == 1
+    assert body["errors"] == 3
+    statuses = {r["source_name"]: r["status"] for r in body["results"]}
+    assert statuses == {
+        "HN": "error",
+        "No URL": "error",
+        "Bad URL": "error",
+        "Good": "created",
+    }
+    assert (
+        next(r for r in body["results"] if r["source_name"] == "HN")["detail"]
+        == "Feed not found"
+    )


### PR DESCRIPTION
## What

A new **Import** wizard on the dashboard onboards large numbers of sources at once. The user provides their subscription data, reviews the detected sources, and picks which feed each one goes to.

### Supported platforms & inputs

| Platform | How the user provides subscriptions |
|---|---|
| **Reddit** | GDPR data export (`subscribed_subreddits.csv`) upload, or a pasted list of subreddit names/links in any format (`r/foo`, `/r/foo`, full URLs, comma- or newline-separated). Reddit doesn't expose another user's subscriptions publicly, so a bare username can't work here. |
| **YouTube** | Google Takeout `subscriptions.csv` upload (channel IDs map straight to native RSS), or pasted channel URLs / `@handles` / channel IDs — handles and custom URLs are resolved to channel IDs server-side (capped at 50 lookups per request). |
| **Bluesky** | Just a handle — the public AT-proto API lists anyone's follows with no auth, and every profile has native RSS. This is the "type your username" flow. |
| **RSS / OPML** | The standard export of any RSS reader or podcast app (Feedly, Inoreader, NewsBlur, AntennaPod, …). |

### UX flow

1. **Input step** — platform tabs, per-platform help text, file upload and/or smart paste box (file + paste are combined), or a handle field for Bluesky.
2. **Review step** — every detected source as a row with a checkbox, an *editable* name, its resolved URL, and a per-row feed dropdown. Toolbar offers *assign selected to feed*, *inline new-feed creation*, and — when the import has OPML folders — a one-click **"Use folders as feeds"** that creates a feed per folder and assigns its sources. Unresolvable entries show as disabled rows with the error; junk tokens surface as a skip warning. Import stays disabled until every selected row has a feed. With exactly one feed, rows auto-assign to it.
3. **Results step** — created / already-existed / failed counts, with per-row detail for anything that didn't import.

The first-run onboarding card also gains an "or import your subscriptions" shortcut.

### Backend

- `POST /import/parse` — turns export-file content, pasted text, or a handle into source candidates (`src/api/bulk_import.py` holds the per-platform parsers; the YouTube page-fetch resolver is injectable so tests never touch the network).
- `POST /import/create` — creates many sources across feeds in one call with per-row `created` / `duplicate` / `error` results (row failures never abort the batch; capped at 2000 rows).
- New built-in **YouTube Channel** and **Bluesky User** templates (native RSS, no rss-bridge). Imported Reddit/YouTube/Bluesky sources reference their templates, so they stay editable through the existing template UI.
- No ingest stampede: bulk-created sources are simply due for ingestion, so the existing scheduler drains a large import gradually (the results screen tells the user articles will roll in over the next hour or so).

## Testing

- 21 new tests: parser units (Reddit CSV/paste, Takeout CSV, handle resolution success/failure, OPML folders, Bluesky pagination with a fake client) and router tests (parse + bulk create happy paths, duplicates, per-row errors, auth).
- Full suite run against a local Postgres 16 + migrations: **234 passed**; the 11 failures are identical to the baseline on `main` in the same environment (missing rss-bridge container, locale-dependent date parsing) — no regressions.
- `generate_sdk.py --check` passes (sdk.js regenerated).
- Verified end-to-end in Chromium via Playwright with the real Tailwind build: paste → review → inline feed creation → import → duplicate detection on re-import → OPML "use folders as feeds", with zero console/page errors. Live YouTube/Bluesky lookups couldn't be exercised from this sandbox (egress proxy 403s those domains); their failure paths degrade as designed (per-row error / friendly 502).

## Notes for reviewers

- Platforms considered but deferred: Mastodon (following CSV export → `https://instance/@user.rss`) and Twitch would slot into the same parser + template pattern if wanted.
- `main.py`'s new import line adds one more pre-existing-style E402 (imports intentionally follow the BLAS env setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013n8WXXvUay9nDuycwMdrgr

---
_Generated by [Claude Code](https://claude.ai/code/session_013n8WXXvUay9nDuycwMdrgr)_