### PR TITLE
Add lists (playlists) feature and fix landscape video sizing

### DIFF
--- a/src/api/db/base.py
+++ b/src/api/db/base.py
@@ -97,6 +97,8 @@ class AggyBaseModel(BaseModel):
 # Tables managed by Flyway. Listed for use by the test/dev flush helper.
 _ALL_TABLES = (
     "ranking_model_stats",
+    "list_items",
+    "lists",
     "item_states",
     "source_items",
     "feed_items",

--- a/src/api/db/feed.py
+++ b/src/api/db/feed.py
@@ -146,6 +146,9 @@ class Feed(ItemCollection):
             "SELECT i.*, c.score, c.added_at, "
             "c.predicted_score, c.predicted_confidence, "
             "st.score AS user_score, st.is_read AS is_read, "
+            "EXISTS (SELECT 1 FROM list_items li"
+            " WHERE li.user_hash = c.user_hash"
+            "  AND li.item_url_hash = c.item_url_hash) AS in_list, "
             "src.name AS source_name, src.color AS source_color, "
             "ROW_NUMBER() OVER (PARTITION BY src.name_hash "
             f"ORDER BY {order_by}) AS source_rank "
@@ -219,6 +222,7 @@ class Feed(ItemCollection):
                 "source_color": row.pop("source_color", None),
                 "user_score": row.pop("user_score", None),
                 "is_read": row.pop("is_read", None),
+                "in_list": row.pop("in_list", None),
                 "predicted_score": row.pop("predicted_score", None),
                 "predicted_confidence": row.pop("predicted_confidence", None),
             }

--- a/src/api/db/list.py
+++ b/src/api/db/list.py
@@ -1,0 +1,154 @@
+from typing import List, Optional
+
+from pydantic import StringConstraints
+from typing_extensions import Annotated
+
+from .base import AggyBaseModel
+from .item import ItemStrict
+from .user import User
+
+
+class UserList(AggyBaseModel):
+    """A user-owned, playlist-like collection of items.
+
+    Lists span feeds: any item may belong to any number of a user's lists.
+    Membership doubles as a positive ranking signal (see ranking/engine.py).
+    """
+
+    user_hash: str
+    name: Annotated[str, StringConstraints(strict=True, min_length=1)]
+
+    @property
+    def key(self):
+        return f"USER:{self.user_hash}:LIST:{self.name_hash}"
+
+    @property
+    def name_hash(self):
+        return self.__insecure_hash__(self.name)
+
+    def exists(self) -> bool:
+        with self.db_con() as cur:
+            cur.execute(
+                "SELECT 1 FROM lists WHERE user_hash = %s AND name_hash = %s",
+                (self.user_hash, self.name_hash),
+            )
+            return cur.fetchone() is not None
+
+    def create(self):
+        # check the owner exists (raises if missing)
+        User.read(self.user_hash)
+
+        if self.exists():
+            raise ValueError(f"List with name {self.name} already exists")
+
+        with self.db_con() as cur:
+            cur.execute(
+                "INSERT INTO lists (user_hash, name_hash, name) VALUES (%s, %s, %s)",
+                (self.user_hash, self.name_hash, self.name),
+            )
+
+        return self.key
+
+    def delete(self):
+        # ON DELETE CASCADE removes this list's memberships.
+        with self.db_con() as cur:
+            cur.execute(
+                "DELETE FROM lists WHERE user_hash = %s AND name_hash = %s",
+                (self.user_hash, self.name_hash),
+            )
+
+    def item_count(self) -> int:
+        with self.db_con() as cur:
+            cur.execute(
+                "SELECT COUNT(*) AS n FROM list_items "
+                "WHERE user_hash = %s AND list_hash = %s",
+                (self.user_hash, self.name_hash),
+            )
+            return cur.fetchone()["n"]
+
+    def contains(self, item_url_hash: str) -> bool:
+        with self.db_con() as cur:
+            cur.execute(
+                "SELECT 1 FROM list_items "
+                "WHERE user_hash = %s AND list_hash = %s AND item_url_hash = %s",
+                (self.user_hash, self.name_hash, item_url_hash),
+            )
+            return cur.fetchone() is not None
+
+    def add_item(self, item_url_hash: str) -> None:
+        with self.db_con() as cur:
+            cur.execute(
+                "INSERT INTO list_items (user_hash, list_hash, item_url_hash) "
+                "VALUES (%s, %s, %s) ON CONFLICT DO NOTHING",
+                (self.user_hash, self.name_hash, item_url_hash),
+            )
+
+    def remove_item(self, item_url_hash: str) -> None:
+        with self.db_con() as cur:
+            cur.execute(
+                "DELETE FROM list_items "
+                "WHERE user_hash = %s AND list_hash = %s AND item_url_hash = %s",
+                (self.user_hash, self.name_hash, item_url_hash),
+            )
+
+    def items(self) -> List[ItemStrict]:
+        with self.db_con() as cur:
+            cur.execute(
+                "SELECT i.* FROM items i "
+                "JOIN list_items li ON li.item_url_hash = i.url_hash "
+                "WHERE li.user_hash = %s AND li.list_hash = %s "
+                "ORDER BY li.added_at DESC",
+                (self.user_hash, self.name_hash),
+            )
+            rows = cur.fetchall()
+        return [ItemStrict.from_row(row) for row in rows if row]
+
+    @classmethod
+    def read(cls, user_hash, name_hash) -> Optional["UserList"]:
+        with cls.db_con() as cur:
+            cur.execute(
+                "SELECT name FROM lists WHERE user_hash = %s AND name_hash = %s",
+                (user_hash, name_hash),
+            )
+            row = cur.fetchone()
+
+        if row:
+            return cls(user_hash=user_hash, name=row["name"])
+        return None
+
+    @classmethod
+    def read_all(cls, user_hash) -> List["UserList"]:
+        with cls.db_con() as cur:
+            cur.execute(
+                "SELECT name FROM lists WHERE user_hash = %s ORDER BY name",
+                (user_hash,),
+            )
+            rows = cur.fetchall()
+        return [cls(user_hash=user_hash, name=row["name"]) for row in rows]
+
+    @classmethod
+    def set_item_membership(
+        cls, user_hash: str, item_url_hash: str, list_hashes: List[str]
+    ) -> None:
+        """Make the item belong to exactly ``list_hashes`` (of the user's own
+        lists) and no others — the "submit" from the add-to-list checklist.
+
+        Hashes that don't name one of the user's lists are ignored.
+        """
+        wanted = set(list_hashes or [])
+        owned = {lst.name_hash for lst in cls.read_all(user_hash)}
+        wanted &= owned
+
+        with cls.db_con() as cur:
+            # drop memberships the user unchecked
+            cur.execute(
+                "DELETE FROM list_items "
+                "WHERE user_hash = %s AND item_url_hash = %s",
+                (user_hash, item_url_hash),
+            )
+            for list_hash in wanted:
+                cur.execute(
+                    "INSERT INTO list_items (user_hash, list_hash, item_url_hash) "
+                    "VALUES (%s, %s, %s) ON CONFLICT DO NOTHING",
+                    (user_hash, list_hash, item_url_hash),
+                )

--- a/src/api/db/migrations/V11__lists.sql
+++ b/src/api/db/migrations/V11__lists.sql
@@ -1,0 +1,27 @@
+-- User "lists" (playlist-like collections of items).
+--
+-- Lists belong to a user and span feeds: any item the user can see may be
+-- dropped into one or more lists. Membership in a list also feeds the ranking
+-- model as an extra positive signal (see ranking/engine.py), so a listed item
+-- is treated like an upvote even without an explicit vote.
+
+CREATE TABLE lists (
+    user_hash  TEXT NOT NULL REFERENCES users(name_hash) ON DELETE CASCADE,
+    name_hash  TEXT NOT NULL,
+    name       TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_hash, name_hash)
+);
+
+CREATE TABLE list_items (
+    user_hash     TEXT NOT NULL,
+    list_hash     TEXT NOT NULL,
+    item_url_hash TEXT NOT NULL REFERENCES items(url_hash) ON DELETE CASCADE,
+    added_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_hash, list_hash, item_url_hash),
+    FOREIGN KEY (user_hash, list_hash)
+        REFERENCES lists(user_hash, name_hash) ON DELETE CASCADE
+);
+
+-- Ranking joins list membership per (user, item) across the feed's items.
+CREATE INDEX list_items_user_item_idx ON list_items(user_hash, item_url_hash);

