### PR TITLE
Respect device orientation in PWA and auto-detect RSS vs HTML sources

### DIFF
--- a/src/api/bridge/analyze.py
+++ b/src/api/bridge/analyze.py
@@ -13,6 +13,7 @@ import threading
 from datetime import datetime
 from urllib.parse import urljoin, urlparse
 
+import feedparser
 import requests
 from bs4 import BeautifulSoup, Comment
 
@@ -550,3 +551,62 @@ def suggest_source_name(title: str, url: str) -> str:
         if first:
             return first[:80]
     return urlparse(url).netloc or url
+
+
+# <link rel="alternate"> types that advertise a subscribable feed on an HTML
+# page; JSON Feed is intentionally excluded since ingestion parses RSS/Atom.
+FEED_LINK_TYPES = ("application/rss+xml", "application/atom+xml")
+
+
+def discover_feed_url(html: str, base_url: str):
+    """Return a feed URL advertised in an HTML page's <link> tags, or None."""
+    soup = BeautifulSoup(html, "html.parser")
+    for link in soup.find_all("link"):
+        rels = [r.lower() for r in (link.get("rel") or [])]
+        if "alternate" not in rels:
+            continue
+        link_type = (link.get("type") or "").lower()
+        if link_type in FEED_LINK_TYPES or "rss" in link_type or "atom" in link_type:
+            href = (link.get("href") or "").strip()
+            if href:
+                return urljoin(base_url, href)
+    return None
+
+
+def detect_source_type(url: str, cookie: str = "") -> dict:
+    """Decide whether ``url`` is a subscribable feed or a page to scrape.
+
+    Fetches the URL once and inspects it: if it parses as RSS/Atom the URL is
+    used directly; if it's an HTML page advertising a feed via <link> that
+    feed is used; otherwise it's treated as an HTML page for selector analysis.
+
+    Returns ``{"kind": "feed"|"html", "feed_url": str|None,
+    "suggested_source_name": str}``.
+    """
+    html = fetch_page(url, cookie=cookie)
+
+    # feedparser leaves ``version`` empty for anything it doesn't recognise as
+    # a feed, so a truthy version is a reliable RSS/Atom signal.
+    parsed = feedparser.parse(html)
+    if parsed.version:
+        title = (parsed.feed.get("title") or "").strip()
+        return {
+            "kind": "feed",
+            "feed_url": url,
+            "suggested_source_name": suggest_source_name(title, url),
+        }
+
+    title = page_title(html)
+    discovered = discover_feed_url(html, url)
+    if discovered:
+        return {
+            "kind": "feed",
+            "feed_url": discovered,
+            "suggested_source_name": suggest_source_name(title, url),
+        }
+
+    return {
+        "kind": "html",
+        "feed_url": None,
+        "suggested_source_name": suggest_source_name(title, url),
+    }

--- a/src/api/route_models/source_analyze.py
+++ b/src/api/route_models/source_analyze.py
@@ -14,6 +14,16 @@ class AnalyzeRequest(BaseRouteModel):
     }
 
 
+class DetectResponse(BaseRouteModel):
+    # "feed" when the URL is (or advertises) an RSS/Atom feed, else "html"
+    kind: str
+    # the feed to subscribe to when kind == "feed"; may differ from the input
+    # URL when auto-discovered from an HTML page's <link> tags
+    feed_url: Optional[str] = None
+    # friendly default source name from the page/feed title or domain
+    suggested_source_name: str
+
+
 class SelectorCandidate(BaseRouteModel):
     selector: str
     # how many elements the selector matched on the page (entry selector) or

