### PR TITLE
Truncate long source-name badges instead of overflowing

### DIFF
--- a/src/api/static/css/style.css
+++ b/src/api/static/css/style.css
@@ -38,6 +38,17 @@
   }
 }
 
+/* ---- Source name badge ---- */
+
+/* A long source name would wrap inside the outlined pill and spill past its
+   rounded border (see the two-line overflow it used to cause). Cap the badge
+   width; the inner label (a `truncate min-w-0` flex child) then collapses with
+   an ellipsis so the badge always stays a single tidy line, regardless of how
+   long the source name is. max-width keeps room for the author/date beside it. */
+.aggy-source-badge {
+  max-width: 12rem;
+}
+
 /* ---- YouTube player (Plyr + SponsorBlock) ---- */
 
 /* Match Plyr's accent to the app's primary colour. */

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -719,9 +719,10 @@ function sourceBadge(name, storedColor) {
   if (!name) return null;
   const color = sourceColor(name, storedColor);
   return h('span', {
-    class: 'badge badge-outline badge-xs',
+    class: 'badge badge-outline badge-xs aggy-source-badge',
     style: `border-color:${color};color:${color}`,
-  }, name);
+    title: name,
+  }, h('span', { class: 'truncate min-w-0' }, name));
 }
 
 // "Open in new tab" icon (matches the modal close button's size/style),


### PR DESCRIPTION
## Problem

When a source has a long name (e.g. `YouTube (By custom name) - @bycloudAI`), the source-name badge on article cards wrapped onto two lines and spilled past its rounded outline border, looking broken.

## Fix

- Added an `.aggy-source-badge` class in `style.css` that caps the badge at `max-width: 12rem`, leaving room for the author/date beside it.
- In `sourceBadge()` (`app.js`), the name is now rendered inside an inner `truncate min-w-0` span, so a long name collapses to a single line with a trailing `…` instead of wrapping.
- Set the full name as the badge's `title` attribute so it's still available on hover.

Both places that render the badge (feed grid cards and list mode) go through `sourceBadge()`, so both are covered. Short names (e.g. `SimonDev`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VT137ATunef46Ri3wEwXB

---
_Generated by [Claude Code](https://claude.ai/code/session_018VT137ATunef46Ri3wEwXB)_