--- a/src/api/generate_sdk.py
+++ b/src/api/generate_sdk.py
@@ -28,6 +28,7 @@ def build_app():
     from routers.source_analyze import source_analyze_router
     from routers.bulk_import import bulk_import_router
     from routers.item import item_router
+    from routers.list import list_router
 
     app = FastAPI()
     app.include_router(admin_router, tags=["Admin"])
@@ -42,6 +43,7 @@ def build_app():
     )
     app.include_router(bulk_import_router, prefix="/import", tags=["Bulk Import"])
     app.include_router(item_router, prefix="/item", tags=["Items"])
+    app.include_router(list_router, prefix="/list", tags=["Lists"])
     return app
 
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -30,6 +30,7 @@ from routers.source import source_router
 from routers.source_analyze import source_analyze_router
 from routers.bulk_import import bulk_import_router
 from routers.item import item_router
+from routers.list import list_router
 from routers.web import web_router
 from bridge.jobs import rss_bridge_get_templates_job
 from builtin_templates import create_builtin_source_templates
@@ -131,6 +132,7 @@ app.include_router(
 )
 app.include_router(bulk_import_router, prefix="/import", tags=["Bulk Import"])
 app.include_router(item_router, prefix="/item", tags=["Items"])
+app.include_router(list_router, prefix="/list", tags=["Lists"])
 app.include_router(web_router)
 
 

--- a/src/api/ranking/engine.py
+++ b/src/api/ranking/engine.py
@@ -40,6 +40,20 @@ def _parse_embedding(embeddings) -> Optional[np.ndarray]:
     return None
 
 
+def _effective_label(vote, list_added_at):
+    """Fold list membership into the training label.
+
+    Adding an item to a list counts as an extra positive vote: it lifts the
+    label by one upvote (clamped to the +1..-1 vote scale). An unvoted but
+    listed item therefore reads as an upvote; a downvoted-but-listed one lands
+    back at neutral.
+    """
+    if list_added_at is None:
+        return vote
+    base = 0.0 if vote is None else float(vote)
+    return max(-1.0, min(1.0, base + 1.0))
+
+
 def _row_to_features(row) -> ItemFeatures:
     media = row.get("media")
     if isinstance(media, str):
@@ -47,6 +61,7 @@ def _row_to_features(row) -> ItemFeatures:
             media = json.loads(media)
         except (TypeError, ValueError):
             media = None
+    list_added_at = row.get("list_added_at")
     return ItemFeatures(
         url_hash=row["url_hash"],
         embedding=_parse_embedding(row.get("embeddings")),
@@ -55,8 +70,9 @@ def _row_to_features(row) -> ItemFeatures:
         date_published=row.get("date_published"),
         has_image=bool(row.get("image_url")),
         has_media=bool(media),
-        label=row.get("vote"),
-        label_date=row.get("vote_date"),
+        label=_effective_label(row.get("vote"), list_added_at),
+        # an unvoted-but-listed item is labelled as of when it was listed
+        label_date=row.get("vote_date") or list_added_at,
     )
 
 
