### PR TITLE
Add random-guessing baseline model for stats comparison

### DIFF
--- a/src/api/ranking/models.py
+++ b/src/api/ranking/models.py
@@ -2,7 +2,8 @@
 
 Each model learns from the user's past votes (-1..1) on items in a feed and
 predicts a (score, confidence) pair for unseen items. A whole zoo of
-methodologies is implemented — from a trivial global mean, through classic
+methodologies is implemented — from a random-guessing baseline and a trivial
+global mean, through classic
 regressors (source averages, kNN, ridge, logistic, SVR) and tree ensembles
 (random forest, gradient boosting), up to shallow and deep neural nets — and
 `ranking.engine` cross-validates them all, keeps stats for each, and ranks the
@@ -118,12 +119,40 @@ class VoteModel:
 
     name: str = "base"
     min_labels: int = 1
+    # Whether this model may be picked to actually order the feed. A model with
+    # `rankable = False` still gets cross-validated and reported in the stats UI
+    # (as a yardstick to compare the real models against) but is never chosen as
+    # the winner.
+    rankable: bool = True
 
     def fit(self, items: Sequence[ItemFeatures]) -> None:
         raise NotImplementedError
 
     def predict(self, items: Sequence[ItemFeatures]) -> Tuple[np.ndarray, np.ndarray]:
         raise NotImplementedError
+
+
+class RandomModel(VoteModel):
+    """Chance baseline: ignore the features and guess a uniformly random vote in
+    [-1, 1]. It learns nothing, so it's the yardstick every real model should
+    beat — the stats UI shows it purely so you can see how far ahead the chosen
+    model is. Never used to actually rank a feed (`rankable = False`)."""
+
+    name = "random"
+    rankable = False
+
+    def __init__(self, seed: int = 0):
+        self.seed = seed
+
+    def fit(self, items):
+        # Nothing to learn; seed a generator so the cross-validated metrics are
+        # reproducible instead of jittering on every recompute.
+        self.rng = np.random.default_rng(self.seed)
+
+    def predict(self, items):
+        n = len(items)
+        scores = self.rng.uniform(-1.0, 1.0, n)
+        return scores, np.full(n, 0.05)
 
 
 class GlobalMeanModel(VoteModel):
@@ -473,6 +502,7 @@ def all_models() -> List[VoteModel]:
     feed another candidate — it never hurts a well-labeled feed and quietly
     sits out (null metrics) until it has enough votes to compete."""
     return [
+        RandomModel(),
         GlobalMeanModel(),
         SourceMeanModel(),
         KNNEmbeddingModel(),
@@ -554,8 +584,10 @@ def evaluate_models(
             )
         )
 
-    # pick the winner: lowest MAE among models that produced metrics
-    scored = [r for r in results if r.mae is not None]
+    # pick the winner: lowest MAE among models that both produced metrics and
+    # are allowed to rank (the random baseline is reported but never chosen)
+    rankable = {m.name for m in models if m.rankable}
+    scored = [r for r in results if r.mae is not None and r.model_name in rankable]
     if scored:
         best = min(scored, key=lambda r: r.mae)
         best.chosen = True

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -386,6 +386,7 @@ function formatMetric(v, digits = 3) {
 
 // Human labels for the backend model names.
 const MODEL_LABELS = {
+  random: 'Random guessing (baseline)',
   global_mean: 'Global mean (baseline)',
   source_mean: 'Source average',
   knn_embedding: 'Similar posts (kNN)',

--- a/src/api/tests/ranking/models_test.py
+++ b/src/api/tests/ranking/models_test.py
@@ -14,6 +14,7 @@ from ranking.models import (
     LogisticVoteModel,
     MLPModel,
     RandomForestModel,
+    RandomModel,
     RidgeModel,
     SVRModel,
     SourceMeanModel,
@@ -187,6 +188,31 @@ def test_gradient_boost_learns_direction():
     assert scores[0] > 0 > scores[1]
     assert (np.abs(scores) <= 1).all()
     assert (confs >= 0).all() and (confs <= 1).all()
+
+
+def test_random_model_predicts_in_range_and_reproducibly():
+    items = two_cluster_data(n=20)
+    model = RandomModel()
+    model.fit(items)
+    probes = _up_down_probes()
+    scores, confs = model.predict(probes)
+    assert (np.abs(scores) <= 1).all()
+    assert (confs >= 0).all() and (confs <= 1).all()
+    # same seed -> same guesses, so the stats don't jitter on every recompute
+    again = RandomModel()
+    again.fit(items)
+    assert again.predict(probes)[0] == pytest.approx(scores)
+
+
+def test_random_baseline_is_never_chosen():
+    # separable data: real models beat chance, and the random baseline — even
+    # if it got lucky — is excluded from winning because it's not rankable
+    items = two_cluster_data(n=40)
+    stats = evaluate_models(items)
+    by_name = {s.model_name: s for s in stats}
+    assert by_name["random"].mae is not None  # still reported for comparison
+    assert not by_name["random"].chosen
+    assert next(m for m in all_models() if m.name == "random").rankable is False
 
 
 def test_evaluate_models_reports_all_and_picks_one():


### PR DESCRIPTION
## What

Adds a **random guessing** "model" to the ranking zoo so the stats view shows how much the real models outperform pure chance.

## Why

The stats modal already cross-validates every vote-prediction model and reports MAE / RMSE / direction accuracy. Until now the weakest yardstick was the global-mean baseline. A chance baseline makes "how much do we outperform random?" answerable at a glance.

## How

- **`ranking/models.py`**
  - New `RandomModel`: ignores all features and predicts a uniformly random vote in `[-1, 1]`. Seeded per `fit` so the cross-validated metrics are reproducible instead of jittering on every recompute.
  - Added a `rankable` flag on `VoteModel` (default `True`). `RandomModel` sets it `False`: it is still evaluated and reported for comparison, but `evaluate_models` excludes non-rankable models from winner selection, so a feed is never actually ordered by random guesses.
  - Registered `RandomModel` first in `all_models()`.
- **`static/js/app.js`**: added the `random → "Random guessing (baseline)"` display label for the stats table.
- **`tests/ranking/models_test.py`**: tests that the random model predicts in range and reproducibly, and that the baseline is reported but never chosen.

## Testing

`python -m pytest tests/ranking/models_test.py` — 19 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LZBtkS7W6Goia1BeUFx41

---
_Generated by [Claude Code](https://claude.ai/code/session_019LZBtkS7W6Goia1BeUFx41)_