--- a/src/api/routers/source_analyze.py
+++ b/src/api/routers/source_analyze.py
@@ -12,6 +12,7 @@ from bridge.analyze import (
     AnalyzeError,
     BRIDGE_SHORT_NAME,
     PREVIEW_TIMEOUT_SECONDS,
+    detect_source_type,
     fetch_page,
     page_title,
     request_selector_suggestions,
@@ -25,6 +26,7 @@ from route_models.source_analyze import (
     AnalyzeJobStatus,
     AnalyzeRequest,
     AnalyzeResponse,
+    DetectResponse,
     PreviewItem,
     PreviewRequest,
     PreviewResponse,
@@ -111,6 +113,21 @@ def _drop_stale_jobs() -> None:
     with _jobs_lock:
         for job_id in [j for j, job in _jobs.items() if job["created"] < cutoff]:
             del _jobs[job_id]
+
+
+@source_analyze_router.post(
+    "/detect",
+    summary="Detect whether a URL is an RSS/Atom feed or an HTML page to scrape",
+    response_model=DetectResponse,
+)
+def detect_source(
+    request: AnalyzeRequest, user: User = Depends(authenticate)
+) -> DetectResponse:
+    try:
+        result = detect_source_type(request.url, request.cookie or "")
+    except AnalyzeError as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
+    return DetectResponse(**result)
 
 
 @source_analyze_router.post(

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -77,16 +77,16 @@ function bindControls() {
 
   $('addSourceBtn').onclick = openAddSourceModal;
   $('srcTabTemplate').onclick = () => switchSourceTab('template');
-  $('srcTabManual').onclick = () => switchSourceTab('manual');
   $('srcTabAnalyze').onclick = () => switchSourceTab('analyze');
   $('srcTabFeed').onclick = () => switchSourceTab('feed');
-  $('analyzeForm').onsubmit = handleAnalyzeWebsite;
+  $('analyzeForm').onsubmit = handleAddByUrl;
   $('analyzeBackBtn').onclick = resetAnalyzeTab;
   $('analyzeAddBtn').onclick = handleCreateAnalyzedSource;
+  $('analyzeFeedBackBtn').onclick = resetAnalyzeTab;
+  $('analyzeFeedAddBtn').onclick = handleAddDetectedFeed;
   $('templateSearch').oninput = debounce(searchTemplates, 300);
   $('templateBackBtn').onclick = clearTemplateSelection;
   $('templateAddBtn').onclick = handleCreateSourceFromTemplate;
-  $('manualSourceForm').onsubmit = handleCreateManualSource;
   $('editSourceSaveBtn').onclick = handleUpdateSource;
 
   $('createListForm').onsubmit = handleCreateList;
@@ -1670,11 +1670,9 @@ function confirmDeleteSource(source) {
 
 function switchSourceTab(tab) {
   $('srcTabTemplate').classList.toggle('tab-active', tab === 'template');
-  $('srcTabManual').classList.toggle('tab-active', tab === 'manual');
   $('srcTabAnalyze').classList.toggle('tab-active', tab === 'analyze');
   $('srcTabFeed').classList.toggle('tab-active', tab === 'feed');
   $('sourceTabTemplate').classList.toggle('hidden', tab !== 'template');
-  $('sourceTabManual').classList.toggle('hidden', tab !== 'manual');
   $('sourceTabAnalyze').classList.toggle('hidden', tab !== 'analyze');
   $('sourceTabFeed').classList.toggle('hidden', tab !== 'feed');
   if (tab === 'feed') loadFeedSourceOptions();
@@ -1734,26 +1732,11 @@ async function handleAddFeedSource(feed, btn) {
   }
 }
 
-async function handleCreateManualSource(e) {
-  e.preventDefault();
-  if (!currentFeed) return;
-  const name = $('manualSourceName').value.trim();
-  const url = $('manualSourceUrl').value.trim();
-  try {
-    await sdk.sourceCreate({ feed_name_hash: currentFeed.feed_name_hash, source_name: name, source_url: url });
-    closeModal('addSourceModal');
-    toast(`Source "${name}" added`);
-    $('manualSourceName').value = '';
-    $('manualSourceUrl').value = '';
-    loadSources();
-    // the first ingest runs in the background; refresh to pick up its result
-    setTimeout(loadSources, 5000);
-  } catch (err) {
-    toast(err.message, 'alert-error');
-  }
-}
-
-// ---------- analyze a website into selectors (✨ From Website tab) ----------
+// ---------- add a source from a URL (From URL tab) ----------
+//
+// One entry point for both feeds and websites: the backend fetches the URL
+// and reports whether it's an RSS/Atom feed (added directly) or an HTML page
+// that needs the Ollama selector analysis below.
 
 // The backend asks Ollama for candidate CSS selectors per rss-bridge
 // parameter; the user can switch between candidates and watch the preview
@@ -1768,11 +1751,14 @@ const ANALYZE_FIELDS = [
 
 let analyzeState = null; // { suggestion, params } while the result step is open
 let analyzePreviewSeq = 0; // ignore out-of-order preview responses
+let detectedFeed = null; // { feed_url } while the feed-confirm step is open
 
 function resetAnalyzeTab() {
   analyzeState = null;
+  detectedFeed = null;
   analyzePreviewSeq += 1;
   $('analyzeInputStep').classList.remove('hidden');
+  $('analyzeFeedStep').classList.add('hidden');
   $('analyzeResultStep').classList.add('hidden');
   $('analyzeProgress').classList.add('hidden');
   $('analyzeBtn').disabled = false;
@@ -1799,17 +1785,30 @@ async function pollAnalyzeJob(jobId) {
   }
 }
 
-async function handleAnalyzeWebsite(e) {
+async function handleAddByUrl(e) {
   e.preventDefault();
   const url = $('analyzeUrl').value.trim();
   if (!url) return;
+  const cookie = $('analyzeCookie').value.trim() || null;
 
   $('analyzeBtn').disabled = true;
   $('analyzeProgress').classList.remove('hidden');
-  $('analyzeProgressText').textContent =
-    'Scraping the page and asking Ollama for selectors — this can take a minute or two…';
+  $('analyzeProgressText').textContent = 'Checking the URL…';
   try {
-    const cookie = $('analyzeCookie').value.trim() || null;
+    // First find out what we're dealing with: an RSS/Atom feed we can add
+    // straight away, or a website that needs the selector analysis.
+    const detected = await sdk.sourceAnalyzeDetect({ body: { url, cookie } });
+    if (detected.kind === 'feed') {
+      detectedFeed = { feed_url: detected.feed_url || url };
+      $('analyzeFeedName').value = detected.suggested_source_name || '';
+      $('analyzeFeedUrl').textContent = detectedFeed.feed_url;
+      $('analyzeInputStep').classList.add('hidden');
+      $('analyzeFeedStep').classList.remove('hidden');
+      return;
+    }
+
+    $('analyzeProgressText').textContent =
+      'Scraping the page and asking Ollama for selectors — this can take a minute or two…';
     const job = await sdk.sourceAnalyzeSuggest({ body: { url, cookie } });
     const suggestion = await pollAnalyzeJob(job.job_id);
     // custom: fields where the user typed a selector instead of picking one
@@ -1824,6 +1823,34 @@ async function handleAnalyzeWebsite(e) {
   } finally {
     $('analyzeBtn').disabled = false;
     $('analyzeProgress').classList.add('hidden');
+  }
+}
+
+// Add a source straight from a detected RSS/Atom feed URL (no scraping).
+async function handleAddDetectedFeed() {
+  if (!detectedFeed || !currentFeed) return;
+  const name = $('analyzeFeedName').value.trim();
+  if (!name) { toast('Please enter a source name', 'alert-error'); return; }
+
+  const btn = $('analyzeFeedAddBtn');
+  btn.disabled = true;
+  try {
+    await sdk.sourceCreate({
+      feed_name_hash: currentFeed.feed_name_hash,
+      source_name: name,
+      source_url: detectedFeed.feed_url,
+    });
+    closeModal('addSourceModal');
+    toast(`Source "${name}" added`);
+    resetAnalyzeTab();
+    $('analyzeUrl').value = '';
+    loadSources();
+    // the first ingest runs in the background; refresh to pick up its result
+    setTimeout(loadSources, 5000);
+  } catch (err) {
+    toast(err.message, 'alert-error');
+  } finally {
+    btn.disabled = false;
   }
 }
 

--- a/src/api/static/js/sdk.js
+++ b/src/api/static/js/sdk.js
@@ -205,6 +205,11 @@ class AggySDK {
     return this._request("POST", "/source/update", { body });
   }
 
+  /** Detect whether a URL is an RSS/Atom feed or an HTML page to scrape */
+  async sourceAnalyzeDetect({ body }) {
+    return this._request("POST", "/source_analyze/detect", { body });
+  }
+
   /** Preview the feed produced by a set of CSS selectors */
   async sourceAnalyzePreview({ body }) {
     return this._request("POST", "/source_analyze/preview", { body });

--- a/src/api/static/manifest.webmanifest
+++ b/src/api/static/manifest.webmanifest
@@ -6,7 +6,6 @@
   "start_url": "/app",
   "scope": "/",
   "display": "standalone",
-  "orientation": "any",
   "background_color": "#20252E",
   "theme_color": "#242933",
   "icons": [

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -289,8 +289,7 @@
 
     <div role="tablist" class="tabs tabs-boxed mb-4" id="sourceTabs">
       <a role="tab" class="tab tab-active" id="srcTabTemplate">From Template</a>
-      <a role="tab" class="tab" id="srcTabManual">Manual URL</a>
-      <a role="tab" class="tab" id="srcTabAnalyze">✨ From Website</a>
+      <a role="tab" class="tab" id="srcTabAnalyze">From URL</a>
       <a role="tab" class="tab" id="srcTabFeed">Another Feed</a>
     </div>
 
@@ -311,24 +310,6 @@
       </div>
     </div>
 
-    <!-- Manual Tab -->
-    <div id="sourceTabManual" class="hidden">
-      <form id="manualSourceForm">
-        <div class="form-control mb-3">
-          <label class="label" for="manualSourceName"><span class="label-text">Source Name</span></label>
-          <input type="text" class="input input-bordered w-full" id="manualSourceName" placeholder="e.g. Hacker News" required>
-        </div>
-        <div class="form-control mb-4">
-          <label class="label" for="manualSourceUrl"><span class="label-text">RSS Feed URL</span></label>
-          <input type="url" class="input input-bordered w-full" id="manualSourceUrl" placeholder="https://example.com/rss.xml" required>
-        </div>
-        <div class="modal-action">
-          <button type="button" class="btn btn-ghost" data-close-modal>Cancel</button>
-          <button type="submit" class="btn btn-primary">Add Source</button>
-        </div>
-      </form>
-    </div>
-
     <!-- Another Feed Tab -->
     <div id="sourceTabFeed" class="hidden">
       <p class="text-sm text-base-content/60 mb-3">
@@ -339,18 +320,20 @@
       <div class="max-h-[60vh] overflow-y-auto border border-base-300 rounded-lg" id="feedSourceList"></div>
     </div>
 
-    <!-- Analyze (AI) Tab -->
+    <!-- From URL Tab (auto-detects RSS feed vs. website to scrape) -->
     <div id="sourceTabAnalyze" class="hidden">
       <div id="analyzeInputStep">
         <p class="text-sm text-base-content/60 mb-3">
-          Paste the address of a page that lists articles (a blog index, news
-          section, release page...). Aggy scrapes it and uses the local Ollama
-          model to work out which parts of the page are the articles.
+          Paste an RSS/Atom feed URL, or the address of a page that lists
+          articles (a blog index, news section, release page...). Aggy detects
+          which it is: a feed is added directly, while a website is scraped and
+          analyzed by the local Ollama model to work out which parts are the
+          articles.
         </p>
         <form id="analyzeForm">
           <div class="form-control mb-3">
-            <label class="label" for="analyzeUrl"><span class="label-text">Website URL</span></label>
-            <input type="url" class="input input-bordered w-full" id="analyzeUrl" placeholder="https://example.com/blog/" required>
+            <label class="label" for="analyzeUrl"><span class="label-text">Feed or website URL</span></label>
+            <input type="url" class="input input-bordered w-full" id="analyzeUrl" placeholder="https://example.com/rss.xml or https://example.com/blog/" required>
           </div>
           <div class="form-control mb-3">
             <label class="label" for="analyzeCookie">
@@ -364,12 +347,31 @@
             </span></label>
           </div>
           <div class="flex justify-end">
-            <button type="submit" class="btn btn-primary btn-sm" id="analyzeBtn">Analyze Website</button>
+            <button type="submit" class="btn btn-primary btn-sm" id="analyzeBtn">Add Source</button>
           </div>
         </form>
         <div id="analyzeProgress" class="hidden text-sm text-base-content/60 mt-3">
           <span class="loading loading-spinner loading-sm align-middle mr-2"></span>
-          <span id="analyzeProgressText">Analyzing…</span>
+          <span id="analyzeProgressText">Checking the URL…</span>
+        </div>
+      </div>
+
+      <!-- Shown when the URL is detected to be an RSS/Atom feed -->
+      <div id="analyzeFeedStep" class="hidden">
+        <p class="text-sm text-success mb-3">
+          ✓ Detected an RSS/Atom feed — no scraping needed.
+        </p>
+        <div class="form-control mb-3">
+          <label class="label" for="analyzeFeedName"><span class="label-text">Source Name</span></label>
+          <input type="text" class="input input-bordered w-full" id="analyzeFeedName" placeholder="e.g. Hacker News" required>
+        </div>
+        <div class="form-control mb-3">
+          <label class="label"><span class="label-text">Feed URL</span></label>
+          <div class="text-xs text-base-content/50 break-all font-mono border border-base-300 rounded-lg p-2" id="analyzeFeedUrl"></div>
+        </div>
+        <div class="flex gap-2 justify-end mt-4">
+          <button class="btn btn-ghost btn-sm" id="analyzeFeedBackBtn">Back</button>
+          <button class="btn btn-primary btn-sm" id="analyzeFeedAddBtn">Add Source</button>
         </div>
       </div>
 

--- a/src/api/tests/bridge/analyze_test.py
+++ b/src/api/tests/bridge/analyze_test.py
@@ -3,6 +3,8 @@ import pytest
 from bridge.analyze import (
     AnalyzeError,
     condense_html,
+    detect_source_type,
+    discover_feed_url,
     fetch_page,
     php_time_format_to_strptime,
     suggest_source_name,
@@ -132,3 +134,60 @@ def test_suggest_source_name():
         == "Latest news"
     )
     assert suggest_source_name("", "https://some.site/news") == "some.site"
+
+
+RSS_FEED = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Some Blog Feed</title>
+    <item><title>First</title><link>https://some.site/one</link></item>
+  </channel>
+</rss>
+"""
+
+HTML_WITH_FEED_LINK = """
+<html>
+<head>
+  <title>Some Blog | Home</title>
+  <link rel="alternate" type="application/rss+xml" href="/feed.xml">
+</head>
+<body><a href="/one">First</a></body>
+</html>
+"""
+
+
+def test_detect_source_type_recognises_a_feed(monkeypatch):
+    monkeypatch.setattr("bridge.analyze.fetch_page", lambda url, cookie="": RSS_FEED)
+    result = detect_source_type("https://some.site/feed")
+    assert result["kind"] == "feed"
+    assert result["feed_url"] == "https://some.site/feed"
+    assert result["suggested_source_name"] == "Some Blog Feed"
+
+
+def test_detect_source_type_discovers_advertised_feed(monkeypatch):
+    monkeypatch.setattr(
+        "bridge.analyze.fetch_page", lambda url, cookie="": HTML_WITH_FEED_LINK
+    )
+    result = detect_source_type("https://some.site/")
+    assert result["kind"] == "feed"
+    # the relative href is resolved against the page URL
+    assert result["feed_url"] == "https://some.site/feed.xml"
+    assert result["suggested_source_name"] == "Some Blog"
+
+
+def test_detect_source_type_falls_back_to_html(monkeypatch):
+    monkeypatch.setattr("bridge.analyze.fetch_page", lambda url, cookie="": SAMPLE_HTML)
+    result = detect_source_type("https://example.com/blog/")
+    assert result["kind"] == "html"
+    assert result["feed_url"] is None
+    assert result["suggested_source_name"] == "Example Blog"
+
+
+def test_discover_feed_url_ignores_non_feed_links():
+    html = """
+    <html><head>
+      <link rel="stylesheet" href="/style.css">
+      <link rel="alternate" type="application/json" href="/feed.json">
+    </head><body></body></html>
+    """
+    assert discover_feed_url(html, "https://some.site/") is None

--- a/src/api/tests/routers/source_analyze_test.py
+++ b/src/api/tests/routers/source_analyze_test.py
@@ -175,6 +175,54 @@ def test_suggest_requires_auth(client):
     assert response.status_code == 401
 
 
+def test_detect_returns_feed_kind(client, token, monkeypatch):
+    monkeypatch.setattr(
+        "routers.source_analyze.detect_source_type",
+        lambda url, cookie: {
+            "kind": "feed",
+            "feed_url": url,
+            "suggested_source_name": "Example Blog",
+        },
+    )
+
+    args = build_api_request_args(
+        path="/source_analyze/detect",
+        token=token,
+        data={"url": "https://example.com/feed.xml"},
+    )
+    response = client.post(**args)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["kind"] == "feed"
+    assert data["feed_url"] == "https://example.com/feed.xml"
+    assert data["suggested_source_name"] == "Example Blog"
+
+
+def test_detect_surfaces_fetch_errors(client, token, monkeypatch):
+    def failing_detect(url, cookie):
+        raise AnalyzeError("Couldn't fetch the page", status_code=502)
+
+    monkeypatch.setattr("routers.source_analyze.detect_source_type", failing_detect)
+
+    args = build_api_request_args(
+        path="/source_analyze/detect",
+        token=token,
+        data={"url": "https://example.com/"},
+    )
+    response = client.post(**args)
+
+    assert response.status_code == 502
+    assert "Couldn't fetch" in response.json()["detail"]
+
+
+def test_detect_requires_auth(client):
+    response = client.post(
+        "/source_analyze/detect", json={"url": "https://example.com/"}
+    )
+    assert response.status_code == 401
+
+
 def test_preview_renders_bridge_feed(client, token, css_selector_template, monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Summary

Two UX fixes: one for the installed PWA, one for the add-source flow.

### 1. PWA respects the device orientation setting

The web app manifest declared `"orientation": "any"`. Declaring any orientation applies a **screen-orientation lock**, which overrides the device's own rotation-lock setting — so the app rotated even when the user had auto-rotate turned off.

Removing the `orientation` member means no lock is applied and the device's setting governs. The deliberate landscape lock used for fullscreen video (`screen.orientation.lock('landscape')` in `app.js`) is unrelated and left unchanged.

### 2. Combine "Manual URL" and "From Website" into one auto-detecting tab

Previously users had to know in advance whether a URL was an RSS feed (→ *Manual URL* tab) or a website to scrape (→ *✨ From Website* tab). These are now a single **From URL** tab that figures it out:

- A new `POST /source_analyze/detect` endpoint fetches the URL once and reports its `kind`:
  - **feed** — the URL parses as RSS/Atom (via `feedparser`), *or* it's an HTML page advertising a feed through `<link rel="alternate" type="application/rss+xml|atom+xml">` (auto-discovered and resolved to an absolute URL).
  - **html** — anything else.
- Detected feeds are added straight away via the existing `/source/create`, with a prefilled source name.
- HTML pages fall through to the existing Ollama selector-analysis flow, unchanged.

## Changes

- `static/manifest.webmanifest` — drop `orientation: any`.
- `bridge/analyze.py` — `detect_source_type()` + `discover_feed_url()` helpers.
- `route_models/source_analyze.py` — `DetectResponse` model.
- `routers/source_analyze.py` — `POST /source_analyze/detect`.
- `static/js/sdk.js` — regenerated: `sourceAnalyzeDetect()`.
- `templates/app.html` — merge the two tabs; add the feed-confirmation step.
- `static/js/app.js` — `handleAddByUrl()` (detect-first) and `handleAddDetectedFeed()`; remove the old manual-source handler.

## Testing

- `tests/bridge/analyze_test.py` — feed detection, `<link>` auto-discovery, HTML fallback, and non-feed link filtering.
- `tests/routers/source_analyze_test.py` — `/detect` returns the feed kind, surfaces fetch errors, and requires auth.
- Ran `python generate_sdk.py --check` locally: **sdk.js is up to date**.
- Bridge analyze test module passes (11 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTGSXTkG2FUPn9KzTrLemv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTGSXTkG2FUPn9KzTrLemv)_