@@ -67,7 +83,12 @@ _FEED_ITEMS_SQL = (
     " JOIN sources s ON s.user_hash = si.user_hash"
     "  AND s.feed_hash = si.feed_hash AND s.name_hash = si.source_hash"
     " WHERE si.user_hash = c.user_hash AND si.feed_hash = c.feed_hash"
-    "  AND si.item_url_hash = c.item_url_hash LIMIT 1) AS source_name "
+    "  AND si.item_url_hash = c.item_url_hash LIMIT 1) AS source_name, ("
+    # earliest time this item was added to any of the user's lists; a listed
+    # item counts as an extra positive vote (see _effective_label)
+    " SELECT MIN(li.added_at) FROM list_items li"
+    " WHERE li.user_hash = c.user_hash"
+    "  AND li.item_url_hash = c.item_url_hash) AS list_added_at "
     "FROM feed_items c "
     "JOIN items i ON i.url_hash = c.item_url_hash "
     "LEFT JOIN item_states st ON st.user_hash = c.user_hash "
@@ -171,21 +192,33 @@ def rank_feed(feed: Feed) -> List[ModelStats]:
 
 
 def feeds_needing_rank() -> List[Feed]:
-    """Feeds with at least one vote where votes or items are newer than the
+    """Feeds with at least one label — an explicit vote or a listed item, since
+    list membership counts as a vote — where a label or item is newer than the
     latest prediction (or no prediction exists yet)."""
     with get_db_con() as cur:
         cur.execute(
-            "SELECT f.user_hash, f.name FROM feeds f WHERE EXISTS ("
-            " SELECT 1 FROM item_states st"
-            " WHERE st.user_hash = f.user_hash AND st.feed_hash = f.name_hash"
-            "  AND st.score IS NOT NULL"
+            "SELECT f.user_hash, f.name FROM feeds f WHERE ("
+            " EXISTS (SELECT 1 FROM item_states st"
+            "  WHERE st.user_hash = f.user_hash AND st.feed_hash = f.name_hash"
+            "   AND st.score IS NOT NULL)"
+            " OR EXISTS (SELECT 1 FROM feed_items c"
+            "  JOIN list_items li ON li.user_hash = c.user_hash"
+            "   AND li.item_url_hash = c.item_url_hash"
+            "  WHERE c.user_hash = f.user_hash AND c.feed_hash = f.name_hash)"
             ") AND ("
             " EXISTS (SELECT 1 FROM feed_items c"
             "  WHERE c.user_hash = f.user_hash AND c.feed_hash = f.name_hash"
             "   AND c.predicted_at IS NULL)"
-            " OR COALESCE((SELECT MAX(st.score_date) FROM item_states st"
-            "  WHERE st.user_hash = f.user_hash AND st.feed_hash = f.name_hash),"
-            "  'epoch') > COALESCE((SELECT MAX(c.predicted_at) FROM feed_items c"
+            " OR GREATEST("
+            "  COALESCE((SELECT MAX(st.score_date) FROM item_states st"
+            "   WHERE st.user_hash = f.user_hash AND st.feed_hash = f.name_hash),"
+            "   'epoch'),"
+            "  COALESCE((SELECT MAX(li.added_at) FROM feed_items c"
+            "   JOIN list_items li ON li.user_hash = c.user_hash"
+            "    AND li.item_url_hash = c.item_url_hash"
+            "   WHERE c.user_hash = f.user_hash AND c.feed_hash = f.name_hash),"
+            "   'epoch')"
+            " ) > COALESCE((SELECT MAX(c.predicted_at) FROM feed_items c"
             "  WHERE c.user_hash = f.user_hash AND c.feed_hash = f.name_hash),"
             "  'epoch'))",
         )

--- a/src/api/route_models/item.py
+++ b/src/api/route_models/item.py
@@ -22,6 +22,7 @@ class ItemResponse(BaseRouteModel):
     item_source_color: Optional[str] = None
     item_user_score: Optional[float] = None
     item_is_read: Optional[bool] = None
+    item_in_list: Optional[bool] = None
     item_predicted_score: Optional[float] = None
     item_predicted_confidence: Optional[float] = None
 
@@ -48,6 +49,7 @@ class ItemResponse(BaseRouteModel):
         source_color: str = None,
         user_score: float = None,
         is_read: bool = None,
+        in_list: bool = None,
         predicted_score: float = None,
         predicted_confidence: float = None,
     ):
@@ -56,6 +58,7 @@ class ItemResponse(BaseRouteModel):
             item_source_color=source_color,
             item_user_score=user_score,
             item_is_read=is_read,
+            item_in_list=in_list,
             item_predicted_score=predicted_score,
             item_predicted_confidence=predicted_confidence,
             item_hash=db_model.url_hash,

--- a/src/api/route_models/list.py
+++ b/src/api/route_models/list.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+from .base import BaseRouteModel
+
+from db.list import UserList
+
+
+class ListResponse(BaseRouteModel):
+    list_name: str
+    list_name_hash: str
+    # Number of items in the list (filled in by /list/list).
+    list_item_count: Optional[int] = None
+    # Whether a queried item is in this list (filled in when /list/list is
+    # called with item_url_hash, to drive the add-to-list checklist).
+    list_contains_item: Optional[bool] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "list_name": "Watch later",
+                "list_name_hash": "982d98h98hf1uhfdi1sdhu",
+            }
+        }
+    }
+
+    @classmethod
+    def from_db_model(
+        cls,
+        db_model: UserList,
+        item_count: int = None,
+        contains_item: bool = None,
+    ):
+        return cls(
+            list_name=db_model.name,
+            list_name_hash=db_model.name_hash,
+            list_item_count=item_count,
+            list_contains_item=contains_item,
+        )

--- a/src/api/routers/list.py
+++ b/src/api/routers/list.py
@@ -1,0 +1,108 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from typing import List, Optional
+
+from routers.auth import authenticate
+from db.list import UserList
+from db.item import ItemLoose
+from db.user import User
+from route_models.list import ListResponse
+from route_models.item import ItemResponse
+from route_models.acknowledge import AcknowledgeResponse
+
+list_router = APIRouter()
+
+
+def get_list_by_name_hash(user_hash: str, name_hash: str) -> UserList:
+    lst = UserList.read(user_hash=user_hash, name_hash=name_hash)
+    if lst is None:
+        raise HTTPException(status_code=404, detail="List not found")
+    return lst
+
+
+@list_router.post("/create", summary="Create a list", response_model=ListResponse)
+def create_list(list_name: str, user: User = Depends(authenticate)) -> ListResponse:
+    name = list_name.strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="List name cannot be empty")
+
+    lst = UserList(user_hash=user.name_hash, name=name)
+    if lst.exists():
+        raise HTTPException(
+            status_code=409, detail=f'A list named "{name}" already exists'
+        )
+    lst.create()
+    return ListResponse.from_db_model(lst, item_count=0, contains_item=False)
+
+
+@list_router.get(
+    "/list",
+    summary="List a user's lists",
+    response_model=List[ListResponse],
+)
+def get_lists(
+    item_url_hash: Optional[str] = Query(
+        None,
+        description="If given, each list reports whether it contains this item "
+        "(for the add-to-list checklist).",
+    ),
+    user: User = Depends(authenticate),
+) -> List[ListResponse]:
+    return [
+        ListResponse.from_db_model(
+            lst,
+            item_count=lst.item_count(),
+            contains_item=(
+                lst.contains(item_url_hash) if item_url_hash is not None else None
+            ),
+        )
+        for lst in UserList.read_all(user.name_hash)
+    ]
+
+
+@list_router.delete(
+    "/delete",
+    summary="Delete a list",
+    response_model=AcknowledgeResponse,
+)
+def delete_list(
+    list_name_hash: str, user: User = Depends(authenticate)
+) -> AcknowledgeResponse:
+    lst = get_list_by_name_hash(user.name_hash, list_name_hash)
+    lst.delete()
+    return AcknowledgeResponse()
+
+
+@list_router.get(
+    "/items",
+    summary="List the items in a list",
+    response_model=List[ItemResponse],
+)
+def get_list_items(
+    list_name_hash: str, user: User = Depends(authenticate)
+) -> List[ItemResponse]:
+    lst = get_list_by_name_hash(user.name_hash, list_name_hash)
+    return [ItemResponse.from_db_model(item) for item in lst.items()]
+
+
+@list_router.post(
+    "/set_item_lists",
+    summary="Set which of the user's lists an item belongs to",
+    response_model=AcknowledgeResponse,
+)
+def set_item_lists(
+    item_url_hash: str,
+    list_hashes: Optional[str] = Query(
+        None, description="Comma-separated list name hashes the item should be in"
+    ),
+    user: User = Depends(authenticate),
+) -> AcknowledgeResponse:
+    if not ItemLoose.read(item_url_hash):
+        raise HTTPException(status_code=404, detail="Item not found")
+
+    hashes = [h for h in (list_hashes or "").split(",") if h]
+    UserList.set_item_membership(
+        user_hash=user.name_hash,
+        item_url_hash=item_url_hash,
+        list_hashes=hashes,
+    )
+    return AcknowledgeResponse()

--- a/src/api/routers/list.py
+++ b/src/api/routers/list.py
@@ -59,6 +59,14 @@ def get_lists(
     ]
 
 
+@list_router.get("/get", summary="Get a list", response_model=ListResponse)
+def get_list(
+    list_name_hash: str, user: User = Depends(authenticate)
+) -> ListResponse:
+    lst = get_list_by_name_hash(user.name_hash, list_name_hash)
+    return ListResponse.from_db_model(lst, item_count=lst.item_count())
+
+
 @list_router.delete(
     "/delete",
     summary="Delete a list",

--- a/src/api/static/css/style.css
+++ b/src/api/static/css/style.css
@@ -1,5 +1,43 @@
 /* Custom overrides; base utilities/components are compiled into tailwind.css. */
 
+/* ---- Landscape card media ---- */
+
+/* On a phone held in landscape the viewport is short and wide, so a
+   full-width 16:9 video (or a tall image) can push the title and vote row off
+   the bottom of the screen. Cap the media height and let it shrink so an
+   image + title + voting buttons generally fit without scrolling. Scoped to
+   short landscape viewports (phones) so tablets/desktops are untouched. */
+@media (orientation: landscape) and (max-height: 600px) {
+  .aggy-card-media {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: transparent;
+    max-height: 48vh;
+  }
+  /* single image / video: shrink to the height cap, keep the aspect ratio */
+  .aggy-card-media > img,
+  .aggy-card-media > video {
+    max-height: 48vh;
+    width: auto;
+    max-width: 100%;
+    object-fit: contain;
+  }
+  /* the YouTube/Plyr player keeps 16:9; drive it by height so a wide screen
+     doesn't make it tall. */
+  .aggy-card-media .aggy-player {
+    width: auto;
+    height: 48vh;
+    max-width: 100%;
+    aspect-ratio: 16 / 9;
+  }
+  /* galleries and any nested media: cap the height, letterboxing as needed */
+  .aggy-card-media img,
+  .aggy-card-media video {
+    max-height: 48vh;
+  }
+}
+
 /* ---- YouTube player (Plyr + SponsorBlock) ---- */
 
 /* Match Plyr's accent to the app's primary colour. */

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -86,6 +86,9 @@ function bindControls() {
   $('manualSourceForm').onsubmit = handleCreateManualSource;
   $('editSourceSaveBtn').onclick = handleUpdateSource;
 
+  $('createListForm').onsubmit = handleCreateList;
+  $('listSaveBtn').onclick = handleListSave;
+
   // stop gifs/videos/embeds when the reader closes: destroy the youtube
   // player first (halts audio, clears its timers), then empty the media host
   // to unload any <video>/iframe
@@ -1027,11 +1030,11 @@ function itemCard(item) {
   const excerpt = cleanExcerpt(item);
 
   const mediaBlock = ytId
-    ? h('figure', { class: 'bg-base-300' }, youtubeEmbed(ytId))
+    ? h('figure', { class: 'bg-base-300 aggy-card-media' }, youtubeEmbed(ytId))
     : media
-    ? h('figure', { class: 'bg-base-300' }, mediaGallery(media))
+    ? h('figure', { class: 'bg-base-300 aggy-card-media' }, mediaGallery(media))
     : imageUrl
-      ? h('figure', { class: 'bg-base-300' },
+      ? h('figure', { class: 'bg-base-300 aggy-card-media' },
           h('img', {
             src: imageUrl, class: 'w-full max-h-[70vh] object-contain', alt: '', loading: 'lazy',
             onerror: (e) => { e.target.closest('figure').remove(); },
@@ -1074,6 +1077,7 @@ function itemCard(item) {
         published && h('span', { class: 'whitespace-nowrap' }, published),
         predictedBadge),
       h('div', { class: 'flex items-center gap-1 ml-auto' },
+        listButton(item),
         voteButton('▲', 1, 'Upvote'),
         voteButton('●', 0, 'Neutral — seen it, no strong feelings'),
         voteButton('▼', -1, 'Downvote'))));
@@ -1146,6 +1150,115 @@ async function voteItem(item, score, btn) {
       const card = btn.closest('.card');
       if (card) collapseCard(card);
     }
+  } catch (err) {
+    toast(err.message, 'alert-error');
+  }
+}
+
+// ---------- lists ----------
+// The current item + its list button while the list modal is open, so a save
+// can update the card in place.
+let listModalItem = null;
+let listModalBtn = null;
+
+// Bookmark icon; filled when the article is saved to at least one list.
+function listIconSvg(filled) {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', filled ? 'currentColor' : 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '1.8');
+  svg.setAttribute('class', 'w-5 h-5');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('stroke-linecap', 'round');
+  path.setAttribute('stroke-linejoin', 'round');
+  path.setAttribute('d', 'M6.32 2.577a49.255 49.255 0 0111.36 0c1.497.174 2.57 '
+    + '1.46 2.57 2.93V21a.75.75 0 01-1.085.67L12 18.089l-7.165 3.583A.75.75 0 '
+    + '013.75 21V5.507c0-1.47 1.073-2.756 2.57-2.93z');
+  svg.appendChild(path);
+  return svg;
+}
+
+// The "add to list" button shown in each card's action row.
+function listButton(item) {
+  return h('button', {
+    class: `btn btn-ghost btn-sm btn-square ${item.item_in_list ? 'text-primary' : 'text-base-content/60'}`,
+    title: 'Add to a list',
+    onclick: (e) => { e.stopPropagation(); openListModal(item, e.currentTarget); },
+  }, listIconSvg(!!item.item_in_list));
+}
+
+// One row of the list checklist: a checkbox + name + item count.
+function listChecklistRow(l) {
+  return h('label', {
+    class: 'label cursor-pointer justify-start gap-3 py-1.5 px-2 rounded-lg hover:bg-base-200',
+  },
+    h('input', {
+      type: 'checkbox', class: 'checkbox checkbox-sm checkbox-primary',
+      checked: !!l.list_contains_item, 'data-list-hash': l.list_name_hash,
+    }),
+    h('span', { class: 'label-text flex-1 min-w-0 truncate' }, l.list_name),
+    h('span', { class: 'text-xs text-base-content/40' }, String(l.list_item_count ?? 0)));
+}
+
+async function openListModal(item, btn) {
+  listModalItem = item;
+  listModalBtn = btn || null;
+  $('newListName').value = '';
+  showModal('listModal');
+  render($('listChecklist'), spinner());
+  try {
+    const lists = await sdk.listList({ item_url_hash: item.item_hash });
+    renderListChecklist(lists);
+  } catch (err) {
+    render($('listChecklist'), h('p', { class: 'text-sm text-error py-2' }, err.message));
+  }
+}
+
+function renderListChecklist(lists) {
+  if (!lists.length) {
+    render($('listChecklist'),
+      h('p', { class: 'text-sm text-base-content/50 py-2' }, 'No lists yet — create one below.'));
+    return;
+  }
+  render($('listChecklist'), lists.map(listChecklistRow));
+}
+
+// Create a new list from the inline field and add its (pre-checked) row without
+// reloading, so any boxes the user already ticked stay ticked.
+async function handleCreateList(e) {
+  e.preventDefault();
+  const name = $('newListName').value.trim();
+  if (!name) return;
+  try {
+    const created = await sdk.listCreate({ list_name: name });
+    $('newListName').value = '';
+    const box = $('listChecklist');
+    if (!box.querySelector('input')) render(box); // clear the "no lists yet" note
+    box.append(listChecklistRow({ ...created, list_contains_item: true }));
+  } catch (err) {
+    toast(err.message, 'alert-error');
+  }
+}
+
+async function handleListSave() {
+  if (!listModalItem) return;
+  const hashes = Array.from($('listChecklist').querySelectorAll('input:checked'))
+    .map((i) => i.getAttribute('data-list-hash'));
+  try {
+    await sdk.listSetItemLists({
+      item_url_hash: listModalItem.item_hash,
+      list_hashes: hashes.join(','),
+    });
+    const inList = hashes.length > 0;
+    listModalItem.item_in_list = inList;
+    if (listModalBtn) {
+      listModalBtn.classList.toggle('text-primary', inList);
+      listModalBtn.classList.toggle('text-base-content/60', !inList);
+      render(listModalBtn, listIconSvg(inList));
+    }
+    closeModal('listModal');
+    toast(inList ? 'Saved to lists' : 'Removed from all lists');
   } catch (err) {
     toast(err.message, 'alert-error');
   }

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -8,6 +8,7 @@ const sdk = new AggySDK();
 // ---------- state ----------
 const PAGE_SIZE = 20;
 let currentFeed = null;
+let currentList = null; // the list being browsed in the list-detail view
 let itemSkip = 0;
 let lastItemBand = null; // sort-band of the last rendered item, for threshold dividers
 // filter/sort state for the current feed; sources: null means "all sources"
@@ -39,6 +40,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   router
     .add('', showDashboard)
     .add('feed/:hash', ({ hash }) => showFeed(hash))
+    .add('list/:hash', ({ hash }) => showList(hash))
     .start();
 });
 
@@ -88,6 +90,7 @@ function bindControls() {
 
   $('createListForm').onsubmit = handleCreateList;
   $('listSaveBtn').onclick = handleListSave;
+  $('deleteListBtn').onclick = confirmDeleteList;
 
   // stop gifs/videos/embeds when the reader closes: destroy the youtube
   // player first (halts audio, clears its timers), then empty the media host
@@ -134,6 +137,7 @@ function setupAutoHideNav() {
 function setView(name) {
   $('viewDashboard').classList.toggle('hidden', name !== 'dashboard');
   $('viewFeed').classList.toggle('hidden', name !== 'feed');
+  $('viewList').classList.toggle('hidden', name !== 'list');
   // never leave the navbar tucked away when switching views
   $('appNavbar')?.classList.remove('-translate-y-full');
 }
@@ -142,7 +146,24 @@ function setView(name) {
 function showDashboard() {
   setView('dashboard');
   currentFeed = null;
+  currentList = null;
   loadFeeds();
+  loadLists();
+}
+
+// The lists section only appears once the user has at least one list; lists
+// are created by bookmarking articles from a feed.
+async function loadLists() {
+  const section = $('listsSection');
+  const grid = $('listGrid');
+  try {
+    const lists = await sdk.listList({});
+    if (!lists.length) { section.classList.add('hidden'); return; }
+    section.classList.remove('hidden');
+    render(grid, lists.map(listCard));
+  } catch {
+    section.classList.add('hidden');
+  }
 }
 
 async function loadFeeds() {
@@ -192,22 +213,36 @@ function onboardingWelcome() {
 }
 
 function feedCard(feed) {
-  // summary line: total posts, unread, average posts/day (last 30 days)
+  // summary line: unread count (or total when nothing's unread) + posts/day
   const stats = [];
   if (feed.feed_item_count != null) {
-    stats.push(`${feed.feed_item_count} post${feed.feed_item_count === 1 ? '' : 's'}`);
-    if (feed.feed_unread_count != null) stats.push(`${feed.feed_unread_count} unread`);
+    if (feed.feed_unread_count) stats.push(`${feed.feed_unread_count} unread`);
+    else stats.push(`${feed.feed_item_count} post${feed.feed_item_count === 1 ? '' : 's'}`);
     if (feed.feed_posts_per_day != null) stats.push(`~${feed.feed_posts_per_day}/day`);
   }
   return h('div', {
-    class: 'card bg-base-200 shadow-sm hover:shadow-md transition-shadow cursor-pointer border border-base-300 hover:border-primary',
+    class: 'card bg-base-200 border border-base-300 hover:border-primary transition-colors cursor-pointer',
     onclick: () => router.go(`feed/${feed.feed_name_hash}`),
   },
-    h('div', { class: 'card-body p-5' },
-      h('div', { class: 'badge badge-primary badge-outline font-bold text-lg p-3' },
-        feed.feed_name.charAt(0).toUpperCase()),
-      h('h2', { class: 'card-title text-base mt-2' }, feed.feed_name),
-      stats.length ? h('div', { class: 'text-xs text-base-content/50' }, stats.join(' · ')) : null));
+    h('div', { class: 'card-body p-3 gap-1' },
+      h('h2', { class: 'font-semibold text-sm leading-snug line-clamp-2' }, feed.feed_name),
+      stats.length ? h('div', { class: 'text-xs text-base-content/50 truncate' }, stats.join(' · ')) : null));
+}
+
+// Compact card for a saved list, mirroring the feed cards but visually
+// distinct (a bookmark glyph + secondary hover accent).
+function listCard(list) {
+  const count = list.list_item_count ?? 0;
+  return h('div', {
+    class: 'card bg-base-200 border border-base-300 hover:border-secondary transition-colors cursor-pointer',
+    onclick: () => router.go(`list/${list.list_name_hash}`),
+  },
+    h('div', { class: 'card-body p-3 gap-1' },
+      h('div', { class: 'flex items-center gap-1.5 min-w-0' },
+        h('span', { class: 'text-secondary flex-none' }, '\u{1F516}'),
+        h('h2', { class: 'font-semibold text-sm leading-snug line-clamp-2' }, list.list_name)),
+      h('div', { class: 'text-xs text-base-content/50 truncate' },
+        `${count} item${count === 1 ? '' : 's'}`)));
 }
 
 async function handleCreateFeed(e) {
@@ -268,6 +303,7 @@ async function handleRenameFeed(e) {
 // ---------- feed view ----------
 async function showFeed(hash) {
   setView('feed');
+  currentList = null; // leaving any list-detail context
   itemSkip = 0;
   render($('itemList'), spinner());
 
@@ -313,6 +349,63 @@ function switchFeedTab(tab) {
   $('filterBtn').classList.toggle('hidden', tab !== 'items');
   if (tab !== 'items') $('filterPanel').classList.add('hidden');
   if (tab === 'sources') loadSources();
+}
+
+// ---------- list detail view ----------
+// A list browses like a feed's article list, but with no recommendation
+// engine: no sort/filter, model stats, predictions, or vote buttons — just
+// the saved articles, newest-added first.
+async function showList(hash) {
+  setView('list');
+  currentFeed = null; // no feed context: the reader won't record vote state
+  render($('listItemList'), spinner());
+
+  if (!currentList || currentList.list_name_hash !== hash) {
+    try {
+      currentList = await sdk.listGet({ list_name_hash: hash });
+    } catch (err) {
+      toast(err.message, 'alert-error');
+      router.go('');
+      return;
+    }
+  }
+
+  $('listTitle').textContent = currentList.list_name;
+  $('listBreadcrumb').textContent = currentList.list_name;
+  loadListItems();
+}
+
+async function loadListItems() {
+  const list = $('listItemList');
+  render(list, spinner());
+  try {
+    const items = await sdk.listItems({ list_name_hash: currentList.list_name_hash });
+    if (!items.length) {
+      render(list, emptyState('\u{1F516}', 'This list is empty',
+        'Save articles to this list from any feed with the bookmark button.'));
+      return;
+    }
+    render(list);
+    items.forEach((item) => list.append(itemCard(item, { listMode: true })));
+  } catch (err) {
+    render(list, h('div', { class: 'text-center py-16 text-base-content/50' }, 'Failed to load list'));
+    toast(err.message, 'alert-error');
+  }
+}
+
+function confirmDeleteList() {
+  if (!currentList) return;
+  confirmDialog({
+    title: 'Delete List',
+    message: `Delete "${currentList.list_name}"? The articles stay in their feeds; only the list is removed.`,
+    action: 'Delete List',
+    onConfirm: async () => {
+      await sdk.listDelete({ list_name_hash: currentList.list_name_hash });
+      currentList = null;
+      toast('List deleted');
+      router.go('');
+    },
+  });
 }
 
 // ---------- filters ----------
@@ -1021,8 +1114,10 @@ function mediaGallery(mediaList) {
 }
 
 // Reddit-app-style card: meta row and title up top, full-feed-width media
-// below, then the vote row.
-function itemCard(item) {
+// below, then the action row. In `listMode` the recommendation-engine bits
+// (the "why recommended" button, the predicted-match badge, and the vote
+// buttons) are dropped — a list is a plain saved collection.
+function itemCard(item, { listMode = false } = {}) {
   const published = item.item_date_published ? timeAgo(item.item_date_published) : '';
   const ytId = youtubeId(item.item_url);
   const media = !ytId && (item.item_media || []).length ? item.item_media : null;
@@ -1066,7 +1161,7 @@ function itemCard(item) {
     h('div', { class: 'px-4 pt-3 pb-2' },
       h('div', { class: 'flex items-start gap-2' },
         h('h3', { class: 'font-semibold leading-snug flex-1 min-w-0 line-clamp-2' }, item.item_title || 'Untitled'),
-        explainButton(item),
+        listMode ? null : explainButton(item),
         openLinkButton(item.item_url)),
       !mediaBlock && excerpt && h('p', { class: 'text-xs text-base-content/50 line-clamp-2 mt-1' }, excerpt)),
     mediaBlock,
@@ -1075,12 +1170,12 @@ function itemCard(item) {
         sourceBadge(item.item_source_name, item.item_source_color),
         item.item_author && h('span', { class: 'truncate max-w-32' }, item.item_author),
         published && h('span', { class: 'whitespace-nowrap' }, published),
-        predictedBadge),
+        listMode ? null : predictedBadge),
       h('div', { class: 'flex items-center gap-1 ml-auto' },
         listButton(item),
-        voteButton('▲', 1, 'Upvote'),
-        voteButton('●', 0, 'Neutral — seen it, no strong feelings'),
-        voteButton('▼', -1, 'Downvote'))));
+        listMode ? null : voteButton('▲', 1, 'Upvote'),
+        listMode ? null : voteButton('●', 0, 'Neutral — seen it, no strong feelings'),
+        listMode ? null : voteButton('▼', -1, 'Downvote'))));
 }
 
 // ---------- why recommended ----------
@@ -1259,6 +1354,8 @@ async function handleListSave() {
     }
     closeModal('listModal');
     toast(inList ? 'Saved to lists' : 'Removed from all lists');
+    // while browsing a list, membership changes can add/remove the card
+    if (currentList) loadListItems();
   } catch (err) {
     toast(err.message, 'alert-error');
   }

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -238,9 +238,7 @@ function listCard(list) {
     onclick: () => router.go(`list/${list.list_name_hash}`),
   },
     h('div', { class: 'card-body p-3 gap-1' },
-      h('div', { class: 'flex items-center gap-1.5 min-w-0' },
-        h('span', { class: 'text-secondary flex-none' }, '\u{1F516}'),
-        h('h2', { class: 'font-semibold text-sm leading-snug line-clamp-2' }, list.list_name)),
+      h('h2', { class: 'font-semibold text-sm leading-snug line-clamp-2' }, list.list_name),
       h('div', { class: 'text-xs text-base-content/50 truncate' },
         `${count} item${count === 1 ? '' : 's'}`)));
 }

--- a/src/api/static/js/sdk.js
+++ b/src/api/static/js/sdk.js
@@ -145,6 +145,31 @@ class AggySDK {
     return this._request("POST", "/item/set_state", { query: { feed_hash, item_url_hash, score, is_read } });
   }
 
+  /** Create a list */
+  async listCreate({ list_name }) {
+    return this._request("POST", "/list/create", { query: { list_name } });
+  }
+
+  /** Delete a list */
+  async listDelete({ list_name_hash }) {
+    return this._request("DELETE", "/list/delete", { query: { list_name_hash } });
+  }
+
+  /** List the items in a list */
+  async listItems({ list_name_hash }) {
+    return this._request("GET", "/list/items", { query: { list_name_hash } });
+  }
+
+  /** List a user's lists */
+  async listList({ item_url_hash }) {
+    return this._request("GET", "/list/list", { query: { item_url_hash } });
+  }
+
+  /** Set which of the user's lists an item belongs to */
+  async listSetItemLists({ item_url_hash, list_hashes }) {
+    return this._request("POST", "/list/set_item_lists", { query: { item_url_hash, list_hashes } });
+  }
+
   /** Create a source (within a feed) */
   async sourceCreate({ feed_name_hash, source_name, source_url }) {
     return this._request("POST", "/source/create", { query: { feed_name_hash, source_name, source_url } });

--- a/src/api/static/js/sdk.js
+++ b/src/api/static/js/sdk.js
@@ -155,6 +155,11 @@ class AggySDK {
     return this._request("DELETE", "/list/delete", { query: { list_name_hash } });
   }
 
+  /** Get a list */
+  async listGet({ list_name_hash }) {
+    return this._request("GET", "/list/get", { query: { list_name_hash } });
+  }
+
   /** List the items in a list */
   async listItems({ list_name_hash }) {
     return this._request("GET", "/list/items", { query: { list_name_hash } });

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -154,6 +154,28 @@
   <form method="dialog" class="modal-backdrop"><button>close</button></form>
 </dialog>
 
+<!-- Add to List Modal -->
+<dialog class="modal" id="listModal">
+  <div class="modal-box max-w-sm">
+    <form method="dialog"><button class="btn btn-sm btn-circle btn-ghost absolute right-4 top-4">✕</button></form>
+    <h3 class="text-lg font-bold mb-1">Add to list</h3>
+    <p class="text-xs text-base-content/60 mb-3">
+      Pick any lists for this article. Adding it to a list also counts as an upvote.
+    </p>
+    <div id="listChecklist" class="flex flex-col gap-1 max-h-[40vh] overflow-y-auto"></div>
+    <form id="createListForm" class="flex gap-2 mt-3 pt-3 border-t border-base-300">
+      <input type="text" class="input input-bordered input-sm flex-1" id="newListName"
+        placeholder="New list name" maxlength="100" autocomplete="off">
+      <button type="submit" class="btn btn-sm btn-square btn-primary" title="Create list">+</button>
+    </form>
+    <div class="modal-action">
+      <button type="button" class="btn btn-ghost btn-sm" data-close-modal>Cancel</button>
+      <button type="button" class="btn btn-primary btn-sm" id="listSaveBtn">Save</button>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
+
 <!-- Model Stats Modal -->
 <dialog class="modal" id="statsModal">
   <div class="modal-box max-w-2xl">

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -25,7 +25,7 @@
 
   <!-- Dashboard View -->
   <div id="viewDashboard">
-    <div class="flex items-center justify-between mb-6">
+    <div class="flex items-center justify-between mb-4">
       <div>
         <h1 class="text-2xl font-bold">Your Feeds</h1>
         <p class="text-sm text-base-content/60 mt-1">Curated content, ranked by relevance</p>
@@ -35,7 +35,44 @@
         <button class="btn btn-primary btn-sm" id="newFeedBtn">+ New Feed</button>
       </div>
     </div>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" id="feedGrid"></div>
+    <div class="grid gap-2 grid-cols-[repeat(auto-fill,minmax(9rem,1fr))]" id="feedGrid"></div>
+
+    <!-- Lists section -->
+    <div id="listsSection" class="hidden mt-8">
+      <div class="flex items-center justify-between mb-4">
+        <div>
+          <h2 class="text-2xl font-bold">Your Lists</h2>
+          <p class="text-sm text-base-content/60 mt-1">Saved collections you curate yourself</p>
+        </div>
+      </div>
+      <div class="grid gap-2 grid-cols-[repeat(auto-fill,minmax(9rem,1fr))]" id="listGrid"></div>
+    </div>
+  </div>
+
+  <!-- List Detail View -->
+  <div id="viewList" class="hidden">
+    <div class="breadcrumbs text-sm mb-4">
+      <ul>
+        <li><a href="#/">Home</a></li>
+        <li id="listBreadcrumb"></li>
+      </ul>
+    </div>
+
+    <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+      <div class="flex items-center gap-2 min-w-0">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 flex-none text-primary" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M6.32 2.577a49.255 49.255 0 0111.36 0c1.497.174 2.57 1.46 2.57 2.93V21a.75.75 0 01-1.085.67L12 18.089l-7.165 3.583A.75.75 0 013.75 21V5.507c0-1.47 1.073-2.756 2.57-2.93z"/>
+        </svg>
+        <h1 class="text-2xl font-bold truncate" id="listTitle"></h1>
+      </div>
+      <button class="btn btn-ghost btn-sm btn-square text-error" id="deleteListBtn" title="Delete list">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"/>
+        </svg>
+      </button>
+    </div>
+
+    <div class="flex flex-col gap-2" id="listItemList"></div>
   </div>
 
   <!-- Feed Detail View -->

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from tests.fixtures.feed import unique_feed, existing_feed  # noqa
 from tests.fixtures.item import unique_item_strict, existing_item_strict  # noqa
 from tests.fixtures.item_state import unique_item_state, existing_item_state  # noqa
+from tests.fixtures.list import unique_list, existing_list  # noqa
 from tests.fixtures.source import unique_source, existing_source  # noqa
 from tests.fixtures.source_template import (  # noqa
     unique_source_template,  # noqa

--- a/src/api/tests/db/list_test.py
+++ b/src/api/tests/db/list_test.py
@@ -1,0 +1,123 @@
+import pytest
+
+from db.list import UserList
+
+
+def test_create_list(existing_list):
+    assert existing_list.exists(), "List should exist after creation"
+
+
+def test_create_duplicate_list_raises(existing_list):
+    dup = UserList(user_hash=existing_list.user_hash, name=existing_list.name)
+    with pytest.raises(ValueError):
+        dup.create()
+
+
+def test_create_list_bad_user():
+    lst = UserList(user_hash="nope", name="My List")
+    with pytest.raises(Exception):
+        lst.create()
+
+
+def test_delete_list(existing_list):
+    existing_list.delete()
+    assert not existing_list.exists(), "List should not exist after deletion"
+
+
+def test_read_list(existing_list):
+    read = UserList.read(existing_list.user_hash, existing_list.name_hash)
+    assert read is not None
+    assert read.name == existing_list.name
+    assert read.name_hash == existing_list.name_hash
+
+
+def test_read_missing_list(existing_user):
+    assert UserList.read(existing_user.name_hash, "missing") is None
+
+
+def test_read_all_lists(existing_user):
+    a = UserList(user_hash=existing_user.name_hash, name="Alpha")
+    b = UserList(user_hash=existing_user.name_hash, name="Beta")
+    a.create()
+    b.create()
+    lists = UserList.read_all(existing_user.name_hash)
+    names = {lst.name for lst in lists}
+    assert {"Alpha", "Beta"} <= names
+
+
+def test_add_and_remove_item(existing_list, existing_item_strict):
+    item_hash = existing_item_strict.url_hash
+    assert not existing_list.contains(item_hash)
+    assert existing_list.item_count() == 0
+
+    existing_list.add_item(item_hash)
+    assert existing_list.contains(item_hash)
+    assert existing_list.item_count() == 1
+
+    # adding again is idempotent
+    existing_list.add_item(item_hash)
+    assert existing_list.item_count() == 1
+
+    existing_list.remove_item(item_hash)
+    assert not existing_list.contains(item_hash)
+    assert existing_list.item_count() == 0
+
+
+def test_items_returns_added_items(existing_list, existing_item_strict):
+    existing_list.add_item(existing_item_strict.url_hash)
+    items = existing_list.items()
+    assert len(items) == 1
+    assert items[0].url_hash == existing_item_strict.url_hash
+
+
+def test_set_item_membership(existing_user, existing_item_strict):
+    a = UserList(user_hash=existing_user.name_hash, name="Alpha")
+    b = UserList(user_hash=existing_user.name_hash, name="Beta")
+    c = UserList(user_hash=existing_user.name_hash, name="Gamma")
+    a.create()
+    b.create()
+    c.create()
+    item_hash = existing_item_strict.url_hash
+
+    UserList.set_item_membership(
+        existing_user.name_hash, item_hash, [a.name_hash, b.name_hash]
+    )
+    assert a.contains(item_hash)
+    assert b.contains(item_hash)
+    assert not c.contains(item_hash)
+
+    # re-submitting a different selection replaces membership
+    UserList.set_item_membership(
+        existing_user.name_hash, item_hash, [c.name_hash]
+    )
+    assert not a.contains(item_hash)
+    assert not b.contains(item_hash)
+    assert c.contains(item_hash)
+
+    # an empty selection clears membership
+    UserList.set_item_membership(existing_user.name_hash, item_hash, [])
+    assert not c.contains(item_hash)
+
+
+def test_set_item_membership_ignores_foreign_hashes(
+    existing_user, existing_item_strict
+):
+    a = UserList(user_hash=existing_user.name_hash, name="Alpha")
+    a.create()
+    item_hash = existing_item_strict.url_hash
+
+    # "bogus" is not one of the user's lists and must be ignored, not inserted
+    UserList.set_item_membership(
+        existing_user.name_hash, item_hash, [a.name_hash, "bogus"]
+    )
+    assert a.contains(item_hash)
+    assert a.item_count() == 1
+
+
+def test_delete_list_cascades_membership(existing_list, existing_item_strict):
+    existing_list.add_item(existing_item_strict.url_hash)
+    existing_list.delete()
+    # a fresh list of the same name starts empty (membership was removed)
+    remade = UserList(user_hash=existing_list.user_hash, name=existing_list.name)
+    remade.create()
+    assert remade.item_count() == 0

--- a/src/api/tests/fixtures/list.py
+++ b/src/api/tests/fixtures/list.py
@@ -1,0 +1,23 @@
+import pytest
+import uuid
+
+from db.list import UserList
+from db.user import User
+
+
+@pytest.fixture(scope="function")
+def unique_list(existing_user: User) -> UserList:
+    """A list whose owning user exists, so the FK to users is satisfied if
+    the list is later persisted."""
+    lst = UserList(
+        user_hash=existing_user.name_hash,
+        name=f"List Name {uuid.uuid4()}",
+    )
+    yield lst
+
+
+@pytest.fixture(scope="function")
+def existing_list(unique_list: UserList) -> UserList:
+    if not unique_list.exists():
+        unique_list.create()
+    yield unique_list

--- a/src/api/tests/ranking/list_vote_test.py
+++ b/src/api/tests/ranking/list_vote_test.py
@@ -1,0 +1,61 @@
+"""List membership acts as an extra positive vote for the ranking model."""
+
+from db.item_state import ItemState
+from db.list import UserList
+from ranking.engine import _effective_label, load_feed_features
+
+
+def test_effective_label_unvoted_listed_reads_as_upvote():
+    assert _effective_label(None, None) is None
+    assert _effective_label(None, "2021-01-01") == 1.0
+
+
+def test_effective_label_downvote_plus_list_is_neutral():
+    assert _effective_label(-1.0, "2021-01-01") == 0.0
+
+
+def test_effective_label_upvote_stays_clamped():
+    assert _effective_label(1.0, "2021-01-01") == 1.0
+
+
+def test_effective_label_no_list_keeps_vote():
+    assert _effective_label(-1.0, None) == -1.0
+    assert _effective_label(0.0, None) == 0.0
+
+
+def test_listed_item_becomes_positive_label(
+    existing_user, existing_feed, existing_source, existing_item_strict
+):
+    # no vote yet -> no label
+    features = {f.url_hash: f for f in load_feed_features(existing_feed)}
+    assert features[existing_item_strict.url_hash].label is None
+
+    # adding the item to a list gives it a positive label
+    lst = UserList(user_hash=existing_user.name_hash, name="Favourites")
+    lst.create()
+    lst.add_item(existing_item_strict.url_hash)
+
+    features = {f.url_hash: f for f in load_feed_features(existing_feed)}
+    labeled = features[existing_item_strict.url_hash]
+    assert labeled.label == 1.0
+    assert labeled.label_date is not None
+
+
+def test_explicit_vote_takes_precedence_over_list_date(
+    existing_user, existing_feed, existing_source, existing_item_strict
+):
+    ItemState.set_state(
+        user_hash=existing_user.name_hash,
+        feed_hash=existing_feed.name_hash,
+        item_url_hash=existing_item_strict.url_hash,
+        score=-1,
+        is_read=True,
+    )
+    lst = UserList(user_hash=existing_user.name_hash, name="Favourites")
+    lst.create()
+    lst.add_item(existing_item_strict.url_hash)
+
+    features = {f.url_hash: f for f in load_feed_features(existing_feed)}
+    labeled = features[existing_item_strict.url_hash]
+    # downvote (-1) plus a list membership (+1) nets to neutral
+    assert labeled.label == 0.0

--- a/src/api/tests/routers/list_test.py
+++ b/src/api/tests/routers/list_test.py
@@ -63,6 +63,28 @@ def test_list_lists_with_item_membership(
     assert row["list_item_count"] == 1
 
 
+def test_get_list(client, existing_list, existing_item_strict, token):
+    existing_list.add_item(existing_item_strict.url_hash)
+    args = build_api_request_args(
+        path="/list/get",
+        token=token,
+        params={"list_name_hash": existing_list.name_hash},
+    )
+    response = client.get(**args)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["list_name"] == existing_list.name
+    assert body["list_item_count"] == 1
+
+
+def test_get_missing_list_404(client, token):
+    args = build_api_request_args(
+        path="/list/get", token=token, params={"list_name_hash": "missing"}
+    )
+    response = client.get(**args)
+    assert response.status_code == 404
+
+
 def test_delete_list(client, existing_list, existing_user, token):
     args = build_api_request_args(
         path="/list/delete",

--- a/src/api/tests/routers/list_test.py
+++ b/src/api/tests/routers/list_test.py
@@ -1,0 +1,165 @@
+from tests.testing_utils import build_api_request_args
+
+from db.list import UserList
+
+
+def test_create_list(client, existing_user, token):
+    args = build_api_request_args(
+        path="/list/create",
+        token=token,
+        params={"list_name": "Watch later"},
+    )
+    response = client.post(**args)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["list_name"] == "Watch later"
+    assert body["list_item_count"] == 0
+
+    lst = UserList.read(existing_user.name_hash, body["list_name_hash"])
+    assert lst is not None
+
+
+def test_create_duplicate_list_conflicts(client, existing_list, token):
+    args = build_api_request_args(
+        path="/list/create",
+        token=token,
+        params={"list_name": existing_list.name},
+    )
+    response = client.post(**args)
+    assert response.status_code == 409
+
+
+def test_create_blank_list_rejected(client, token):
+    args = build_api_request_args(
+        path="/list/create", token=token, params={"list_name": "   "}
+    )
+    response = client.post(**args)
+    assert response.status_code == 422
+
+
+def test_list_lists(client, existing_list, token):
+    args = build_api_request_args(path="/list/list", token=token)
+    response = client.get(**args)
+    assert response.status_code == 200
+    names = {row["list_name"] for row in response.json()}
+    assert existing_list.name in names
+
+
+def test_list_lists_with_item_membership(
+    client, existing_list, existing_item_strict, token
+):
+    existing_list.add_item(existing_item_strict.url_hash)
+    args = build_api_request_args(
+        path="/list/list",
+        token=token,
+        params={"item_url_hash": existing_item_strict.url_hash},
+    )
+    response = client.get(**args)
+    assert response.status_code == 200
+    row = next(
+        r for r in response.json() if r["list_name_hash"] == existing_list.name_hash
+    )
+    assert row["list_contains_item"] is True
+    assert row["list_item_count"] == 1
+
+
+def test_delete_list(client, existing_list, existing_user, token):
+    args = build_api_request_args(
+        path="/list/delete",
+        token=token,
+        params={"list_name_hash": existing_list.name_hash},
+    )
+    response = client.delete(**args)
+    assert response.status_code == 200
+    assert UserList.read(existing_user.name_hash, existing_list.name_hash) is None
+
+
+def test_delete_missing_list_404(client, token):
+    args = build_api_request_args(
+        path="/list/delete", token=token, params={"list_name_hash": "missing"}
+    )
+    response = client.delete(**args)
+    assert response.status_code == 404
+
+
+def test_set_item_lists(client, existing_user, existing_item_strict, token):
+    a = UserList(user_hash=existing_user.name_hash, name="Alpha")
+    b = UserList(user_hash=existing_user.name_hash, name="Beta")
+    a.create()
+    b.create()
+
+    args = build_api_request_args(
+        path="/list/set_item_lists",
+        token=token,
+        params={
+            "item_url_hash": existing_item_strict.url_hash,
+            "list_hashes": f"{a.name_hash},{b.name_hash}",
+        },
+    )
+    response = client.post(**args)
+    assert response.status_code == 200
+    assert a.contains(existing_item_strict.url_hash)
+    assert b.contains(existing_item_strict.url_hash)
+
+    # submitting an empty selection clears membership
+    args = build_api_request_args(
+        path="/list/set_item_lists",
+        token=token,
+        params={"item_url_hash": existing_item_strict.url_hash, "list_hashes": ""},
+    )
+    response = client.post(**args)
+    assert response.status_code == 200
+    assert not a.contains(existing_item_strict.url_hash)
+    assert not b.contains(existing_item_strict.url_hash)
+
+
+def test_set_item_lists_missing_item_404(client, existing_list, token):
+    args = build_api_request_args(
+        path="/list/set_item_lists",
+        token=token,
+        params={"item_url_hash": "missing", "list_hashes": existing_list.name_hash},
+    )
+    response = client.post(**args)
+    assert response.status_code == 404
+
+
+def test_get_list_items(client, existing_list, existing_item_strict, token):
+    existing_list.add_item(existing_item_strict.url_hash)
+    args = build_api_request_args(
+        path="/list/items",
+        token=token,
+        params={"list_name_hash": existing_list.name_hash},
+    )
+    response = client.get(**args)
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 1
+    assert body[0]["item_hash"] == existing_item_strict.url_hash
+
+
+def test_feed_items_reflect_list_membership(
+    client, existing_feed, existing_source, existing_item_strict, existing_list, token
+):
+    def feed_item():
+        args = build_api_request_args(
+            path="/feed/items",
+            params={"feed_name_hash": existing_feed.name_hash},
+            token=token,
+        )
+        response = client.get(**args)
+        assert response.status_code == 200
+        return next(
+            i
+            for i in response.json()
+            if i["item_hash"] == existing_item_strict.url_hash
+        )
+
+    assert feed_item()["item_in_list"] is False
+
+    existing_list.add_item(existing_item_strict.url_hash)
+    assert feed_item()["item_in_list"] is True
+
+
+def test_list_requires_auth(client):
+    response = client.get("/list/list")
+    assert response.status_code in (401, 403)


### PR DESCRIPTION
## Summary

Adds a **Lists** feature (playlist-like collections of articles), surfaces them on the home screen, makes the feed grid more compact, and fixes video thumbnails being too tall on phones in landscape.

### Lists — saving articles
- An **"add to list" bookmark button** sits in each article's vote row. Tapping it opens a modal with a **checklist of the user's lists** plus an inline **"+" field to create a new list**. Tick any number of lists and hit **Save**.
- The bookmark turns filled/primary when the article is saved to at least one list, so saved state is visible right in the feed.
- Lists span feeds — any article can go into any of the user's lists.

### Being on a list counts as an extra positive vote
- The ranking model folds list membership into its training label via `_effective_label`: an unvoted-but-listed item reads as an upvote (`+1`), a downvoted-but-listed one nets back to neutral (`0`), all clamped to the `-1..1` vote scale.
- `feeds_needing_rank` also fires re-ranking for feeds whose only labels come from listed items.

### Home screen: lists section + compact reflowing feeds
- New **"Your Lists"** section below the feeds (shown once the user has ≥1 list), separate from the feeds.
- Feeds and lists are now **compact cards in a grid that reflows with screen width** (`auto-fill` / `minmax`). The old single-letter chip on feed cards is removed.

### Browsable list view (no recommendation engine)
- Tapping a list opens a dedicated view that browses **like a feed's article list** — same cards, media, and reader — but with **no recommendation engine**: no sort/filter, model stats, predicted-match badges, "why recommended", or vote buttons.
- The bookmark button stays so items can be removed from a list (the view refreshes on change). Deleting the list is available from its header; the articles stay in their feeds.
- Opening an article from a list is safe: the reader only records read/vote state when there's a feed context.

### Landscape video fix
- On short landscape viewports (phones), card media is capped at ~48vh and centered, so a wide 16:9 video no longer makes the card taller than the screen. Verified: a 16:9 YouTube card that would have been ~478px tall full-width renders at 202px media / 292px card inside a 420px viewport.

## Changes
- **DB:** migration `V11__lists.sql` (`lists`, `list_items`) and a `UserList` model (`db/list.py`).
- **API:** `/list` router — `create`, `list` (with per-item membership flag), `get`, `delete`, `items`, and `set_item_lists`. Wired into `main.py` and `generate_sdk.py`.
- **Ranking:** `ranking/engine.py` treats list membership as a positive label and includes listed feeds in the re-rank set.
- **Feed responses:** `item_in_list` added to `ItemResponse` / feed item query so the bookmark reflects saved state; `sdk.js` regenerated.
- **Frontend:** add-to-list button/modal, home lists section, compact reflow feed+list cards, the list-detail view, and landscape media CSS.

## Testing
- New tests: `tests/db/list_test.py`, `tests/routers/list_test.py`, `tests/ranking/list_vote_test.py` (plus a `list` fixture) — list CRUD, `/list/get`, membership set/clear, the label math, and `/feed/items` reflecting membership.
- Full backend suite: **288 passed**. The 11 failures are pre-existing and reproduce identically on `main` in the same environment (unrelated dateparser/numpy/timezone quirks and a prior `count_items` SQL issue) — none in code touched here.
- SDK up to date (`generate_sdk.py --check`).
- End-to-end verified in a headless browser: saving to lists, multi-select persistence, the bookmark turning filled, the landscape video sizing, the compact reflowing home grid, and browsing/removing/deleting a list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvG5uGwSVVYzkYx6rWRH15