### PR TITLE
Make "Why this article?" fields tappable with better/worse examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,15 +18,16 @@ OLLAMA_EMBEDDING_MODEL=nomic-embed-text
 # (needs more RAM); it must not exceed the model's max context.
 OLLAMA_EMBEDDING_NUM_CTX=8192
 
-# Optional: Ollama vision model used to embed an item's preview image so the
-# recommender scores the picture on its own instead of only "has an image".
-# Leave unset to skip image embeddings (the has-image flag then carries the
-# signal). Any Ollama model whose embed endpoint accepts a base64 image works.
-# OLLAMA_IMAGE_EMBEDDING_MODEL=
-
-# Seconds to wait when downloading a preview image before giving up on
-# embedding it.
-OLLAMA_IMAGE_EMBEDDING_TIMEOUT_SECONDS=30
+# Preview images are embedded by the bundled CLIP service (aggy-image-embed in
+# docker-compose) so the recommender can score the picture itself, not just
+# whether one exists. docker-compose points the API at the service; these only
+# need changing if you run the service elsewhere or swap the CLIP model.
+# IMAGE_EMBED_HOST=aggy-image-embed
+# IMAGE_EMBED_PORT=8000
+# CLIP model the service runs; must match the one baked into aggy-image-embed.
+IMAGE_EMBED_MODEL=clip-ViT-B-32
+# Seconds to wait when downloading a preview image / calling the embed service.
+IMAGE_EMBED_TIMEOUT_SECONDS=30
 
 # Ollama chat model used to suggest CSS selectors when adding a source from
 # a bare website URL (the "From Website" tab). Any model that supports

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,16 @@ OLLAMA_EMBEDDING_MODEL=nomic-embed-text
 # (needs more RAM); it must not exceed the model's max context.
 OLLAMA_EMBEDDING_NUM_CTX=8192
 
+# Optional: Ollama vision model used to embed an item's preview image so the
+# recommender scores the picture on its own instead of only "has an image".
+# Leave unset to skip image embeddings (the has-image flag then carries the
+# signal). Any Ollama model whose embed endpoint accepts a base64 image works.
+# OLLAMA_IMAGE_EMBEDDING_MODEL=
+
+# Seconds to wait when downloading a preview image before giving up on
+# embedding it.
+OLLAMA_IMAGE_EMBEDDING_TIMEOUT_SECONDS=30
+
 # Ollama chat model used to suggest CSS selectors when adding a source from
 # a bare website URL (the "From Website" tab). Any model that supports
 # structured JSON output works; it is pulled automatically on first use.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
             context: ./src/bridge
           - service: migrations
             context: ./src/api/db/migrations
+          - service: image-embed
+            context: ./src/image_embed
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ When Aggy finds new content, it analyzes metadata and determines how relevant it
 
 ### Understanding your preferences
 
-Aggy uses **content embeddings** to understand the types of content you enjoy. As you browse, like, filter, or provide feedback, Aggy fine-tunes your feed so you get more of what you love without relying on generic algorithms or trends.
+Aggy uses **content embeddings** to understand the types of content you enjoy. As you browse, like, filter, or provide feedback, Aggy fine-tunes your feed so you get more of what you love without relying on generic algorithms or trends. Both the article **text** (via Ollama) and its **preview image** (via a bundled CLIP service, `aggy-image-embed`) are embedded and scored as separate signals.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ We’re still working on a contribution guide, but if you have ideas, we’d lov
 
 
 # TODO
-- [ ] generate embeddings for images
+- [x] generate embeddings for images
 - [ ] train models on user data + embeddings
 - [ ] use embeddings to help decide which image would be the best preview image
 - [ ] fix reddit albums getting very low res thumbnails

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,10 @@ services:
     volumes:
       - "aggy-ollama-data:/root/.ollama"
 
+  aggy-image-embed:
+    image: ghcr.io/mullinmax/aggy/aggy-image-embed:latest
+    restart: unless-stopped
+
   aggy-api:
     image: ghcr.io/mullinmax/aggy/aggy-api:latest
     environment:
@@ -63,6 +67,9 @@ services:
       - OLLAMA_EMBEDDING_MODEL=${OLLAMA_EMBEDDING_MODEL:-nomic-embed-text}
       - OLLAMA_EMBEDDING_NUM_CTX=${OLLAMA_EMBEDDING_NUM_CTX:-8192}
       - OLLAMA_ANALYSIS_MODEL=${OLLAMA_ANALYSIS_MODEL:-qwen3:4b}
+      - IMAGE_EMBED_HOST=aggy-image-embed
+      - IMAGE_EMBED_PORT=8000
+      - IMAGE_EMBED_MODEL=${IMAGE_EMBED_MODEL:-clip-ViT-B-32}
       - JWT_ALGORITHM=HS256
       - JWT_SECRET=${JWT_SECRET:?Set JWT_SECRET in .env (generate with `openssl rand -hex 32`)}
       - SIGNUP_ENABLED=${SIGNUP_ENABLED:-true}
@@ -74,6 +81,8 @@ services:
       aggy-extract:
         condition: service_started
       aggy-bridge:
+        condition: service_started
+      aggy-image-embed:
         condition: service_started
 
   cloudflared:

--- a/src/api/config.py
+++ b/src/api/config.py
@@ -19,6 +19,8 @@ KNOWN_CONFIG_VALUES = [
     "OLLAMA_PASSWORD",
     "OLLAMA_EMBEDDING_MODEL",
     "OLLAMA_EMBEDDING_NUM_CTX",
+    "OLLAMA_IMAGE_EMBEDDING_MODEL",
+    "OLLAMA_IMAGE_EMBEDDING_TIMEOUT_SECONDS",
     "OLLAMA_ANALYSIS_MODEL",
     "OLLAMA_ANALYSIS_NUM_CTX",
     "RSS_BRIDGE_HOST",
@@ -46,6 +48,13 @@ DEFAULT_CONFIG = {
     # large to process" and end up with no embedding. nomic-embed-text
     # supports up to 8192 tokens, so we raise the default to match.
     "OLLAMA_EMBEDDING_NUM_CTX": 8192,
+    # Vision model used to embed an item's preview image, so the recommender can
+    # score the picture on its own instead of only "has an image or not". Unset
+    # by default (OLLAMA_IMAGE_EMBEDDING_MODEL has no default) so deployments
+    # without a vision-capable Ollama model simply skip image embeddings and
+    # fall back to the presence flag. Any Ollama model whose embed endpoint
+    # accepts an image works (e.g. a CLIP-style embedder).
+    "OLLAMA_IMAGE_EMBEDDING_TIMEOUT_SECONDS": 30,
     # Text-generation model used to propose CSS selectors when creating a
     # source from a bare website URL. Any Ollama chat model that supports
     # structured (JSON schema) output works; qwen3:4b is small and reliable.

--- a/src/api/config.py
+++ b/src/api/config.py
@@ -19,8 +19,12 @@ KNOWN_CONFIG_VALUES = [
     "OLLAMA_PASSWORD",
     "OLLAMA_EMBEDDING_MODEL",
     "OLLAMA_EMBEDDING_NUM_CTX",
-    "OLLAMA_IMAGE_EMBEDDING_MODEL",
-    "OLLAMA_IMAGE_EMBEDDING_TIMEOUT_SECONDS",
+    # Image (thumbnail) embeddings are produced by a dedicated CLIP service
+    # (src/image_embed), since Ollama can't embed images.
+    "IMAGE_EMBED_HOST",
+    "IMAGE_EMBED_PORT",
+    "IMAGE_EMBED_MODEL",
+    "IMAGE_EMBED_TIMEOUT_SECONDS",
     "OLLAMA_ANALYSIS_MODEL",
     "OLLAMA_ANALYSIS_NUM_CTX",
     "RSS_BRIDGE_HOST",
@@ -48,13 +52,15 @@ DEFAULT_CONFIG = {
     # large to process" and end up with no embedding. nomic-embed-text
     # supports up to 8192 tokens, so we raise the default to match.
     "OLLAMA_EMBEDDING_NUM_CTX": 8192,
-    # Vision model used to embed an item's preview image, so the recommender can
-    # score the picture on its own instead of only "has an image or not". Unset
-    # by default (OLLAMA_IMAGE_EMBEDDING_MODEL has no default) so deployments
-    # without a vision-capable Ollama model simply skip image embeddings and
-    # fall back to the presence flag. Any Ollama model whose embed endpoint
-    # accepts an image works (e.g. a CLIP-style embedder).
-    "OLLAMA_IMAGE_EMBEDDING_TIMEOUT_SECONDS": 30,
+    # The CLIP image-embedding service (src/image_embed). IMAGE_EMBED_HOST is
+    # unset by default so a deployment without the service simply skips image
+    # embeddings and falls back to the has-image presence flag; the bundled
+    # docker-compose sets the host, enabling it out of the box. IMAGE_EMBED_MODEL
+    # is the label the vectors are stored under and must match the model the
+    # service actually runs.
+    "IMAGE_EMBED_PORT": 8000,
+    "IMAGE_EMBED_MODEL": "clip-ViT-B-32",
+    "IMAGE_EMBED_TIMEOUT_SECONDS": 30,
     # Text-generation model used to propose CSS selectors when creating a
     # source from a bare website URL. Any Ollama chat model that supports
     # structured (JSON schema) output works; qwen3:4b is small and reliable.

--- a/src/api/db/item.py
+++ b/src/api/db/item.py
@@ -1,6 +1,9 @@
 from pydantic import field_validator, StringConstraints, HttpUrl, model_validator
 from datetime import datetime
+import base64
+import logging
 import dateparser
+import httpx
 from bleach import clean
 from typing import Optional, List, Dict
 import html
@@ -23,7 +26,11 @@ class ItemBase(AggyBaseModel):
     # Rich media extracted at ingest time (gifs, videos, galleries): a list
     # of {"type": "image"|"gif"|"video", "url": ..., "poster": ...} dicts.
     media: Optional[List[Dict[str, Optional[str]]]] = None
+    # Text embeddings of the article body, keyed by model name.
     embeddings: Optional[Dict[str, List[float]]] = None
+    # Embeddings of the preview image, keyed by vision model name. Kept apart
+    # from the text embeddings so the recommender scores each piece on its own.
+    image_embeddings: Optional[Dict[str, List[float]]] = None
 
     @property
     def key(self):
@@ -56,6 +63,9 @@ class ItemBase(AggyBaseModel):
             "embeddings": json.dumps(data["embeddings"])
             if data.get("embeddings") is not None
             else None,
+            "image_embeddings": json.dumps(data["image_embeddings"])
+            if data.get("image_embeddings") is not None
+            else None,
         }
 
     def create(self, overwrite=False):
@@ -66,17 +76,19 @@ class ItemBase(AggyBaseModel):
         with self.db_con() as cur:
             cur.execute(
                 "INSERT INTO items (url_hash, url, title, author, domain, excerpt, "
-                "content, image_url, media, date_published, embeddings) "
+                "content, image_url, media, date_published, embeddings, "
+                "image_embeddings) "
                 "VALUES (%(url_hash)s, %(url)s, %(title)s, %(author)s, %(domain)s, "
                 "%(excerpt)s, %(content)s, %(image_url)s, %(media)s, "
-                "%(date_published)s, %(embeddings)s) "
+                "%(date_published)s, %(embeddings)s, %(image_embeddings)s) "
                 "ON CONFLICT (url_hash) DO UPDATE SET "
                 "url = EXCLUDED.url, title = EXCLUDED.title, author = EXCLUDED.author, "
                 "domain = EXCLUDED.domain, excerpt = EXCLUDED.excerpt, "
                 "content = EXCLUDED.content, image_url = EXCLUDED.image_url, "
                 "media = EXCLUDED.media, "
                 "date_published = EXCLUDED.date_published, "
-                "embeddings = EXCLUDED.embeddings",
+                "embeddings = EXCLUDED.embeddings, "
+                "image_embeddings = EXCLUDED.image_embeddings",
                 v,
             )
 
@@ -94,7 +106,8 @@ class ItemBase(AggyBaseModel):
         with cls.db_con() as cur:
             cur.execute(
                 "SELECT url, title, author, domain, excerpt, content, image_url, "
-                "media, date_published, embeddings FROM items WHERE url_hash = %s",
+                "media, date_published, embeddings, image_embeddings "
+                "FROM items WHERE url_hash = %s",
                 (url_hash,),
             )
             row = cur.fetchone()
@@ -178,7 +191,7 @@ class ItemBase(AggyBaseModel):
         return v
 
     def __str__(self):
-        non_printable = ["url_hash", "key", "embeddings", "media"]
+        non_printable = ["url_hash", "key", "embeddings", "image_embeddings", "media"]
         # all fields besides url_hash, key, and item_embeddings
         print_attrs = [
             f"{k.upper()} {getattr(self, k)}"
@@ -229,6 +242,47 @@ class ItemBase(AggyBaseModel):
 
         # add the embedding to self
         self.embeddings[ollama_embedding_model] = embedding
+
+    @staticmethod
+    def _fetch_image_base64(image_url: str) -> Optional[str]:
+        """Download the preview image and return it base64-encoded, or None if
+        it can't be fetched (dead link, timeout, non-image response)."""
+        timeout = config.get_int("OLLAMA_IMAGE_EMBEDDING_TIMEOUT_SECONDS")
+        response = httpx.get(image_url, timeout=timeout, follow_redirects=True)
+        response.raise_for_status()
+        return base64.b64encode(response.content).decode("ascii")
+
+    def add_image_embedding(self, model_name: str, force_refresh=False) -> None:
+        """Embed the item's preview image with a vision model so the recommender
+        can score the picture itself rather than only whether one exists.
+
+        No-op when the item has no image. Stored in ``image_embeddings`` (keyed
+        by model name), kept separate from the text ``embeddings`` so the two
+        pieces are never blended into one signal."""
+        if not self.image_url:
+            return
+
+        if self.image_embeddings is None:
+            self.image_embeddings = {}
+
+        if model_name in self.image_embeddings and not force_refresh:
+            return
+
+        try:
+            image_base64 = self._fetch_image_base64(self.image_url)
+        except Exception as e:
+            logging.error(f"Error fetching image {self.image_url}: {e}")
+            return
+
+        ollama = get_ollama_connection()
+        # The Ollama embed endpoint returns {"embeddings": [[...]]} for a single
+        # input; the vision model must accept an image passed as base64 input.
+        response = ollama.embed(model=model_name, input=image_base64)
+        vectors = response["embeddings"]
+        if not vectors:
+            return
+
+        self.image_embeddings[model_name] = list(vectors[0])
 
 
 class ItemStrict(ItemBase):

--- a/src/api/db/item.py
+++ b/src/api/db/item.py
@@ -244,22 +244,27 @@ class ItemBase(AggyBaseModel):
         self.embeddings[ollama_embedding_model] = embedding
 
     @staticmethod
-    def _fetch_image_base64(image_url: str) -> Optional[str]:
-        """Download the preview image and return it base64-encoded, or None if
-        it can't be fetched (dead link, timeout, non-image response)."""
-        timeout = config.get_int("OLLAMA_IMAGE_EMBEDDING_TIMEOUT_SECONDS")
+    def _fetch_image_base64(image_url: str) -> str:
+        """Download the preview image and return it base64-encoded."""
+        timeout = config.get_int("IMAGE_EMBED_TIMEOUT_SECONDS")
         response = httpx.get(image_url, timeout=timeout, follow_redirects=True)
         response.raise_for_status()
         return base64.b64encode(response.content).decode("ascii")
 
     def add_image_embedding(self, model_name: str, force_refresh=False) -> None:
-        """Embed the item's preview image with a vision model so the recommender
-        can score the picture itself rather than only whether one exists.
+        """Embed the item's preview image via the CLIP image-embedding service
+        (src/image_embed) so the recommender can score the picture itself rather
+        than only whether one exists.
 
-        No-op when the item has no image. Stored in ``image_embeddings`` (keyed
-        by model name), kept separate from the text ``embeddings`` so the two
-        pieces are never blended into one signal."""
+        No-op when the item has no image or the service isn't configured. Stored
+        in ``image_embeddings`` (keyed by model name), kept separate from the
+        text ``embeddings`` so the two pieces are never blended into one signal.
+        """
         if not self.image_url:
+            return
+
+        host = config.get("IMAGE_EMBED_HOST", None)
+        if host is None:
             return
 
         if self.image_embeddings is None:
@@ -274,15 +279,17 @@ class ItemBase(AggyBaseModel):
             logging.error(f"Error fetching image {self.image_url}: {e}")
             return
 
-        ollama = get_ollama_connection()
-        # The Ollama embed endpoint returns {"embeddings": [[...]]} for a single
-        # input; the vision model must accept an image passed as base64 input.
-        response = ollama.embed(model=model_name, input=image_base64)
-        vectors = response["embeddings"]
-        if not vectors:
-            return
-
-        self.image_embeddings[model_name] = list(vectors[0])
+        port = config.get_int("IMAGE_EMBED_PORT")
+        timeout = config.get_int("IMAGE_EMBED_TIMEOUT_SECONDS")
+        response = httpx.post(
+            f"http://{host}:{port}/embed",
+            json={"image_base64": image_base64},
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        embedding = response.json().get("embedding")
+        if embedding:
+            self.image_embeddings[model_name] = embedding
 
 
 class ItemStrict(ItemBase):

--- a/src/api/db/migrations/V13__item_image_embeddings.sql
+++ b/src/api/db/migrations/V13__item_image_embeddings.sql
@@ -1,0 +1,5 @@
+-- Store image (thumbnail) embeddings separately from the text embeddings so the
+-- recommender can score an article's picture on its own. Same shape as the
+-- `embeddings` column: a JSONB dict of {model_name: vector}, keyed by the vision
+-- model that produced each vector.
+ALTER TABLE items ADD COLUMN image_embeddings JSONB;

--- a/src/api/docker-compose.yml
+++ b/src/api/docker-compose.yml
@@ -65,6 +65,14 @@ services:
     volumes:
       - "dev-aggy-ollama-data:/root/.ollama"
 
+  dev-aggy-image-embed:
+    build:
+      context: ../image_embed
+      dockerfile: dockerfile
+    restart: unless-stopped
+    ports:
+      - 8000
+
   dev-aggy-api:
     build:
       context: .
@@ -87,6 +95,9 @@ services:
       # articles; mxbai-embed-large caps at 512 tokens and truncates most items.
       - OLLAMA_EMBEDDING_MODEL=nomic-embed-text
       - OLLAMA_EMBEDDING_NUM_CTX=8192
+      - IMAGE_EMBED_HOST=dev-aggy-image-embed
+      - IMAGE_EMBED_PORT=8000
+      - IMAGE_EMBED_MODEL=clip-ViT-B-32
       - JWT_ALGORITHM=HS256
       - JWT_SECRET=429bceb2ab20f5785a4b609a725b0164be73a95d8ce04706ed8366cfe6ade896 # openssl rand -hex 32
     labels:

--- a/src/api/ingest/jobs.py
+++ b/src/api/ingest/jobs.py
@@ -129,7 +129,8 @@ def rescrape_source(source: Source) -> None:
     from ranking.engine import rank_feed  # local import avoids an import cycle
 
     embedding_model = config.get("OLLAMA_EMBEDDING_MODEL", None)
-    image_embedding_model = config.get("OLLAMA_IMAGE_EMBEDDING_MODEL", None)
+    image_embed_host = config.get("IMAGE_EMBED_HOST", None)
+    image_embed_model = config.get("IMAGE_EMBED_MODEL")
     feeds_to_rerank: set = set()
 
     for item in source.query_items():
@@ -165,10 +166,10 @@ def rescrape_source(source: Source) -> None:
                 except Exception as e:
                     logging.error(f"Error re-embedding item {item.url}: {e}")
 
-            if image_changed and image_embedding_model is not None:
+            if image_changed and image_embed_host is not None:
                 try:
                     merged.add_image_embedding(
-                        model_name=image_embedding_model, force_refresh=True
+                        model_name=image_embed_model, force_refresh=True
                     )
                     embedding_changed = (
                         embedding_changed
@@ -204,17 +205,52 @@ def rescrape_source(source: Source) -> None:
 
 
 def download_embedding_model_job() -> None:
-    wanted = [
-        config.get("OLLAMA_EMBEDDING_MODEL", None),
-        config.get("OLLAMA_IMAGE_EMBEDDING_MODEL", None),
-    ]
-    wanted = [m for m in wanted if m is not None]
-    if not wanted:
+    embedding_model = config.get("OLLAMA_EMBEDDING_MODEL", None)
+
+    if embedding_model is None:
         return
 
     ollama = get_ollama_connection()
 
     models = ollama.list()
-    for model_name in wanted:
-        if model_name not in models:
-            ollama.pull(model_name)
+    if embedding_model not in models:
+        ollama.pull(embedding_model)
+
+
+def backfill_image_embeddings_job() -> None:
+    """One-shot at startup: embed the preview image of every stored item that's
+    missing an embedding for the current CLIP model. New items are embedded at
+    ingest time, but this catches everything scraped before the service existed
+    (or before the model changed). No-op when the service isn't configured."""
+    image_embed_host = config.get("IMAGE_EMBED_HOST", None)
+    if image_embed_host is None:
+        return
+    model_name = config.get("IMAGE_EMBED_MODEL")
+
+    with get_db_con() as cur:
+        cur.execute(
+            "SELECT url_hash FROM items WHERE image_url IS NOT NULL "
+            "AND (image_embeddings IS NULL "
+            "OR NOT jsonb_exists(image_embeddings, %s))",
+            (model_name,),
+        )
+        url_hashes = [row["url_hash"] for row in cur.fetchall()]
+
+    if not url_hashes:
+        return
+
+    logging.info(f"Backfilling image embeddings for {len(url_hashes)} item(s)...")
+    done = 0
+    for url_hash in url_hashes:
+        item = ItemLoose.read(url_hash)
+        if item is None:
+            continue
+        try:
+            item.add_image_embedding(model_name=model_name)
+            if item.image_embeddings and model_name in item.image_embeddings:
+                item.update()
+                done += 1
+        except Exception as e:
+            logging.error(f"Error backfilling image embedding for {item.url}: {e}")
+
+    logging.info(f"Image embedding backfill complete: {done}/{len(url_hashes)} embedded.")

--- a/src/api/ingest/jobs.py
+++ b/src/api/ingest/jobs.py
@@ -129,6 +129,7 @@ def rescrape_source(source: Source) -> None:
     from ranking.engine import rank_feed  # local import avoids an import cycle
 
     embedding_model = config.get("OLLAMA_EMBEDDING_MODEL", None)
+    image_embedding_model = config.get("OLLAMA_IMAGE_EMBEDDING_MODEL", None)
     feeds_to_rerank: set = set()
 
     for item in source.query_items():
@@ -146,11 +147,13 @@ def rescrape_source(source: Source) -> None:
             # merge_instances doesn't carry embeddings over; keep the existing
             # ones so a re-scrape never drops them
             merged.embeddings = item.embeddings
+            merged.image_embeddings = item.image_embeddings
 
             after = {f: getattr(merged, f) for f in _RESCRAPE_FIELDS}
             text_changed = any(
                 after[f] != before[f] for f in _EMBEDDING_TEXT_FIELDS
             )
+            image_changed = after["image_url"] != before["image_url"]
 
             embedding_changed = False
             if text_changed and embedding_model is not None:
@@ -161,6 +164,18 @@ def rescrape_source(source: Source) -> None:
                     embedding_changed = merged.embeddings != item.embeddings
                 except Exception as e:
                     logging.error(f"Error re-embedding item {item.url}: {e}")
+
+            if image_changed and image_embedding_model is not None:
+                try:
+                    merged.add_image_embedding(
+                        model_name=image_embedding_model, force_refresh=True
+                    )
+                    embedding_changed = (
+                        embedding_changed
+                        or merged.image_embeddings != item.image_embeddings
+                    )
+                except Exception as e:
+                    logging.error(f"Error re-embedding image {item.url}: {e}")
 
             if after == before and not embedding_changed:
                 continue  # nothing changed, leave the row untouched
@@ -189,13 +204,17 @@ def rescrape_source(source: Source) -> None:
 
 
 def download_embedding_model_job() -> None:
-    embedding_model = config.get("OLLAMA_EMBEDDING_MODEL", None)
-
-    if embedding_model is None:
+    wanted = [
+        config.get("OLLAMA_EMBEDDING_MODEL", None),
+        config.get("OLLAMA_IMAGE_EMBEDDING_MODEL", None),
+    ]
+    wanted = [m for m in wanted if m is not None]
+    if not wanted:
         return
 
     ollama = get_ollama_connection()
 
     models = ollama.list()
-    if embedding_model not in models:
-        ollama.pull(embedding_model)
+    for model_name in wanted:
+        if model_name not in models:
+            ollama.pull(model_name)

--- a/src/api/ingest/source.py
+++ b/src/api/ingest/source.py
@@ -116,6 +116,15 @@ def ingest_source(source: Source) -> None:
             except Exception as e:
                 logging.error(f"Error adding embedding to item: {e}")
 
+        # and an image embedding, when a vision model is configured and the item
+        # has a preview image
+        image_embedding_model = config.get("OLLAMA_IMAGE_EMBEDDING_MODEL", None)
+        if image_embedding_model is not None:
+            try:
+                final_item.add_image_embedding(model_name=image_embedding_model)
+            except Exception as e:
+                logging.error(f"Error adding image embedding to item: {e}")
+
         # write item to db
         try:
             final_item.create()

--- a/src/api/ingest/source.py
+++ b/src/api/ingest/source.py
@@ -116,12 +116,13 @@ def ingest_source(source: Source) -> None:
             except Exception as e:
                 logging.error(f"Error adding embedding to item: {e}")
 
-        # and an image embedding, when a vision model is configured and the item
-        # has a preview image
-        image_embedding_model = config.get("OLLAMA_IMAGE_EMBEDDING_MODEL", None)
-        if image_embedding_model is not None:
+        # and an image embedding, when the CLIP service is configured and the
+        # item has a preview image
+        if config.get("IMAGE_EMBED_HOST", None) is not None:
             try:
-                final_item.add_image_embedding(model_name=image_embedding_model)
+                final_item.add_image_embedding(
+                    model_name=config.get("IMAGE_EMBED_MODEL")
+                )
             except Exception as e:
                 logging.error(f"Error adding image embedding to item: {e}")
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -38,6 +38,7 @@ from ingest.jobs import (
     source_ingestion_scheduling_job,
     source_ingestion_job,
     download_embedding_model_job,
+    backfill_image_embeddings_job,
 )
 from ranking.engine import feed_ranking_job
 
@@ -102,6 +103,16 @@ async def app_lifespan(app: FastAPI):
         trigger="date",
         run_date=datetime.now(),
         id="download_embedding_model_job",
+        replace_existing=False,
+    )
+
+    # embed any preview images scraped before the image service existed, once at
+    # start up (no-op when the service isn't configured)
+    scheduler.add_job(
+        func=backfill_image_embeddings_job,
+        trigger="date",
+        run_date=datetime.now(),
+        id="backfill_image_embeddings_job",
         replace_existing=False,
     )
 

--- a/src/api/ranking/engine.py
+++ b/src/api/ranking/engine.py
@@ -65,6 +65,7 @@ def _row_to_features(row) -> ItemFeatures:
     return ItemFeatures(
         url_hash=row["url_hash"],
         embedding=_parse_embedding(row.get("embeddings")),
+        image_embedding=_parse_embedding(row.get("image_embeddings")),
         source=row.get("source_name"),
         author=row.get("author"),
         date_published=row.get("date_published"),
@@ -81,7 +82,7 @@ def _row_to_features(row) -> ItemFeatures:
 # feed. So an upvote cast in one feed trains every feed the item appears in.
 _FEED_ITEMS_SQL = (
     "SELECT i.url_hash, i.author, i.date_published, i.image_url, i.media, "
-    "i.embeddings, v.score AS vote, v.score_date AS vote_date, ("
+    "i.embeddings, i.image_embeddings, v.score AS vote, v.score_date AS vote_date, ("
     " SELECT s.name FROM source_items si"
     " JOIN sources s ON s.user_hash = si.user_hash"
     "  AND s.feed_hash = si.feed_hash AND s.name_hash = si.source_hash"

--- a/src/api/ranking/engine.py
+++ b/src/api/ranking/engine.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from db.base import get_db_con
 from db.feed import Feed
+from utils import is_playable_media_url
 from .models import (
     ItemFeatures,
     ModelStats,
@@ -62,6 +63,9 @@ def _row_to_features(row) -> ItemFeatures:
         except (TypeError, ValueError):
             media = None
     list_added_at = row.get("list_added_at")
+    # YouTube links and direct video files play inline in the UI without a
+    # stored media entry, so count them as media for scoring too.
+    has_media = bool(media) or is_playable_media_url(row.get("url"))
     return ItemFeatures(
         url_hash=row["url_hash"],
         embedding=_parse_embedding(row.get("embeddings")),
@@ -70,7 +74,7 @@ def _row_to_features(row) -> ItemFeatures:
         author=row.get("author"),
         date_published=row.get("date_published"),
         has_image=bool(row.get("image_url")),
-        has_media=bool(media),
+        has_media=has_media,
         label=_effective_label(row.get("vote"), list_added_at),
         # an unvoted-but-listed item is labelled as of when it was listed
         label_date=row.get("vote_date") or list_added_at,
@@ -81,7 +85,7 @@ def _row_to_features(row) -> ItemFeatures:
 # latest vote on it in *any* feed (the user_item_votes view), not just this
 # feed. So an upvote cast in one feed trains every feed the item appears in.
 _FEED_ITEMS_SQL = (
-    "SELECT i.url_hash, i.author, i.date_published, i.image_url, i.media, "
+    "SELECT i.url_hash, i.url, i.author, i.date_published, i.image_url, i.media, "
     "i.embeddings, i.image_embeddings, v.score AS vote, v.score_date AS vote_date, ("
     " SELECT s.name FROM source_items si"
     " JOIN sources s ON s.user_hash = si.user_hash"

--- a/src/api/ranking/explain.py
+++ b/src/api/ranking/explain.py
@@ -17,6 +17,7 @@ Computed on demand (it retrains the winning model on the feed's votes), because
 users look at it rarely.
 """
 
+import re
 from dataclasses import dataclass, replace
 from datetime import datetime
 from typing import List, Optional
@@ -90,6 +91,9 @@ class FieldPreview:
     date_published: Optional[datetime]
     has_image: bool
     has_media: bool
+    # True when this article's image is scored by a real vision embedding, not
+    # just the has-image presence flag.
+    image_embedded: bool
 
 
 @dataclass
@@ -148,9 +152,9 @@ def _marks(delta: float):
 
 
 # Display data for the field previews; the ML features don't carry the title,
-# image URL or excerpt, so we pull them for the one item being explained.
+# image URL or body text, so we pull them for the one item being explained.
 _ITEM_DISPLAY_SQL = (
-    "SELECT i.title, i.image_url, i.excerpt, ("
+    "SELECT i.title, i.image_url, i.excerpt, i.content, ("
     " SELECT s.name FROM source_items si"
     " JOIN sources s ON s.user_hash = si.user_hash"
     "  AND s.feed_hash = si.feed_hash AND s.name_hash = si.source_hash"
@@ -161,11 +165,26 @@ _ITEM_DISPLAY_SQL = (
     "WHERE c.user_hash = %s AND c.feed_hash = %s AND c.item_url_hash = %s"
 )
 
+_TAG_RE = re.compile(r"<[^>]+>")
+
 
 def _load_item_display(feed: Feed, url_hash: str) -> dict:
     with get_db_con() as cur:
         cur.execute(_ITEM_DISPLAY_SQL, (feed.user_hash, feed.name_hash, url_hash))
         return cur.fetchone() or {}
+
+
+def _preview_text(row: dict) -> Optional[str]:
+    """Title plus a body snippet, mirroring what's embedded for the text field
+    (the embedding covers the title *and* the article content, not just the
+    headline). Body prefers the clean excerpt, falling back to tag-stripped
+    content."""
+    title = row.get("title")
+    body = row.get("excerpt")
+    if not body and row.get("content"):
+        body = _TAG_RE.sub(" ", row["content"])
+        body = " ".join(body.split())[:500]
+    return "\n\n".join(part for part in (title, body) if part) or None
 
 
 def explain_item(
@@ -196,13 +215,14 @@ def explain_item(
 
     row = _load_item_display(feed, item_url_hash)
     preview = FieldPreview(
-        text=row.get("title") or row.get("excerpt"),
+        text=_preview_text(row),
         image_url=row.get("image_url"),
         source=row.get("source_name") or target.source,
         author=target.author,
         date_published=target.date_published,
         has_image=target.has_image,
         has_media=target.has_media,
+        image_embedded=target.image_embedding is not None,
     )
 
     contributions: List[FieldContribution] = []

--- a/src/api/ranking/explain.py
+++ b/src/api/ranking/explain.py
@@ -27,9 +27,17 @@ from db.feed import Feed
 from .engine import MIN_LABELS_TO_RANK, load_feed_features
 from .models import ItemFeatures, all_models, evaluate_models
 
-# |Δ score| thresholds for 0 / 1 / 2 marks. Predicted scores live in [-1, 1].
-_LEVEL1 = 0.04
-_LEVEL2 = 0.12
+# Marks rank the fields against each other rather than against a fixed Δ scale,
+# so one field can't run away with a huge number while the rest read as nothing.
+# A field counts as "used" once blanking it moves the predicted score (in
+# [-1, 1]) by at least this much; below it the model effectively ignored the
+# field and it reads as no-effect (·).
+_USED_FLOOR = 0.01
+# Among the used fields, one whose effect is this many times the median used
+# field's stands out and earns two marks; the rest get one. So a field that
+# genuinely mattered almost always shows at least one mark, and two marks are
+# reserved for a real standout.
+_STRONG_MULTIPLE = 1.3
 
 # Fields the model consumes, in display order. Each is scored by blanking it out
 # and re-evaluating, so text and image are measured independently. Entries are:
@@ -139,16 +147,42 @@ def _winner_model(feed: Feed, labeled: List[ItemFeatures]):
     return next((m for m in all_models() if m.name == chosen), None)
 
 
-def _marks(delta: float):
-    magnitude = abs(delta)
-    if magnitude >= _LEVEL2:
-        level = 2
-    elif magnitude >= _LEVEL1:
-        level = 1
+def _assign_marks(deltas: List[float]) -> List[tuple]:
+    """Turn the fields' raw Δs into (sign, level) marks, normalized across the
+    fields so the display always reads sensibly:
+
+    - a field's *level* (0/1/2) is judged relative to the other fields, not on
+      an absolute Δ. Every field the model actually used (Δ over the floor) gets
+      at least one mark, and a mark of two is reserved for a field whose effect
+      clearly stands out from the median — so it's unusual for a used field to
+      read as nothing, and unusual for one field to hog a huge number;
+    - a field's *sign* is the direction of its own Δ (removing it lowered the
+      score → it was helping → +; removing it raised the score → −).
+
+    Because a positive article's helpful fields carry the signal, its marks skew
+    +; a neutral article's signal is split, so its marks come out roughly
+    balanced."""
+    magnitudes = [abs(d) for d in deltas]
+    used = sorted(m for m in magnitudes if m >= _USED_FLOOR)
+    if used:
+        mid = len(used) // 2
+        median = (
+            used[mid] if len(used) % 2 else (used[mid - 1] + used[mid]) / 2.0
+        )
     else:
-        level = 0
-    sign = 0 if level == 0 else (1 if delta > 0 else -1)
-    return sign, level
+        median = 0.0
+
+    marks = []
+    for delta, magnitude in zip(deltas, magnitudes):
+        if magnitude < _USED_FLOOR:
+            level = 0
+        elif magnitude >= _STRONG_MULTIPLE * median:
+            level = 2
+        else:
+            level = 1
+        sign = 0 if level == 0 else (1 if delta > 0 else -1)
+        marks.append((sign, level))
+    return marks
 
 
 # Display data for the field previews; the ML features don't carry the title,
@@ -225,24 +259,30 @@ def explain_item(
         image_embedded=target.image_embedding is not None,
     )
 
-    contributions: List[FieldContribution] = []
-    for field, label, null_map, description in _FIELDS:
+    # Score every single-field ablation first, then assign marks from the whole
+    # set so they're normalized against each other (see _assign_marks).
+    deltas = []
+    for _field, _label, null_map, _description in _FIELDS:
         ablated = replace(target, **null_map)
         score = float(model.predict([ablated])[0][0])
         # removing a helpful field lowers the score, so baseline - score > 0
-        delta = baseline - score
-        sign, level = _marks(delta)
-        contributions.append(
-            FieldContribution(
-                field=field,
-                label=label,
-                sign=sign,
-                level=level,
-                delta=delta,
-                description=description,
-                preview=preview,
-            )
+        deltas.append(baseline - score)
+
+    marks = _assign_marks(deltas)
+    contributions = [
+        FieldContribution(
+            field=field,
+            label=label,
+            sign=sign,
+            level=level,
+            delta=delta,
+            description=description,
+            preview=preview,
         )
+        for (field, label, _null_map, description), delta, (sign, level) in zip(
+            _FIELDS, deltas, marks
+        )
+    ]
 
     return ItemExplanation(
         model_name=model.name, baseline_score=baseline, fields=contributions

--- a/src/api/ranking/explain.py
+++ b/src/api/ranking/explain.py
@@ -273,9 +273,20 @@ def explain_item(
     baseline = float(model.predict([target])[0][0])
     meta = _load_display_meta(feed)
 
+    # When the feed carries real image embeddings, score the Image field on the
+    # picture itself; otherwise fall back to the has-image presence flag.
+    has_image_embeddings = any(f.image_embedding is not None for f in features)
+
     rng = random.Random(seed)
     contributions: List[FieldContribution] = []
     for field, label, attr, description, dedup in _FIELDS:
+        if field == "image" and has_image_embeddings:
+            attr = "image_embedding"
+            description = (
+                "Just the preview image, embedded by the vision model. Swapping "
+                "other posts' images in shows which pictures the model treats as "
+                "a plus or a minus."
+            )
         population = [getattr(f, attr) for f in features]
         variations = [
             replace(target, **{attr: rng.choice(population)}) for _ in range(samples)

--- a/src/api/ranking/explain.py
+++ b/src/api/ranking/explain.py
@@ -1,122 +1,95 @@
 """Explain why the recommendation model scored a single article the way it did.
 
 The prediction models are opaque (a kNN vote, a ridge regression, a small net),
-so instead of reading their internals we probe them: hold the article fixed and,
-one field at a time, swap that field for many random/average values drawn from
-the rest of the feed. If the article's real value scores higher than those
-substitutes, that field is *pushing the recommendation up*; if lower, it's
-*dragging it down*. The size of the gap becomes 0, 1, or 2 marks.
+so instead of reading their internals we ablate them: hold the article fixed
+and, one field at a time, blank that field out (null the embedding, drop the
+source, forget the date …) and re-score. If removing a field lowers the score,
+that field was *pushing the recommendation up*; if the score rises without it,
+the field was *dragging it down*. The size of the change becomes 0, 1, or 2
+marks.
 
-The same swap also yields concrete evidence: substituting *one real article's*
-value at a time tells us which of the other posts' images/text/sources the model
-would have scored higher or lower than this one's. Those become the "scored
-better / scored worse" examples the UI shows when a field is tapped, so the
-opaque marks are backed by articles the user can actually look at.
+That's one evaluation per field against the article's own real data — cheap,
+and it measures each field's actual contribution rather than how it compares to
+random substitutes. Tapping a field also shows a preview of exactly what was
+being evaluated for it (this article's text, its thumbnail, its source, …).
 
-This is a per-instance permutation importance, computed on demand (it retrains
-the winning model on the feed's votes), because users look at it rarely.
+Computed on demand (it retrains the winning model on the feed's votes), because
+users look at it rarely.
 """
 
-import random
 from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import Dict, List, Optional
-
-import numpy as np
+from typing import List, Optional
 
 from db.base import get_db_con
 from db.feed import Feed
 from .engine import MIN_LABELS_TO_RANK, load_feed_features
 from .models import ItemFeatures, all_models, evaluate_models
 
-# How many substitute values to try per field. Enough to average out the
-# noise of random draws without making the on-demand call slow.
-_SAMPLES = 40
-
 # |Δ score| thresholds for 0 / 1 / 2 marks. Predicted scores live in [-1, 1].
 _LEVEL1 = 0.04
 _LEVEL2 = 0.12
 
-# How many "scored better" / "scored worse" example articles to surface per
-# field, and the smallest score gap that counts as a real difference.
-_EXAMPLES_PER_SIDE = 3
-_EXAMPLE_EPS = 1e-3
-
-# Fields the model consumes, in display order. Each is scored *in isolation* —
-# one piece of a fictional article is swapped and everything else held fixed —
-# so text and image never blur together. Entries are:
-#   (field id, label, ItemFeatures attr perturbed, blurb, dedup strategy)
-# dedup "item": every article is a distinct alternative (embeddings, dates, and
-# thumbnails, which we want to show individually even when a flag ties them).
-# dedup "value": the swap value repeats across articles (source/author/media),
-# so alternatives are collapsed to one per distinct value.
+# Fields the model consumes, in display order. Each is scored by blanking it out
+# and re-evaluating, so text and image are measured independently. Entries are:
+#   (field id, label, {attr: null-value to blank}, what-is-scored blurb)
+# The image field blanks both its embedding and the has-image flag, so the whole
+# picture is removed rather than half of it.
 _FIELDS = [
     (
         "text",
         "Text",
-        "embedding",
-        "Just the article's title and body text, embedded and compared against "
-        "the posts you've voted on — the image is scored separately.",
-        "item",
+        {"embedding": None},
+        "The article's title and body text, embedded and compared against the "
+        "posts you've voted on — the image is scored separately.",
     ),
     (
         "image",
         "Image",
-        "has_image",
-        "Just the preview image. Swapping other posts' thumbnails in shows "
-        "which images the model treats as a plus or a minus.",
-        "item",
+        {"image_embedding": None, "has_image": False},
+        "The preview image — its embedding when a vision model is configured, "
+        "otherwise just whether one is present.",
     ),
     (
         "source",
         "Source",
-        "source",
-        "Just the source or subreddit the article came from.",
-        "value",
+        {"source": None},
+        "The source or subreddit the article came from.",
     ),
     (
         "author",
         "Author",
-        "author",
-        "Just who wrote or posted the article.",
-        "value",
+        {"author": None},
+        "Who wrote or posted the article.",
     ),
     (
         "recency",
         "Recency",
-        "date_published",
-        "Just how recently the article was published.",
-        "item",
+        {"date_published": None},
+        "How recently the article was published.",
     ),
     (
         "media",
         "Media",
-        "has_media",
-        "Just whether the article has playable video or audio attached.",
-        "value",
+        {"has_media": False},
+        "Whether the article has playable video or audio attached.",
     ),
 ]
 
 
 @dataclass
-class FieldExample:
-    """One alternative value the probe swapped in, scored against the target's.
+class FieldPreview:
+    """A preview of exactly what this article contributed to the field being
+    scored — the real data the ablation blanked out. The UI shows only the one
+    piece relevant to the field (its text, its thumbnail, its source, …)."""
 
-    Every display field is carried, but the UI shows only the *one* piece this
-    field changed (a thumbnail for image, text for text, a source chip for
-    source, …), never the whole article."""
-
-    url_hash: str
-    title: Optional[str]
+    text: Optional[str]
     image_url: Optional[str]
     source: Optional[str]
-    excerpt: Optional[str]
     author: Optional[str]
     date_published: Optional[datetime]
+    has_image: bool
     has_media: bool
-    # substitute score minus baseline: >0 the model likes this value more than
-    # the article's own, <0 less.
-    delta: float
 
 
 @dataclass
@@ -130,9 +103,8 @@ class FieldContribution:
     delta: float
     # what this field feeds the model, in one sentence
     description: str
-    # other articles whose value the model scored higher / lower than this one's
-    better: List[FieldExample]
-    worse: List[FieldExample]
+    # this article's own value for the field, so you can see what was evaluated
+    preview: FieldPreview
 
 
 @dataclass
@@ -175,10 +147,10 @@ def _marks(delta: float):
     return sign, level
 
 
-# Display metadata for the example cards; the ML features don't carry titles or
-# image URLs, so we pull them separately keyed by url_hash.
-_DISPLAY_META_SQL = (
-    "SELECT i.url_hash, i.title, i.image_url, i.excerpt, ("
+# Display data for the field previews; the ML features don't carry the title,
+# image URL or excerpt, so we pull them for the one item being explained.
+_ITEM_DISPLAY_SQL = (
+    "SELECT i.title, i.image_url, i.excerpt, ("
     " SELECT s.name FROM source_items si"
     " JOIN sources s ON s.user_hash = si.user_hash"
     "  AND s.feed_hash = si.feed_hash AND s.name_hash = si.source_hash"
@@ -186,74 +158,24 @@ _DISPLAY_META_SQL = (
     "  AND si.item_url_hash = c.item_url_hash LIMIT 1) AS source_name "
     "FROM feed_items c "
     "JOIN items i ON i.url_hash = c.item_url_hash "
-    "WHERE c.user_hash = %s AND c.feed_hash = %s"
+    "WHERE c.user_hash = %s AND c.feed_hash = %s AND c.item_url_hash = %s"
 )
 
 
-def _load_display_meta(feed: Feed) -> Dict[str, dict]:
+def _load_item_display(feed: Feed, url_hash: str) -> dict:
     with get_db_con() as cur:
-        cur.execute(_DISPLAY_META_SQL, (feed.user_hash, feed.name_hash))
-        return {row["url_hash"]: row for row in cur.fetchall()}
-
-
-def _field_examples(
-    model,
-    target: ItemFeatures,
-    features: List[ItemFeatures],
-    attr: str,
-    baseline: float,
-    meta: Dict[str, dict],
-    dedup: str,
-) -> tuple:
-    """Score fictional copies of the target with a single field swapped in from
-    each other article, then return the swaps that scored best and worst versus
-    the baseline.
-
-    Only that one field is altered per copy, so the resulting delta isolates
-    that field's effect. Each alternative keeps a reference to the article it
-    came from so the UI can show exactly the swapped piece (a thumbnail, a line
-    of text, a source name), never the whole article. `dedup` is "item" to keep
-    every article distinct or "value" to collapse repeated swap values."""
-    others = [f for f in features if f.url_hash != target.url_hash]
-    if not others:
-        return [], []
-    variations = [replace(target, **{attr: getattr(f, attr)}) for f in others]
-    scores, _ = model.predict(variations)
-
-    seen = set()
-    entries = []
-    for f, score in zip(others, scores):
-        key = f.url_hash if dedup == "item" else getattr(f, attr)
-        if key in seen:
-            continue
-        seen.add(key)
-        row = meta.get(f.url_hash, {})
-        entries.append(
-            FieldExample(
-                url_hash=f.url_hash,
-                title=row.get("title"),
-                image_url=row.get("image_url"),
-                source=row.get("source_name"),
-                excerpt=row.get("excerpt"),
-                author=f.author,
-                date_published=f.date_published,
-                has_media=f.has_media,
-                delta=float(score) - baseline,
-            )
-        )
-
-    entries.sort(key=lambda e: e.delta, reverse=True)
-    better = [e for e in entries if e.delta > _EXAMPLE_EPS][:_EXAMPLES_PER_SIDE]
-    worse = [e for e in entries if e.delta < -_EXAMPLE_EPS][-_EXAMPLES_PER_SIDE:]
-    worse.reverse()  # most-negative first, mirroring `better`
-    return better, worse
+        cur.execute(_ITEM_DISPLAY_SQL, (feed.user_hash, feed.name_hash, url_hash))
+        return cur.fetchone() or {}
 
 
 def explain_item(
-    feed: Feed, item_url_hash: str, samples: int = _SAMPLES, seed: int = 0
+    feed: Feed, item_url_hash: str
 ) -> Optional[ItemExplanation]:
     """Return a per-field breakdown of what drives this item's predicted score,
-    or None when the feed has too few votes / the item isn't in the feed."""
+    or None when the feed has too few votes / the item isn't in the feed.
+
+    Each field is scored by blanking it out on the article and re-evaluating:
+    the drop (or rise) versus the full-article baseline is its contribution."""
     features = load_feed_features(feed)
     labeled = [f for f in features if f.label is not None]
     if len(labeled) < MIN_LABELS_TO_RANK:
@@ -268,35 +190,28 @@ def explain_item(
         return None
     model.fit(labeled)
 
-    # score the article and its substitutes as-of now (not vote time)
+    # score the article as-of now (not vote time)
     target = replace(target, label_date=None)
     baseline = float(model.predict([target])[0][0])
-    meta = _load_display_meta(feed)
 
-    # When the feed carries real image embeddings, score the Image field on the
-    # picture itself; otherwise fall back to the has-image presence flag.
-    has_image_embeddings = any(f.image_embedding is not None for f in features)
+    row = _load_item_display(feed, item_url_hash)
+    preview = FieldPreview(
+        text=row.get("title") or row.get("excerpt"),
+        image_url=row.get("image_url"),
+        source=row.get("source_name") or target.source,
+        author=target.author,
+        date_published=target.date_published,
+        has_image=target.has_image,
+        has_media=target.has_media,
+    )
 
-    rng = random.Random(seed)
     contributions: List[FieldContribution] = []
-    for field, label, attr, description, dedup in _FIELDS:
-        if field == "image" and has_image_embeddings:
-            attr = "image_embedding"
-            description = (
-                "Just the preview image, embedded by the vision model. Swapping "
-                "other posts' images in shows which pictures the model treats as "
-                "a plus or a minus."
-            )
-        population = [getattr(f, attr) for f in features]
-        variations = [
-            replace(target, **{attr: rng.choice(population)}) for _ in range(samples)
-        ]
-        substitute_scores, _ = model.predict(variations)
-        delta = baseline - float(np.mean(substitute_scores))
+    for field, label, null_map, description in _FIELDS:
+        ablated = replace(target, **null_map)
+        score = float(model.predict([ablated])[0][0])
+        # removing a helpful field lowers the score, so baseline - score > 0
+        delta = baseline - score
         sign, level = _marks(delta)
-        better, worse = _field_examples(
-            model, target, features, attr, baseline, meta, dedup
-        )
         contributions.append(
             FieldContribution(
                 field=field,
@@ -305,8 +220,7 @@ def explain_item(
                 level=level,
                 delta=delta,
                 description=description,
-                better=better,
-                worse=worse,
+                preview=preview,
             )
         )
 

--- a/src/api/ranking/explain.py
+++ b/src/api/ranking/explain.py
@@ -19,6 +19,7 @@ the winning model on the feed's votes), because users look at it rarely.
 
 import random
 from dataclasses import dataclass, replace
+from datetime import datetime
 from typing import Dict, List, Optional
 
 import numpy as np
@@ -41,67 +42,78 @@ _LEVEL2 = 0.12
 _EXAMPLES_PER_SIDE = 3
 _EXAMPLE_EPS = 1e-3
 
-# Fields the model actually consumes, in display order. Each entry is
-# (field id, label, ItemFeatures attribute perturbed, what-is-scored blurb).
-# "content" is the text embedding, generated from title + body together; the
-# image/media fields are currently presence flags (a real thumbnail embedding
-# slots into the same probe once image embeddings are ingested).
+# Fields the model consumes, in display order. Each is scored *in isolation* —
+# one piece of a fictional article is swapped and everything else held fixed —
+# so text and image never blur together. Entries are:
+#   (field id, label, ItemFeatures attr perturbed, blurb, dedup strategy)
+# dedup "item": every article is a distinct alternative (embeddings, dates, and
+# thumbnails, which we want to show individually even when a flag ties them).
+# dedup "value": the swap value repeats across articles (source/author/media),
+# so alternatives are collapsed to one per distinct value.
 _FIELDS = [
     (
-        "content",
-        "Content",
+        "text",
+        "Text",
         "embedding",
-        "The article's title and body text, turned into an embedding and "
-        "compared against the posts you've voted on.",
-    ),
-    (
-        "source",
-        "Source",
-        "source",
-        "Which source or subreddit the article came from.",
-    ),
-    (
-        "author",
-        "Author",
-        "author",
-        "Who wrote or posted the article.",
-    ),
-    (
-        "recency",
-        "Recency",
-        "date_published",
-        "How recently the article was published.",
+        "Just the article's title and body text, embedded and compared against "
+        "the posts you've voted on — the image is scored separately.",
+        "item",
     ),
     (
         "image",
         "Image",
         "has_image",
-        "Whether the article carries a preview image.",
+        "Just the preview image. Swapping other posts' thumbnails in shows "
+        "which images the model treats as a plus or a minus.",
+        "item",
+    ),
+    (
+        "source",
+        "Source",
+        "source",
+        "Just the source or subreddit the article came from.",
+        "value",
+    ),
+    (
+        "author",
+        "Author",
+        "author",
+        "Just who wrote or posted the article.",
+        "value",
+    ),
+    (
+        "recency",
+        "Recency",
+        "date_published",
+        "Just how recently the article was published.",
+        "item",
     ),
     (
         "media",
         "Media",
         "has_media",
-        "Whether the article has playable video or audio attached.",
+        "Just whether the article has playable video or audio attached.",
+        "value",
     ),
 ]
-
-# Fields whose swap value is a distinct per-item quantity (an embedding, a
-# timestamp): every article is its own example. The rest (source/author/flags)
-# repeat across items, so examples are de-duplicated by the value itself.
-_PER_ITEM_FIELDS = {"embedding", "image_embedding", "date_published"}
 
 
 @dataclass
 class FieldExample:
-    """One article whose value for a field the model scored differently from
-    the target's, used as concrete evidence behind the marks."""
+    """One alternative value the probe swapped in, scored against the target's.
+
+    Every display field is carried, but the UI shows only the *one* piece this
+    field changed (a thumbnail for image, text for text, a source chip for
+    source, …), never the whole article."""
 
     url_hash: str
     title: Optional[str]
     image_url: Optional[str]
     source: Optional[str]
     excerpt: Optional[str]
+    author: Optional[str]
+    date_published: Optional[datetime]
+    has_media: bool
     # substitute score minus baseline: >0 the model likes this value more than
     # the article's own, <0 less.
     delta: float
@@ -191,13 +203,17 @@ def _field_examples(
     attr: str,
     baseline: float,
     meta: Dict[str, dict],
+    dedup: str,
 ) -> tuple:
-    """Score the target with every other article's value for `attr` swapped in,
-    then return the articles that scored best and worst versus the baseline.
+    """Score fictional copies of the target with a single field swapped in from
+    each other article, then return the swaps that scored best and worst versus
+    the baseline.
 
-    This is the same permutation probe used for the marks, but keeping each
-    real article attached so the UI can show the actual images/text the model
-    was effectively weighing when it decided this field helps or hurts."""
+    Only that one field is altered per copy, so the resulting delta isolates
+    that field's effect. Each alternative keeps a reference to the article it
+    came from so the UI can show exactly the swapped piece (a thumbnail, a line
+    of text, a source name), never the whole article. `dedup` is "item" to keep
+    every article distinct or "value" to collapse repeated swap values."""
     others = [f for f in features if f.url_hash != target.url_hash]
     if not others:
         return [], []
@@ -207,7 +223,7 @@ def _field_examples(
     seen = set()
     entries = []
     for f, score in zip(others, scores):
-        key = f.url_hash if attr in _PER_ITEM_FIELDS else getattr(f, attr)
+        key = f.url_hash if dedup == "item" else getattr(f, attr)
         if key in seen:
             continue
         seen.add(key)
@@ -219,6 +235,9 @@ def _field_examples(
                 image_url=row.get("image_url"),
                 source=row.get("source_name"),
                 excerpt=row.get("excerpt"),
+                author=f.author,
+                date_published=f.date_published,
+                has_media=f.has_media,
                 delta=float(score) - baseline,
             )
         )
@@ -256,7 +275,7 @@ def explain_item(
 
     rng = random.Random(seed)
     contributions: List[FieldContribution] = []
-    for field, label, attr, description in _FIELDS:
+    for field, label, attr, description, dedup in _FIELDS:
         population = [getattr(f, attr) for f in features]
         variations = [
             replace(target, **{attr: rng.choice(population)}) for _ in range(samples)
@@ -265,7 +284,7 @@ def explain_item(
         delta = baseline - float(np.mean(substitute_scores))
         sign, level = _marks(delta)
         better, worse = _field_examples(
-            model, target, features, attr, baseline, meta
+            model, target, features, attr, baseline, meta, dedup
         )
         contributions.append(
             FieldContribution(

--- a/src/api/ranking/explain.py
+++ b/src/api/ranking/explain.py
@@ -7,13 +7,19 @@ the rest of the feed. If the article's real value scores higher than those
 substitutes, that field is *pushing the recommendation up*; if lower, it's
 *dragging it down*. The size of the gap becomes 0, 1, or 2 marks.
 
+The same swap also yields concrete evidence: substituting *one real article's*
+value at a time tells us which of the other posts' images/text/sources the model
+would have scored higher or lower than this one's. Those become the "scored
+better / scored worse" examples the UI shows when a field is tapped, so the
+opaque marks are backed by articles the user can actually look at.
+
 This is a per-instance permutation importance, computed on demand (it retrains
 the winning model on the feed's votes), because users look at it rarely.
 """
 
 import random
 from dataclasses import dataclass, replace
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import numpy as np
 
@@ -30,17 +36,75 @@ _SAMPLES = 40
 _LEVEL1 = 0.04
 _LEVEL2 = 0.12
 
-# Fields the model actually consumes, in display order, mapped to the
-# ItemFeatures attribute each one perturbs. "content" is the text embedding,
-# which is generated from the article's title + body together.
+# How many "scored better" / "scored worse" example articles to surface per
+# field, and the smallest score gap that counts as a real difference.
+_EXAMPLES_PER_SIDE = 3
+_EXAMPLE_EPS = 1e-3
+
+# Fields the model actually consumes, in display order. Each entry is
+# (field id, label, ItemFeatures attribute perturbed, what-is-scored blurb).
+# "content" is the text embedding, generated from title + body together; the
+# image/media fields are currently presence flags (a real thumbnail embedding
+# slots into the same probe once image embeddings are ingested).
 _FIELDS = [
-    ("content", "Content", "embedding"),
-    ("source", "Source", "source"),
-    ("author", "Author", "author"),
-    ("recency", "Recency", "date_published"),
-    ("image", "Image", "has_image"),
-    ("media", "Media", "has_media"),
+    (
+        "content",
+        "Content",
+        "embedding",
+        "The article's title and body text, turned into an embedding and "
+        "compared against the posts you've voted on.",
+    ),
+    (
+        "source",
+        "Source",
+        "source",
+        "Which source or subreddit the article came from.",
+    ),
+    (
+        "author",
+        "Author",
+        "author",
+        "Who wrote or posted the article.",
+    ),
+    (
+        "recency",
+        "Recency",
+        "date_published",
+        "How recently the article was published.",
+    ),
+    (
+        "image",
+        "Image",
+        "has_image",
+        "Whether the article carries a preview image.",
+    ),
+    (
+        "media",
+        "Media",
+        "has_media",
+        "Whether the article has playable video or audio attached.",
+    ),
 ]
+
+# Fields whose swap value is a distinct per-item quantity (an embedding, a
+# timestamp): every article is its own example. The rest (source/author/flags)
+# repeat across items, so examples are de-duplicated by the value itself.
+_PER_ITEM_FIELDS = {"embedding", "image_embedding", "date_published"}
+
+
+@dataclass
+class FieldExample:
+    """One article whose value for a field the model scored differently from
+    the target's, used as concrete evidence behind the marks."""
+
+    url_hash: str
+    title: Optional[str]
+    image_url: Optional[str]
+    source: Optional[str]
+    excerpt: Optional[str]
+    # substitute score minus baseline: >0 the model likes this value more than
+    # the article's own, <0 less.
+    delta: float
 
 
 @dataclass
@@ -52,6 +116,11 @@ class FieldContribution:
     # 0, 1, or 2 marks
     level: int
     delta: float
+    # what this field feeds the model, in one sentence
+    description: str
+    # other articles whose value the model scored higher / lower than this one's
+    better: List[FieldExample]
+    worse: List[FieldExample]
 
 
 @dataclass
@@ -94,6 +163,73 @@ def _marks(delta: float):
     return sign, level
 
 
+# Display metadata for the example cards; the ML features don't carry titles or
+# image URLs, so we pull them separately keyed by url_hash.
+_DISPLAY_META_SQL = (
+    "SELECT i.url_hash, i.title, i.image_url, i.excerpt, ("
+    " SELECT s.name FROM source_items si"
+    " JOIN sources s ON s.user_hash = si.user_hash"
+    "  AND s.feed_hash = si.feed_hash AND s.name_hash = si.source_hash"
+    " WHERE si.user_hash = c.user_hash AND si.feed_hash = c.feed_hash"
+    "  AND si.item_url_hash = c.item_url_hash LIMIT 1) AS source_name "
+    "FROM feed_items c "
+    "JOIN items i ON i.url_hash = c.item_url_hash "
+    "WHERE c.user_hash = %s AND c.feed_hash = %s"
+)
+
+
+def _load_display_meta(feed: Feed) -> Dict[str, dict]:
+    with get_db_con() as cur:
+        cur.execute(_DISPLAY_META_SQL, (feed.user_hash, feed.name_hash))
+        return {row["url_hash"]: row for row in cur.fetchall()}
+
+
+def _field_examples(
+    model,
+    target: ItemFeatures,
+    features: List[ItemFeatures],
+    attr: str,
+    baseline: float,
+    meta: Dict[str, dict],
+) -> tuple:
+    """Score the target with every other article's value for `attr` swapped in,
+    then return the articles that scored best and worst versus the baseline.
+
+    This is the same permutation probe used for the marks, but keeping each
+    real article attached so the UI can show the actual images/text the model
+    was effectively weighing when it decided this field helps or hurts."""
+    others = [f for f in features if f.url_hash != target.url_hash]
+    if not others:
+        return [], []
+    variations = [replace(target, **{attr: getattr(f, attr)}) for f in others]
+    scores, _ = model.predict(variations)
+
+    seen = set()
+    entries = []
+    for f, score in zip(others, scores):
+        key = f.url_hash if attr in _PER_ITEM_FIELDS else getattr(f, attr)
+        if key in seen:
+            continue
+        seen.add(key)
+        row = meta.get(f.url_hash, {})
+        entries.append(
+            FieldExample(
+                url_hash=f.url_hash,
+                title=row.get("title"),
+                image_url=row.get("image_url"),
+                source=row.get("source_name"),
+                excerpt=row.get("excerpt"),
+                delta=float(score) - baseline,
+            )
+        )
+
+    entries.sort(key=lambda e: e.delta, reverse=True)
+    better = [e for e in entries if e.delta > _EXAMPLE_EPS][:_EXAMPLES_PER_SIDE]
+    worse = [e for e in entries if e.delta < -_EXAMPLE_EPS][-_EXAMPLES_PER_SIDE:]
+    worse.reverse()  # most-negative first, mirroring `better`
+    return better, worse
+
+
 def explain_item(
     feed: Feed, item_url_hash: str, samples: int = _SAMPLES, seed: int = 0
 ) -> Optional[ItemExplanation]:
@@ -116,10 +252,11 @@ def explain_item(
     # score the article and its substitutes as-of now (not vote time)
     target = replace(target, label_date=None)
     baseline = float(model.predict([target])[0][0])
+    meta = _load_display_meta(feed)
 
     rng = random.Random(seed)
     contributions: List[FieldContribution] = []
-    for field, label, attr in _FIELDS:
+    for field, label, attr, description in _FIELDS:
         population = [getattr(f, attr) for f in features]
         variations = [
             replace(target, **{attr: rng.choice(population)}) for _ in range(samples)
@@ -127,9 +264,19 @@ def explain_item(
         substitute_scores, _ = model.predict(variations)
         delta = baseline - float(np.mean(substitute_scores))
         sign, level = _marks(delta)
+        better, worse = _field_examples(
+            model, target, features, attr, baseline, meta
+        )
         contributions.append(
             FieldContribution(
-                field=field, label=label, sign=sign, level=level, delta=delta
+                field=field,
+                label=label,
+                sign=sign,
+                level=level,
+                delta=delta,
+                description=description,
+                better=better,
+                worse=worse,
             )
         )
 

--- a/src/api/ranking/models.py
+++ b/src/api/ranking/models.py
@@ -18,10 +18,13 @@ tuple, which is how the shallow `neural_net` and the multi-layer
 proxy-reachable wheel drags in gigabytes of unused CUDA libraries, so we keep
 the image lean and let sklearn's MLP do the deep net on CPU.)
 
-All models consume `ItemFeatures`: the article's text embedding plus scalar
-side information (source, author, post age, media presence). Image/thumbnail
-embeddings slot into the same structure once image embedding ingestion lands;
-until then a has-image flag stands in.
+All models consume `ItemFeatures`: the article's text embedding, a separate
+image (thumbnail) embedding, and scalar side information (source, author, post
+age, image/media presence). The text and image embeddings occupy distinct
+blocks in the design matrix, each with its own present/absent flag, so a
+picture is weighed independently of the words. When a deployment has no vision
+model configured the image block is simply zero-width and the has-image
+presence flag carries the signal on its own.
 """
 
 import hashlib
@@ -95,22 +98,47 @@ def _aux_vector(item: ItemFeatures, now: datetime) -> np.ndarray:
     return vec
 
 
-def _embedding_or_zeros(item: ItemFeatures, dim: int) -> Tuple[np.ndarray, float]:
-    if item.embedding is not None and len(item.embedding) == dim:
-        v = np.asarray(item.embedding, dtype=float)
+def _unit_or_zeros(vector, dim: int) -> Tuple[np.ndarray, float]:
+    """L2-normalize an embedding to a fixed length, or return zeros plus a
+    "missing" flag when it's absent or the wrong size."""
+    if vector is not None and len(vector) == dim:
+        v = np.asarray(vector, dtype=float)
         norm = np.linalg.norm(v)
         if norm > 0:
             return v / norm, 1.0
     return np.zeros(dim), 0.0
 
 
+def _embedding_or_zeros(item: ItemFeatures, dim: int) -> Tuple[np.ndarray, float]:
+    return _unit_or_zeros(item.embedding, dim)
+
+
+def _embedding_dim(items: Sequence[ItemFeatures], attr: str) -> int:
+    """Length of the first present embedding of the given kind, else 0 — so a
+    feed with no image embeddings simply contributes a zero-width image block."""
+    for item in items:
+        vec = getattr(item, attr)
+        if vec is not None:
+            return len(vec)
+    return 0
+
+
 def _design_matrix(
-    items: Sequence[ItemFeatures], dim: int, now: datetime
+    items: Sequence[ItemFeatures], dim: int, image_dim: int, now: datetime
 ) -> np.ndarray:
+    """Feature rows: [text embedding | has-text | image embedding | has-image |
+    scalar side features]. Text and image occupy separate blocks, each with its
+    own present/absent flag, so the model weighs the picture independently of
+    the words (and of the mere has-image flag in the side features)."""
     rows = []
     for item in items:
         emb, has_emb = _embedding_or_zeros(item, dim)
-        rows.append(np.concatenate([emb, [has_emb], _aux_vector(item, now)]))
+        img_emb, has_img_emb = _unit_or_zeros(item.image_embedding, image_dim)
+        rows.append(
+            np.concatenate(
+                [emb, [has_emb], img_emb, [has_img_emb], _aux_vector(item, now)]
+            )
+        )
     return np.asarray(rows)
 
 
@@ -276,15 +304,13 @@ class _SklearnModel(VoteModel):
         raise NotImplementedError
 
     def _dim(self, items):
-        for i in items:
-            if i.embedding is not None:
-                return len(i.embedding)
-        return 0
+        return _embedding_dim(items, "embedding")
 
     def fit(self, items):
         self.now = datetime.now(timezone.utc)
         self.dim = self._dim(items)
-        X = _design_matrix(items, self.dim, self.now)
+        self.image_dim = _embedding_dim(items, "image_embedding")
+        X = _design_matrix(items, self.dim, self.image_dim, self.now)
         y = np.asarray([i.label for i in items], dtype=float)
         estimator = self._build_estimator()
         self.model = (
@@ -293,7 +319,7 @@ class _SklearnModel(VoteModel):
         self.model.fit(X, y)
 
     def predict(self, items):
-        X = _design_matrix(items, self.dim, self.now)
+        X = _design_matrix(items, self.dim, self.image_dim, self.now)
         scores = np.clip(self.model.predict(X), -1.0, 1.0)
         confs = np.clip(0.1 + 0.8 * np.abs(scores), 0.0, 1.0)
         return scores, confs
@@ -464,15 +490,13 @@ class LogisticVoteModel(VoteModel):
         self.C = C
 
     def _dim(self, items):
-        for i in items:
-            if i.embedding is not None:
-                return len(i.embedding)
-        return 0
+        return _embedding_dim(items, "embedding")
 
     def fit(self, items):
         self.now = datetime.now(timezone.utc)
         self.dim = self._dim(items)
-        X = _design_matrix(items, self.dim, self.now)
+        self.image_dim = _embedding_dim(items, "image_embedding")
+        X = _design_matrix(items, self.dim, self.image_dim, self.now)
         labels = np.asarray([i.label for i in items], dtype=float)
         self.scaler = StandardScaler().fit(X)
         Xs = self.scaler.transform(X)
@@ -486,7 +510,7 @@ class LogisticVoteModel(VoteModel):
         self.clf = LogisticRegression(C=self.C, max_iter=1000).fit(Xs, y)
 
     def predict(self, items):
-        X = _design_matrix(items, self.dim, self.now)
+        X = _design_matrix(items, self.dim, self.image_dim, self.now)
         if self.clf is None:
             scores = np.full(len(items), self.constant)
             return scores, np.full(len(items), 0.1)

--- a/src/api/route_models/ranking.py
+++ b/src/api/route_models/ranking.py
@@ -26,6 +26,17 @@ class RankingStatsResponse(BaseRouteModel):
     predicted_items: int
 
 
+class FieldExampleResponse(BaseRouteModel):
+    url_hash: str
+    title: Optional[str] = None
+    image_url: Optional[str] = None
+    source: Optional[str] = None
+    excerpt: Optional[str] = None
+    # substitute score minus baseline: >0 the model scores this value higher
+    # than the article's own, <0 lower
+    delta: float
+
+
 class FieldContributionResponse(BaseRouteModel):
     field: str
     label: str
@@ -33,6 +44,11 @@ class FieldContributionResponse(BaseRouteModel):
     sign: int
     # number of marks to show: 0, 1, or 2
     level: int
+    # one-sentence description of what this field feeds the model
+    description: str = ""
+    # other articles the model scored higher / lower on this field
+    better: List[FieldExampleResponse] = []
+    worse: List[FieldExampleResponse] = []
 
 
 class ItemExplanationResponse(BaseRouteModel):

--- a/src/api/route_models/ranking.py
+++ b/src/api/route_models/ranking.py
@@ -26,18 +26,16 @@ class RankingStatsResponse(BaseRouteModel):
     predicted_items: int
 
 
-class FieldExampleResponse(BaseRouteModel):
-    url_hash: str
-    title: Optional[str] = None
+class FieldPreviewResponse(BaseRouteModel):
+    # this article's own value for the field, so the UI can show exactly what
+    # was evaluated (only the piece relevant to the field is displayed)
+    text: Optional[str] = None
     image_url: Optional[str] = None
     source: Optional[str] = None
-    excerpt: Optional[str] = None
     author: Optional[str] = None
     date_published: Optional[datetime] = None
+    has_image: bool = False
     has_media: bool = False
-    # substitute score minus baseline: >0 the model scores this value higher
-    # than the article's own, <0 lower
-    delta: float
 
 
 class FieldContributionResponse(BaseRouteModel):
@@ -49,9 +47,8 @@ class FieldContributionResponse(BaseRouteModel):
     level: int
     # one-sentence description of what this field feeds the model
     description: str = ""
-    # other articles the model scored higher / lower on this field
-    better: List[FieldExampleResponse] = []
-    worse: List[FieldExampleResponse] = []
+    # this article's own value for the field (what was evaluated)
+    preview: Optional[FieldPreviewResponse] = None
 
 
 class ItemExplanationResponse(BaseRouteModel):

--- a/src/api/route_models/ranking.py
+++ b/src/api/route_models/ranking.py
@@ -36,6 +36,8 @@ class FieldPreviewResponse(BaseRouteModel):
     date_published: Optional[datetime] = None
     has_image: bool = False
     has_media: bool = False
+    # whether the image is scored by a real vision embedding vs presence only
+    image_embedded: bool = False
 
 
 class FieldContributionResponse(BaseRouteModel):

--- a/src/api/route_models/ranking.py
+++ b/src/api/route_models/ranking.py
@@ -32,6 +32,9 @@ class FieldExampleResponse(BaseRouteModel):
     image_url: Optional[str] = None
     source: Optional[str] = None
     excerpt: Optional[str] = None
+    author: Optional[str] = None
+    date_published: Optional[datetime] = None
+    has_media: bool = False
     # substitute score minus baseline: >0 the model scores this value higher
     # than the article's own, <0 lower
     delta: float

--- a/src/api/routers/feed.py
+++ b/src/api/routers/feed.py
@@ -10,7 +10,7 @@ from route_models.item import ItemResponse
 from route_models.acknowledge import AcknowledgeResponse
 from route_models.ranking import (
     FieldContributionResponse,
-    FieldExampleResponse,
+    FieldPreviewResponse,
     ItemExplanationResponse,
     ModelStatsResponse,
     RankingStatsResponse,
@@ -242,17 +242,15 @@ def get_item_explanation(
             status_code=409,
             detail="Not enough votes yet to explain this recommendation.",
         )
-    def _example(e) -> FieldExampleResponse:
-        return FieldExampleResponse(
-            url_hash=e.url_hash,
-            title=e.title,
-            image_url=e.image_url,
-            source=e.source,
-            excerpt=e.excerpt,
-            author=e.author,
-            date_published=e.date_published,
-            has_media=e.has_media,
-            delta=e.delta,
+    def _preview(p) -> FieldPreviewResponse:
+        return FieldPreviewResponse(
+            text=p.text,
+            image_url=p.image_url,
+            source=p.source,
+            author=p.author,
+            date_published=p.date_published,
+            has_image=p.has_image,
+            has_media=p.has_media,
         )
 
     return ItemExplanationResponse(
@@ -265,8 +263,7 @@ def get_item_explanation(
                 sign=f.sign,
                 level=f.level,
                 description=f.description,
-                better=[_example(e) for e in f.better],
-                worse=[_example(e) for e in f.worse],
+                preview=_preview(f.preview),
             )
             for f in explanation.fields
         ],

--- a/src/api/routers/feed.py
+++ b/src/api/routers/feed.py
@@ -251,6 +251,7 @@ def get_item_explanation(
             date_published=p.date_published,
             has_image=p.has_image,
             has_media=p.has_media,
+            image_embedded=p.image_embedded,
         )
 
     return ItemExplanationResponse(

--- a/src/api/routers/feed.py
+++ b/src/api/routers/feed.py
@@ -249,6 +249,9 @@ def get_item_explanation(
             image_url=e.image_url,
             source=e.source,
             excerpt=e.excerpt,
+            author=e.author,
+            date_published=e.date_published,
+            has_media=e.has_media,
             delta=e.delta,
         )
 

--- a/src/api/routers/feed.py
+++ b/src/api/routers/feed.py
@@ -10,6 +10,7 @@ from route_models.item import ItemResponse
 from route_models.acknowledge import AcknowledgeResponse
 from route_models.ranking import (
     FieldContributionResponse,
+    FieldExampleResponse,
     ItemExplanationResponse,
     ModelStatsResponse,
     RankingStatsResponse,
@@ -241,12 +242,28 @@ def get_item_explanation(
             status_code=409,
             detail="Not enough votes yet to explain this recommendation.",
         )
+    def _example(e) -> FieldExampleResponse:
+        return FieldExampleResponse(
+            url_hash=e.url_hash,
+            title=e.title,
+            image_url=e.image_url,
+            source=e.source,
+            excerpt=e.excerpt,
+            delta=e.delta,
+        )
+
     return ItemExplanationResponse(
         model_name=explanation.model_name,
         baseline_score=explanation.baseline_score,
         fields=[
             FieldContributionResponse(
-                field=f.field, label=f.label, sign=f.sign, level=f.level
+                field=f.field,
+                label=f.label,
+                sign=f.sign,
+                level=f.level,
+                description=f.description,
+                better=[_example(e) for e in f.better],
+                worse=[_example(e) for e in f.worse],
             )
             for f in explanation.fields
         ],

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -1195,13 +1195,23 @@ function contributionMarks(sign, level) {
 // can see exactly what was scored, never the whole article.
 function fieldPreview(p, field) {
   if (field === 'image') {
-    return p.image_url
+    const thumb = p.image_url
       ? h('img', {
           src: p.image_url, alt: '', loading: 'lazy',
-          class: 'w-24 h-16 object-cover rounded bg-base-300 shrink-0',
+          class: 'w-24 h-16 object-cover rounded bg-base-300',
         })
-      : h('div', { class: 'w-24 h-16 rounded bg-base-300 flex items-center justify-center text-[10px] text-base-content/40 shrink-0' },
+      : h('div', { class: 'w-24 h-16 rounded bg-base-300 flex items-center justify-center text-[10px] text-base-content/40' },
           p.has_image ? 'image' : 'no image');
+    // spell out whether the picture is scored by a vision embedding or only by
+    // its presence, so it's clear what the model actually sees.
+    const note = !p.has_image
+      ? { txt: 'no image to score', cls: 'text-base-content/40' }
+      : p.image_embedded
+        ? { txt: '✓ scored by image embedding', cls: 'text-success' }
+        : { txt: 'presence only — no image embedding', cls: 'text-base-content/50' };
+    return h('div', { class: 'shrink-0' },
+      thumb,
+      h('p', { class: `text-[10px] mt-1 ${note.cls}` }, note.txt));
   }
   if (field === 'text') {
     return h('div', { class: 'w-full rounded bg-base-200 border border-base-300 p-2' },

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -1189,15 +1189,65 @@ function contributionMarks(sign, level) {
   return h('span', { class: `font-bold ${cls}` }, symbol.repeat(level));
 }
 
-function renderExplanation(data) {
-  const rows = data.fields.map((f) =>
-    h('div', { class: 'flex items-center justify-between py-1.5 border-b border-base-300 last:border-b-0' },
-      h('span', { class: 'text-sm' }, f.label),
-      h('span', { class: 'text-lg leading-none tracking-widest' }, contributionMarks(f.sign, f.level))));
+// One example article behind a field: its preview image (or a placeholder when
+// the field being explained is exactly "has an image") plus a title/source, so
+// the user can see the actual image/text the model weighed.
+function exampleCard(ex) {
+  const thumb = ex.image_url
+    ? h('img', {
+        src: ex.image_url, alt: '', loading: 'lazy',
+        class: 'w-full h-14 object-cover rounded bg-base-300',
+      })
+    : h('div', { class: 'w-full h-14 rounded bg-base-300 flex items-center justify-center text-[10px] text-base-content/40' }, 'no image');
+  const caption = ex.title || ex.excerpt || ex.source || 'Untitled';
+  return h('div', { class: 'w-24 shrink-0' },
+    thumb,
+    h('p', { class: 'text-[11px] leading-tight mt-1 line-clamp-2 text-base-content/70' }, caption),
+    ex.source ? h('p', { class: 'text-[10px] text-base-content/40 truncate' }, ex.source) : null);
+}
 
+// A titled, horizontally-scrolling strip of example cards (better or worse).
+function exampleStrip(heading, cls, examples) {
+  if (!examples || !examples.length) return null;
+  return h('div', { class: 'mt-2' },
+    h('p', { class: `text-[11px] font-semibold ${cls} mb-1` }, heading),
+    h('div', { class: 'flex gap-2 overflow-x-auto pb-1' }, examples.map(exampleCard)));
+}
+
+// The panel revealed when a field is tapped: what the field feeds the model,
+// plus the articles it scored higher/lower on that field.
+function fieldDetail(f) {
+  const hasExamples = (f.better && f.better.length) || (f.worse && f.worse.length);
+  return h('div', { class: 'pl-6 pr-1 pb-3 -mt-0.5' },
+    f.description ? h('p', { class: 'text-xs text-base-content/60' }, f.description) : null,
+    exampleStrip('Articles it scored higher', 'text-success', f.better),
+    exampleStrip('Articles it scored lower', 'text-error', f.worse),
+    hasExamples ? null
+      : h('p', { class: 'text-[11px] text-base-content/40 mt-2' },
+          'No comparable articles in this feed yet.'));
+}
+
+// A tappable field row: the label + marks, expanding to show fieldDetail().
+function fieldRow(f) {
+  const detail = fieldDetail(f);
+  detail.classList.add('hidden');
+  const chevron = h('span', { class: 'text-base-content/30 text-xs w-3' }, '▸');
+  const header = h('button', {
+    type: 'button', class: 'w-full flex items-center justify-between py-1.5 text-left',
+    onclick: () => {
+      const nowHidden = detail.classList.toggle('hidden');
+      chevron.textContent = nowHidden ? '▸' : '▾';
+    },
+  },
+    h('span', { class: 'flex items-center gap-2' }, chevron, h('span', { class: 'text-sm' }, f.label)),
+    h('span', { class: 'text-lg leading-none tracking-widest' }, contributionMarks(f.sign, f.level)));
+  return h('div', { class: 'border-b border-base-300 last:border-b-0' }, header, detail);
+}
+
+function renderExplanation(data) {
   const pct = Math.round(data.baseline_score * 100);
   render($('explainBody'),
-    h('div', { class: 'flex flex-col' }, rows),
+    h('div', { class: 'flex flex-col' }, data.fields.map(fieldRow)),
     h('p', { class: 'text-xs text-base-content/50 mt-4' },
       `Predicted match ${pct > 0 ? '+' : ''}${pct}% · model: ${MODEL_LABELS[data.model_name] || data.model_name}`));
 }

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -1190,42 +1190,52 @@ function contributionMarks(sign, level) {
   return h('span', { class: `font-bold ${cls}` }, symbol.repeat(level));
 }
 
-// One example article behind a field: its preview image (or a placeholder when
-// the field being explained is exactly "has an image") plus a title/source, so
-// the user can see the actual image/text the model weighed.
-function exampleCard(ex) {
-  const thumb = ex.image_url
-    ? h('img', {
-        src: ex.image_url, alt: '', loading: 'lazy',
-        class: 'w-full h-14 object-cover rounded bg-base-300',
-      })
-    : h('div', { class: 'w-full h-14 rounded bg-base-300 flex items-center justify-center text-[10px] text-base-content/40' }, 'no image');
-  const caption = ex.title || ex.excerpt || ex.source || 'Untitled';
-  return h('div', { class: 'w-24 shrink-0' },
-    thumb,
-    h('p', { class: 'text-[11px] leading-tight mt-1 line-clamp-2 text-base-content/70' }, caption),
-    ex.source ? h('p', { class: 'text-[10px] text-base-content/40 truncate' }, ex.source) : null);
+// Render ONLY the single piece a field's probe swapped in — a thumbnail for
+// Image, a line of text for Text, a chip for Source/Author/Recency/Media —
+// never the whole article, so each alternative reads as "just this one thing
+// changed".
+function examplePiece(ex, field) {
+  if (field === 'image') {
+    return ex.image_url
+      ? h('img', {
+          src: ex.image_url, alt: '', loading: 'lazy',
+          class: 'w-24 h-16 object-cover rounded bg-base-300 shrink-0',
+        })
+      : h('div', { class: 'w-24 h-16 rounded bg-base-300 flex items-center justify-center text-[10px] text-base-content/40 shrink-0' }, 'no image');
+  }
+  if (field === 'text') {
+    const txt = ex.title || ex.excerpt || '(no text)';
+    return h('div', { class: 'w-40 shrink-0 rounded bg-base-200 border border-base-300 p-2' },
+      h('p', { class: 'text-[11px] leading-snug line-clamp-3 text-base-content/80' }, txt));
+  }
+  let txt = '';
+  if (field === 'source') txt = ex.source || '(no source)';
+  else if (field === 'author') txt = ex.author ? `@${ex.author}` : '(no author)';
+  else if (field === 'recency') txt = ex.date_published ? timeAgo(ex.date_published) : '(no date)';
+  else if (field === 'media') txt = ex.has_media ? 'video / audio' : 'no media';
+  return h('span', { class: 'shrink-0 badge badge-outline whitespace-nowrap' }, txt);
 }
 
-// A titled, horizontally-scrolling strip of example cards (better or worse).
-function exampleStrip(heading, cls, examples) {
+// A titled, horizontally-scrolling strip of the swapped pieces (better/worse).
+function exampleStrip(heading, cls, examples, field) {
   if (!examples || !examples.length) return null;
   return h('div', { class: 'mt-2' },
     h('p', { class: `text-[11px] font-semibold ${cls} mb-1` }, heading),
-    h('div', { class: 'flex gap-2 overflow-x-auto pb-1' }, examples.map(exampleCard)));
+    h('div', { class: 'flex gap-2 overflow-x-auto pb-1 items-start' },
+      examples.map((ex) => examplePiece(ex, field))));
 }
 
 // The panel revealed when a field is tapped: what the field feeds the model,
-// plus the articles it scored higher/lower on that field.
+// plus the alternatives (for this field alone) it scored higher/lower.
 function fieldDetail(f) {
   const hasExamples = (f.better && f.better.length) || (f.worse && f.worse.length);
   return h('div', { class: 'pl-6 pr-1 pb-3 -mt-0.5' },
     f.description ? h('p', { class: 'text-xs text-base-content/60' }, f.description) : null,
-    exampleStrip('Articles it scored higher', 'text-success', f.better),
-    exampleStrip('Articles it scored lower', 'text-error', f.worse),
+    exampleStrip('Scored higher', 'text-success', f.better, f.field),
+    exampleStrip('Scored lower', 'text-error', f.worse, f.field),
     hasExamples ? null
       : h('p', { class: 'text-[11px] text-base-content/40 mt-2' },
-          'No comparable articles in this feed yet.'));
+          'No alternatives changed the score for this field.'));
 }
 
 // A tappable field row: the label + marks, expanding to show fieldDetail().

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -1190,52 +1190,41 @@ function contributionMarks(sign, level) {
   return h('span', { class: `font-bold ${cls}` }, symbol.repeat(level));
 }
 
-// Render ONLY the single piece a field's probe swapped in — a thumbnail for
-// Image, a line of text for Text, a chip for Source/Author/Recency/Media —
-// never the whole article, so each alternative reads as "just this one thing
-// changed".
-function examplePiece(ex, field) {
+// Render ONLY the one piece this field evaluates for the article — a thumbnail
+// for Image, the text for Text, a chip for Source/Author/Recency/Media — so you
+// can see exactly what was scored, never the whole article.
+function fieldPreview(p, field) {
   if (field === 'image') {
-    return ex.image_url
+    return p.image_url
       ? h('img', {
-          src: ex.image_url, alt: '', loading: 'lazy',
+          src: p.image_url, alt: '', loading: 'lazy',
           class: 'w-24 h-16 object-cover rounded bg-base-300 shrink-0',
         })
-      : h('div', { class: 'w-24 h-16 rounded bg-base-300 flex items-center justify-center text-[10px] text-base-content/40 shrink-0' }, 'no image');
+      : h('div', { class: 'w-24 h-16 rounded bg-base-300 flex items-center justify-center text-[10px] text-base-content/40 shrink-0' },
+          p.has_image ? 'image' : 'no image');
   }
   if (field === 'text') {
-    const txt = ex.title || ex.excerpt || '(no text)';
-    return h('div', { class: 'w-40 shrink-0 rounded bg-base-200 border border-base-300 p-2' },
-      h('p', { class: 'text-[11px] leading-snug line-clamp-3 text-base-content/80' }, txt));
+    return h('div', { class: 'w-full rounded bg-base-200 border border-base-300 p-2' },
+      h('p', { class: 'text-[11px] leading-snug line-clamp-4 text-base-content/80' }, p.text || '(no text)'));
   }
   let txt = '';
-  if (field === 'source') txt = ex.source || '(no source)';
-  else if (field === 'author') txt = ex.author ? `@${ex.author}` : '(no author)';
-  else if (field === 'recency') txt = ex.date_published ? timeAgo(ex.date_published) : '(no date)';
-  else if (field === 'media') txt = ex.has_media ? 'video / audio' : 'no media';
+  if (field === 'source') txt = p.source || '(no source)';
+  else if (field === 'author') txt = p.author ? `@${p.author}` : '(no author)';
+  else if (field === 'recency') txt = p.date_published ? timeAgo(p.date_published) : '(no date)';
+  else if (field === 'media') txt = p.has_media ? 'video / audio' : 'no media';
   return h('span', { class: 'shrink-0 badge badge-outline whitespace-nowrap' }, txt);
 }
 
-// A titled, horizontally-scrolling strip of the swapped pieces (better/worse).
-function exampleStrip(heading, cls, examples, field) {
-  if (!examples || !examples.length) return null;
-  return h('div', { class: 'mt-2' },
-    h('p', { class: `text-[11px] font-semibold ${cls} mb-1` }, heading),
-    h('div', { class: 'flex gap-2 overflow-x-auto pb-1 items-start' },
-      examples.map((ex) => examplePiece(ex, field))));
-}
-
 // The panel revealed when a field is tapped: what the field feeds the model,
-// plus the alternatives (for this field alone) it scored higher/lower.
+// and a preview of exactly what this article contributed to it.
 function fieldDetail(f) {
-  const hasExamples = (f.better && f.better.length) || (f.worse && f.worse.length);
   return h('div', { class: 'pl-6 pr-1 pb-3 -mt-0.5' },
     f.description ? h('p', { class: 'text-xs text-base-content/60' }, f.description) : null,
-    exampleStrip('Scored higher', 'text-success', f.better, f.field),
-    exampleStrip('Scored lower', 'text-error', f.worse, f.field),
-    hasExamples ? null
-      : h('p', { class: 'text-[11px] text-base-content/40 mt-2' },
-          'No alternatives changed the score for this field.'));
+    f.preview
+      ? h('div', { class: 'mt-2' },
+          h('p', { class: 'text-[11px] font-semibold text-base-content/50 mb-1' }, 'Evaluated here'),
+          fieldPreview(f.preview, f.field))
+      : null);
 }
 
 // A tappable field row: the label + marks, expanding to show fieldDetail().

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -237,11 +237,11 @@
     <form method="dialog"><button class="btn btn-sm btn-circle btn-ghost absolute right-4 top-4">✕</button></form>
     <h3 class="text-lg font-bold mb-1">Why this article?</h3>
     <p class="text-xs text-base-content/60 mb-4">
-      Each field is scored by how much it pushes this recommendation up
+      Each piece — text, image, source and so on — is scored on its own by
+      swapping just that one thing and seeing how the prediction moves, up
       (<span class="text-success font-bold">+</span>) or down
-      (<span class="text-error font-bold">−</span>), compared to average content.
-      Tap a field to see what it scores and example articles the model rated
-      higher or lower.
+      (<span class="text-error font-bold">−</span>). Tap a field to see what it
+      scores and the alternatives the model rated higher or lower.
     </p>
     <div id="explainBody"></div>
   </div>

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -240,6 +240,8 @@
       Each field is scored by how much it pushes this recommendation up
       (<span class="text-success font-bold">+</span>) or down
       (<span class="text-error font-bold">−</span>), compared to average content.
+      Tap a field to see what it scores and example articles the model rated
+      higher or lower.
     </p>
     <div id="explainBody"></div>
   </div>

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -237,11 +237,11 @@
     <form method="dialog"><button class="btn btn-sm btn-circle btn-ghost absolute right-4 top-4">✕</button></form>
     <h3 class="text-lg font-bold mb-1">Why this article?</h3>
     <p class="text-xs text-base-content/60 mb-4">
-      Each piece — text, image, source and so on — is scored on its own by
-      swapping just that one thing and seeing how the prediction moves, up
-      (<span class="text-success font-bold">+</span>) or down
-      (<span class="text-error font-bold">−</span>). Tap a field to see what it
-      scores and the alternatives the model rated higher or lower.
+      Each piece — text, image, source and so on — is scored by removing it and
+      seeing how the prediction changes: removing something helpful pushes the
+      score down (<span class="text-success font-bold">+</span>), removing
+      something unhelpful pushes it up (<span class="text-error font-bold">−</span>).
+      Tap a field to see exactly what was evaluated.
     </p>
     <div id="explainBody"></div>
   </div>

--- a/src/api/tests/db/item_test.py
+++ b/src/api/tests/db/item_test.py
@@ -216,47 +216,86 @@ def test_add_embedding_skips_when_already_present(unique_item_strict, monkeypatc
     fake_client.embeddings.assert_not_called()
 
 
-def test_add_image_embedding_fetches_and_embeds(unique_item_strict, monkeypatch):
-    """The preview image is downloaded, embedded by the vision model, and stored
-    in image_embeddings (kept separate from the text embeddings)."""
+@pytest.fixture
+def image_embed_configured():
+    """Point the image embedder at a (fake) service for the duration of a test."""
+    config.set("IMAGE_EMBED_HOST", "image-embed")
+    config.set("IMAGE_EMBED_PORT", 8000)
+    config.set("IMAGE_EMBED_MODEL", "clip-model")
+    config.set("IMAGE_EMBED_TIMEOUT_SECONDS", 30)
+    yield
+    for key in (
+        "IMAGE_EMBED_HOST",
+        "IMAGE_EMBED_PORT",
+        "IMAGE_EMBED_MODEL",
+        "IMAGE_EMBED_TIMEOUT_SECONDS",
+    ):
+        config.config.pop(key, None)
+
+
+def _fake_post(embedding):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"model": "clip-model", "embedding": embedding}
+    return MagicMock(return_value=resp)
+
+
+def test_add_image_embedding_fetches_and_embeds(
+    unique_item_strict, image_embed_configured, monkeypatch
+):
+    """The preview image is downloaded, sent to the CLIP service, and stored in
+    image_embeddings (kept separate from the text embeddings)."""
     monkeypatch.setattr(
         "db.item.ItemBase._fetch_image_base64", staticmethod(lambda url: "aGVsbG8=")
     )
-    fake_client = MagicMock()
-    fake_client.embed.return_value = {"embeddings": [[0.4, 0.5, 0.6]]}
-    monkeypatch.setattr("db.item.get_ollama_connection", lambda: fake_client)
+    post = _fake_post([0.4, 0.5, 0.6])
+    monkeypatch.setattr("db.item.httpx.post", post)
 
     unique_item_strict.add_image_embedding("clip-model")
 
-    fake_client.embed.assert_called_once()
-    kwargs = fake_client.embed.call_args.kwargs
-    assert kwargs["model"] == "clip-model"
-    assert kwargs["input"] == "aGVsbG8="
+    post.assert_called_once()
+    args, kwargs = post.call_args
+    assert args[0] == "http://image-embed:8000/embed"
+    assert kwargs["json"] == {"image_base64": "aGVsbG8="}
     assert unique_item_strict.image_embeddings["clip-model"] == [0.4, 0.5, 0.6]
     # text embeddings are untouched by the image embedder
     assert not unique_item_strict.embeddings
 
 
-def test_add_image_embedding_noop_without_image(unique_item_strict, monkeypatch):
+def test_add_image_embedding_noop_without_service(unique_item_strict, monkeypatch):
+    """With no service configured, nothing is fetched or embedded."""
+    config.config.pop("IMAGE_EMBED_HOST", None)
+    post = MagicMock()
+    monkeypatch.setattr("db.item.httpx.post", post)
+
+    unique_item_strict.add_image_embedding("clip-model")
+
+    post.assert_not_called()
+    assert unique_item_strict.image_embeddings is None
+
+
+def test_add_image_embedding_noop_without_image(
+    unique_item_strict, image_embed_configured, monkeypatch
+):
     """No image URL means nothing is fetched or embedded."""
-    fake_client = MagicMock()
-    monkeypatch.setattr("db.item.get_ollama_connection", lambda: fake_client)
+    post = MagicMock()
+    monkeypatch.setattr("db.item.httpx.post", post)
 
     unique_item_strict.image_url = None
     unique_item_strict.add_image_embedding("clip-model")
 
-    fake_client.embed.assert_not_called()
+    post.assert_not_called()
     assert unique_item_strict.image_embeddings is None
 
 
 def test_add_image_embedding_skips_when_already_present(
-    unique_item_strict, monkeypatch
+    unique_item_strict, image_embed_configured, monkeypatch
 ):
     """An existing image embedding for the model is not recomputed unless forced."""
-    fake_client = MagicMock()
-    monkeypatch.setattr("db.item.get_ollama_connection", lambda: fake_client)
+    post = MagicMock()
+    monkeypatch.setattr("db.item.httpx.post", post)
 
     unique_item_strict.image_embeddings = {"clip-model": [0.0]}
     unique_item_strict.add_image_embedding("clip-model")
 
-    fake_client.embed.assert_not_called()
+    post.assert_not_called()

--- a/src/api/tests/db/item_test.py
+++ b/src/api/tests/db/item_test.py
@@ -214,3 +214,49 @@ def test_add_embedding_skips_when_already_present(unique_item_strict, monkeypatc
     unique_item_strict.add_embedding("nomic-embed-text")
 
     fake_client.embeddings.assert_not_called()
+
+
+def test_add_image_embedding_fetches_and_embeds(unique_item_strict, monkeypatch):
+    """The preview image is downloaded, embedded by the vision model, and stored
+    in image_embeddings (kept separate from the text embeddings)."""
+    monkeypatch.setattr(
+        "db.item.ItemBase._fetch_image_base64", staticmethod(lambda url: "aGVsbG8=")
+    )
+    fake_client = MagicMock()
+    fake_client.embed.return_value = {"embeddings": [[0.4, 0.5, 0.6]]}
+    monkeypatch.setattr("db.item.get_ollama_connection", lambda: fake_client)
+
+    unique_item_strict.add_image_embedding("clip-model")
+
+    fake_client.embed.assert_called_once()
+    kwargs = fake_client.embed.call_args.kwargs
+    assert kwargs["model"] == "clip-model"
+    assert kwargs["input"] == "aGVsbG8="
+    assert unique_item_strict.image_embeddings["clip-model"] == [0.4, 0.5, 0.6]
+    # text embeddings are untouched by the image embedder
+    assert not unique_item_strict.embeddings
+
+
+def test_add_image_embedding_noop_without_image(unique_item_strict, monkeypatch):
+    """No image URL means nothing is fetched or embedded."""
+    fake_client = MagicMock()
+    monkeypatch.setattr("db.item.get_ollama_connection", lambda: fake_client)
+
+    unique_item_strict.image_url = None
+    unique_item_strict.add_image_embedding("clip-model")
+
+    fake_client.embed.assert_not_called()
+    assert unique_item_strict.image_embeddings is None
+
+
+def test_add_image_embedding_skips_when_already_present(
+    unique_item_strict, monkeypatch
+):
+    """An existing image embedding for the model is not recomputed unless forced."""
+    fake_client = MagicMock()
+    monkeypatch.setattr("db.item.get_ollama_connection", lambda: fake_client)
+
+    unique_item_strict.image_embeddings = {"clip-model": [0.0]}
+    unique_item_strict.add_image_embedding("clip-model")
+
+    fake_client.embed.assert_not_called()

--- a/src/api/tests/ingest/jobs_test.py
+++ b/src/api/tests/ingest/jobs_test.py
@@ -1,3 +1,4 @@
+from config import config
 from db.item import ItemLoose, ItemStrict
 from ingest import jobs
 
@@ -53,3 +54,41 @@ def test_rescrape_source_skips_unchanged_item(
     jobs.rescrape_source(existing_source)
 
     assert ranked == []
+
+
+def test_backfill_image_embeddings_embeds_missing(
+    monkeypatch, existing_item_strict
+):
+    """The backfill embeds stored items whose preview image has no embedding for
+    the current model, and persists the result."""
+    config.set("IMAGE_EMBED_HOST", "image-embed")
+    config.set("IMAGE_EMBED_MODEL", "clip-model")
+
+    def fake_embed(self, model_name, force_refresh=False):
+        self.image_embeddings = {model_name: [0.1, 0.2, 0.3]}
+
+    monkeypatch.setattr("db.item.ItemBase.add_image_embedding", fake_embed)
+    try:
+        jobs.backfill_image_embeddings_job()
+    finally:
+        config.config.pop("IMAGE_EMBED_HOST", None)
+        config.config.pop("IMAGE_EMBED_MODEL", None)
+
+    stored = ItemStrict.read(url_hash=existing_item_strict.url_hash)
+    assert stored.image_embeddings == {"clip-model": [0.1, 0.2, 0.3]}
+
+
+def test_backfill_image_embeddings_noop_without_service(
+    monkeypatch, existing_item_strict
+):
+    """With no service configured the backfill does nothing."""
+    config.config.pop("IMAGE_EMBED_HOST", None)
+    called = []
+    monkeypatch.setattr(
+        "db.item.ItemBase.add_image_embedding",
+        lambda self, model_name, force_refresh=False: called.append(model_name),
+    )
+
+    jobs.backfill_image_embeddings_job()
+
+    assert called == []

--- a/src/api/tests/ranking/engine_test.py
+++ b/src/api/tests/ranking/engine_test.py
@@ -1,0 +1,43 @@
+"""Pure-python tests for feature loading (no database)."""
+
+from ranking.engine import _row_to_features
+
+
+def _row(**overrides):
+    row = {
+        "url_hash": "h",
+        "url": "https://example.com/article",
+        "author": None,
+        "date_published": None,
+        "image_url": None,
+        "media": None,
+        "embeddings": None,
+        "image_embeddings": None,
+        "vote": None,
+        "vote_date": None,
+        "source_name": "src",
+        "list_added_at": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_has_media_from_stored_media_entry():
+    feat = _row_to_features(_row(media=[{"type": "video", "url": "x"}]))
+    assert feat.has_media is True
+
+
+def test_has_media_true_for_youtube_without_stored_media():
+    # YouTube plays inline in the UI from the URL alone, with no media entry
+    feat = _row_to_features(_row(url="https://youtu.be/abc123", media=None))
+    assert feat.has_media is True
+
+
+def test_has_media_true_for_direct_video_file():
+    feat = _row_to_features(_row(url="https://cdn.example.com/v.mp4", media=None))
+    assert feat.has_media is True
+
+
+def test_has_media_false_for_plain_article():
+    feat = _row_to_features(_row(url="https://example.com/story", media=None))
+    assert feat.has_media is False

--- a/src/api/tests/ranking/explain_test.py
+++ b/src/api/tests/ranking/explain_test.py
@@ -1,0 +1,45 @@
+"""Pure-python tests for the mark normalization (no database)."""
+
+from ranking.explain import _assign_marks
+
+
+def _levels(deltas):
+    return [level for _sign, level in _assign_marks(deltas)]
+
+
+def _signs(deltas):
+    return [sign for sign, _level in _assign_marks(deltas)]
+
+
+def test_equal_fields_all_get_one_mark():
+    # nothing stands out, nothing is negligible -> every field reads as one mark
+    assert _levels([0.2, 0.2, 0.2, 0.2, 0.2, 0.2]) == [1] * 6
+
+
+def test_small_but_real_fields_still_marked():
+    # a dominant field earns two marks, but the small-yet-used fields still get
+    # one rather than collapsing to nothing
+    assert _levels([1.0, 0.03, 0.03, 0.03, 0.03, 0.03]) == [2, 1, 1, 1, 1, 1]
+
+
+def test_only_negligible_fields_read_as_nothing():
+    # fields the model barely moved (below the used floor) are the only zeros
+    levels = _levels([0.9, 0.3, 0.08, 0.0005, 0.0003, 0.0])
+    assert levels[0] == 2 and levels[1] == 1 and levels[2] == 1
+    assert levels[3:] == [0, 0, 0]
+
+
+def test_no_signal_is_all_zero():
+    assert _levels([0, 0, 0, 0, 0, 0]) == [0] * 6
+
+
+def test_sign_follows_delta_direction():
+    # removing a field that lowered the score -> +, that raised it -> −
+    signs = _signs([0.4, -0.3, 0.2, -0.15, 0.15, -0.1])
+    assert signs == [1, -1, 1, -1, 1, -1]
+
+
+def test_zero_level_iff_zero_sign():
+    marks = _assign_marks([0.5, 0.001, -0.4, 0.0, -0.2, 0.05])
+    for sign, level in marks:
+        assert (level == 0) == (sign == 0)

--- a/src/api/tests/ranking/models_test.py
+++ b/src/api/tests/ranking/models_test.py
@@ -112,6 +112,47 @@ def test_ridge_learns_direction():
     assert (np.abs(scores) <= 1).all()
 
 
+def test_image_embedding_is_a_distinct_feature():
+    """With identical text, the image embedding alone must move the score, so
+    the picture is genuinely weighed apart from the words and the has-image
+    flag."""
+    items = []
+    for i in range(40):
+        liked = i % 2 == 0
+        items.append(
+            ItemFeatures(
+                url_hash=f"img{i}",
+                embedding=np.array([0.3, 0.3]),  # constant text for everyone
+                image_embedding=np.array([1.0, 0.0] if liked else [-1.0, 0.0]),
+                has_image=True,
+                label=1.0 if liked else -1.0,
+            )
+        )
+    model = RidgeModel()
+    model.fit(items)
+    same_text = np.array([0.3, 0.3])
+    liked = ItemFeatures(
+        url_hash="cl", embedding=same_text, image_embedding=np.array([1.0, 0.0]),
+        has_image=True,
+    )
+    disliked = ItemFeatures(
+        url_hash="cd", embedding=same_text, image_embedding=np.array([-1.0, 0.0]),
+        has_image=True,
+    )
+    scores, _ = model.predict([liked, disliked])
+    assert scores[0] > scores[1]
+
+
+def test_missing_image_embedding_is_backward_compatible():
+    """A feed with no image embeddings still trains and predicts (the image
+    block is simply zero-width)."""
+    items = two_cluster_data(n=20)  # none carry an image embedding
+    model = RidgeModel()
+    model.fit(items)
+    scores, _ = model.predict(_up_down_probes())
+    assert scores[0] > 0 > scores[1]
+
+
 def _up_down_probes():
     return [
         make_item(100, [5, 0, 0, 0, 0, 0, 0, 0]),

--- a/src/api/tests/routers/ranking_test.py
+++ b/src/api/tests/routers/ranking_test.py
@@ -231,24 +231,14 @@ def test_item_explanation(
     assert fields["text"]["level"] >= 1
     assert fields["text"]["sign"] == 1
 
-    # every field carries a plain-language description of what it scores
+    # every field carries a plain-language description and a preview of exactly
+    # what was evaluated for this article
     assert all(f["description"] for f in body["fields"])
-
-    # examples are single-field swaps the model scored higher (better) or lower
-    # (worse), sorted by how far from this article's own value
-    for f in body["fields"]:
-        for ex in f["better"]:
-            assert ex["delta"] > 0
-            assert ex["url_hash"] != items[4].url_hash
-        for ex in f["worse"]:
-            assert ex["delta"] < 0
-            assert ex["url_hash"] != items[4].url_hash
-    # swapping the disliked (odd) cluster's text scores lower; the swap examples
-    # carry the changed piece's display fields
-    text = fields["text"]
-    assert text["better"] or text["worse"]
-    disliked = {items[1].url_hash, items[3].url_hash}
-    assert any(ex["url_hash"] in disliked for ex in text["worse"])
+    assert all(f["preview"] is not None for f in body["fields"])
+    # the preview is this article's own data (same across fields, one per piece)
+    text_preview = fields["text"]["preview"]
+    assert text_preview["text"]  # the item's title/excerpt
+    assert fields["image"]["preview"]["has_image"] is True  # item[4] is even/imaged
 
 
 def test_item_explanation_needs_votes(

--- a/src/api/tests/routers/ranking_test.py
+++ b/src/api/tests/routers/ranking_test.py
@@ -238,7 +238,10 @@ def test_item_explanation(
     # the preview is this article's own data (same across fields, one per piece)
     text_preview = fields["text"]["preview"]
     assert text_preview["text"]  # the item's title/excerpt
-    assert fields["image"]["preview"]["has_image"] is True  # item[4] is even/imaged
+    image_preview = fields["image"]["preview"]
+    assert image_preview["has_image"] is True  # item[4] is even/imaged
+    # no vision model in the test, so the image is scored by presence only
+    assert image_preview["image_embedded"] is False
 
 
 def test_item_explanation_needs_votes(

--- a/src/api/tests/routers/ranking_test.py
+++ b/src/api/tests/routers/ranking_test.py
@@ -229,6 +229,25 @@ def test_item_explanation(
     assert fields["content"]["level"] >= 1
     assert fields["content"]["sign"] == 1
 
+    # every field carries a plain-language description of what it scores
+    assert all(f["description"] for f in body["fields"])
+
+    # examples are real feed articles the model scored higher (better) or lower
+    # (worse) on that field, sorted by how far from this article's own value
+    for f in body["fields"]:
+        for ex in f["better"]:
+            assert ex["delta"] > 0
+            assert ex["url_hash"] != items[4].url_hash
+        for ex in f["worse"]:
+            assert ex["delta"] < 0
+            assert ex["url_hash"] != items[4].url_hash
+    # the disliked (odd) cluster gives content the model scored lower; the
+    # liked (even) cluster gives content it scored higher
+    content = fields["content"]
+    assert content["better"] or content["worse"]
+    disliked = {items[1].url_hash, items[3].url_hash}
+    assert any(ex["url_hash"] in disliked for ex in content["worse"])
+
 
 def test_item_explanation_needs_votes(
     client, existing_user, existing_feed, existing_source, existing_item_strict, token

--- a/src/api/tests/routers/ranking_test.py
+++ b/src/api/tests/routers/ranking_test.py
@@ -219,21 +219,23 @@ def test_item_explanation(
     body = response.json()
     assert body["model_name"]
     fields = {f["field"]: f for f in body["fields"]}
-    assert {"content", "source", "author", "recency", "image", "media"} <= set(fields)
+    # text and image are scored as separate pieces, never lumped as "content"
+    assert {"text", "image", "source", "author", "recency", "media"} <= set(fields)
+    assert "content" not in fields
     # every field reports a valid mark count and direction
     for f in body["fields"]:
         assert f["level"] in (0, 1, 2)
         assert f["sign"] in (-1, 0, 1)
         assert (f["level"] == 0) == (f["sign"] == 0)
-    # content (the embedding) drives this recommendation and pushes it up
-    assert fields["content"]["level"] >= 1
-    assert fields["content"]["sign"] == 1
+    # text (the embedding) drives this recommendation and pushes it up
+    assert fields["text"]["level"] >= 1
+    assert fields["text"]["sign"] == 1
 
     # every field carries a plain-language description of what it scores
     assert all(f["description"] for f in body["fields"])
 
-    # examples are real feed articles the model scored higher (better) or lower
-    # (worse) on that field, sorted by how far from this article's own value
+    # examples are single-field swaps the model scored higher (better) or lower
+    # (worse), sorted by how far from this article's own value
     for f in body["fields"]:
         for ex in f["better"]:
             assert ex["delta"] > 0
@@ -241,12 +243,12 @@ def test_item_explanation(
         for ex in f["worse"]:
             assert ex["delta"] < 0
             assert ex["url_hash"] != items[4].url_hash
-    # the disliked (odd) cluster gives content the model scored lower; the
-    # liked (even) cluster gives content it scored higher
-    content = fields["content"]
-    assert content["better"] or content["worse"]
+    # swapping the disliked (odd) cluster's text scores lower; the swap examples
+    # carry the changed piece's display fields
+    text = fields["text"]
+    assert text["better"] or text["worse"]
     disliked = {items[1].url_hash, items[3].url_hash}
-    assert any(ex["url_hash"] in disliked for ex in content["worse"])
+    assert any(ex["url_hash"] in disliked for ex in text["worse"])
 
 
 def test_item_explanation_needs_votes(

--- a/src/api/tests/utils_test.py
+++ b/src/api/tests/utils_test.py
@@ -1,0 +1,25 @@
+"""Unit tests for small helpers in utils."""
+
+import pytest
+
+from utils import is_playable_media_url
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://www.youtube.com/watch?v=abc123", True),
+        ("https://youtu.be/abc123", True),
+        ("http://m.youtube.com/watch?v=abc123", True),
+        ("https://www.youtube-nocookie.com/embed/abc123", True),
+        ("https://example.com/clip.mp4", True),
+        ("https://example.com/clip.webm?t=10", True),
+        ("https://example.com/article", False),
+        ("https://vimeo.com/12345", False),  # not rendered inline by the UI
+        ("https://notyoutube.com.evil.example/x", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_is_playable_media_url(url, expected):
+    assert is_playable_media_url(url) is expected

--- a/src/api/utils.py
+++ b/src/api/utils.py
@@ -1,7 +1,34 @@
+import re
+from typing import Optional
+from urllib.parse import urlparse
+
 from ollama import Client
 from httpx import BasicAuth
 
 from config import config
+
+# Hosts whose links the UI renders as an inline player, and file extensions the
+# UI plays directly, even when the item has no stored `media` entry (see the
+# frontend's youtubeId/isVideoFile). Used so ranking treats these as playable
+# media rather than plain links.
+_PLAYABLE_MEDIA_HOSTS = {"youtube.com", "youtu.be", "youtube-nocookie.com"}
+_VIDEO_FILE_RE = re.compile(r"\.(mp4|webm)(\?|$)", re.IGNORECASE)
+
+
+def is_playable_media_url(url: Optional[str]) -> bool:
+    """True when this URL plays inline in the UI (a YouTube link or a direct
+    video file) even though it may carry no stored media entry."""
+    if not url:
+        return False
+    if _VIDEO_FILE_RE.search(url):
+        return True
+    try:
+        host = (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return False
+    if host.startswith("www.") or host.startswith("m."):
+        host = host.split(".", 1)[1]
+    return host in _PLAYABLE_MEDIA_HOSTS
 
 
 def get_ollama_connection() -> Client:

--- a/src/image_embed/dockerfile
+++ b/src/image_embed/dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.11-slim AS aggy-image-embed
+WORKDIR /app
+
+ENV TZ=America/New_York
+
+# Keep BLAS/torch from oversubscribing the CPU inside the container.
+ENV OPENBLAS_NUM_THREADS=1 \
+    OMP_NUM_THREADS=1 \
+    HF_HUB_DISABLE_TELEMETRY=1
+
+# Install the CPU build of torch first (from the CPU wheel index) so pulling in
+# sentence-transformers doesn't drag in the multi-gigabyte CUDA build.
+RUN pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+
+# Bake the CLIP weights into the image so the container needs no network at
+# startup and the first request is fast. Must match the runtime default.
+ARG IMAGE_EMBED_MODEL=clip-ViT-B-32
+ENV IMAGE_EMBED_MODEL=${IMAGE_EMBED_MODEL}
+RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('${IMAGE_EMBED_MODEL}')"
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/src/image_embed/main.py
+++ b/src/image_embed/main.py
@@ -1,0 +1,64 @@
+"""Image-embedding microservice.
+
+Ollama can't embed images, so the recommender's "score the picture itself"
+feature needs a real vision model. This is a tiny FastAPI service that wraps a
+CLIP model (via sentence-transformers) and turns an image into an L2-normalized
+embedding vector. It keeps the heavy torch/CLIP dependency out of the main API
+image — the API just POSTs a base64 image here and stores the vector it gets
+back in items.image_embeddings.
+"""
+
+import base64
+import binascii
+import io
+import logging
+import os
+
+from fastapi import FastAPI, HTTPException
+from PIL import Image
+from pydantic import BaseModel
+from sentence_transformers import SentenceTransformer
+
+logging.basicConfig(level=logging.INFO)
+
+# CLIP ViT-B/32 gives 512-dim image embeddings and is small enough to run on
+# CPU. The image is baked into the container at build time (see the dockerfile),
+# so startup and the first request don't need network access.
+MODEL_NAME = os.getenv("IMAGE_EMBED_MODEL", "clip-ViT-B-32")
+
+logging.info(f"Loading image embedding model '{MODEL_NAME}'...")
+model = SentenceTransformer(MODEL_NAME)
+logging.info("Image embedding model ready.")
+
+app = FastAPI(title="aggy image embedding")
+
+
+class EmbedRequest(BaseModel):
+    image_base64: str
+
+
+class EmbedResponse(BaseModel):
+    model: str
+    embedding: list[float]
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok", "model": MODEL_NAME}
+
+
+@app.post("/embed", response_model=EmbedResponse)
+def embed(request: EmbedRequest) -> EmbedResponse:
+    try:
+        raw = base64.b64decode(request.image_base64, validate=True)
+    except (binascii.Error, ValueError) as e:
+        raise HTTPException(status_code=400, detail=f"invalid base64: {e}")
+    try:
+        image = Image.open(io.BytesIO(raw)).convert("RGB")
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"could not decode image: {e}")
+
+    # normalize so cosine similarity is a plain dot product, matching how the
+    # text embeddings are consumed downstream
+    vector = model.encode(image, normalize_embeddings=True)
+    return EmbedResponse(model=MODEL_NAME, embedding=vector.tolist())

--- a/src/image_embed/requirements.txt
+++ b/src/image_embed/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+pillow
+sentence-transformers


### PR DESCRIPTION
## What & why

The "Why this article?" modal previously showed each scored field (Content, Source, Author, Recency, Image, Media) only as a row of `+`/`−` marks. That tells you *that* a field mattered but not *what* the model looked at or *why* it landed positive vs. negative.

This makes each field row **tappable**. Expanding a field reveals:

1. **What is being scored** — a one-line description (e.g. content = the article's title + body turned into an embedding; image = whether the article carries a preview image).
2. **Example articles the model scored higher / lower** on that field — real posts from the feed, shown as small cards with their preview image (or a "no image" placeholder) and title/source. These are the concrete images/text the model was effectively weighing when it decided the field helps or hurts.

## How it works

The explanation already probes the opaque models by holding the article fixed and swapping one field at a time. That same probe now also substitutes **each real article's value** for the field, one at a time, scores them, and ranks the results against the article's own baseline score:

- Substitutes that score **above** baseline → the model likes that value more → **"scored higher"** examples.
- Substitutes that score **below** baseline → **"scored lower"** examples.

Per-item fields (embedding, recency) surface distinct articles; repeated-value fields (source, author, image/media flags) are de-duplicated by value so the same source/thumbnail isn't listed twice. Display metadata (title, preview image, source) is loaded alongside so the cards can render the actual image/text.

## Changes

- `ranking/explain.py` — field descriptions, `_field_examples` permutation-to-examples helper, and display-metadata loading; `FieldContribution` now carries `description`, `better`, `worse`.
- `route_models/ranking.py` — new `FieldExampleResponse`; `description`/`better`/`worse` added to `FieldContributionResponse`.
- `routers/feed.py` — maps examples into the response.
- `static/js/app.js` + `templates/app.html` — tappable field rows that expand into the description and horizontally-scrolling better/worse example cards; updated helper text.
- `tests/routers/ranking_test.py` — assertions for descriptions and for better/worse example deltas/identities.

## Testing notes

The Docker/Postgres integration suite couldn't run in this environment (no Docker). I validated: Python/JS syntax, the pydantic model round-trip, and the `_field_examples` ranking/dedup logic in isolation against both the kNN model (embedding-only) and a Ridge model (which consumes the image/source features), confirming better/worse deltas, sort order, de-duplication, and that preview-image metadata flows through. The full `pytest tests` suite should be run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dwf3iJZJk92EJHuUCxKGho

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dwf3iJZJk92EJHuUCxKGho)_