### PR TITLE
Fix "feed_name_hash" error toast when loading a feed

### DIFF
--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -305,6 +305,10 @@ async function showFeed(hash) {
   currentList = null; // leaving any list-detail context
   itemSkip = 0;
   render($('itemList'), spinner());
+  // A prior feed may have left the load-more button visible; hide it now so the
+  // infinite-scroll observer can't auto-click it (and load items with no feed
+  // context) while we await feedGet below.
+  $('loadMoreBtn').classList.add('hidden');
 
   if (!currentFeed || currentFeed.feed_name_hash !== hash) {
     feedFilters = defaultFilters();
@@ -639,6 +643,13 @@ function appendItemWithDivider(list, item) {
 }
 
 async function loadFeedItems() {
+  // The infinite-scroll observer watches the load-more button for the whole
+  // session, so it can fire while we're still awaiting feedGet in showFeed (or
+  // after navigating away) — before currentFeed is set. Bail rather than throw
+  // a "Cannot read properties of null (reading 'feed_name_hash')" the catch
+  // below would surface as an error toast.
+  if (!currentFeed) { $('loadMoreBtn').classList.add('hidden'); return; }
+
   const seq = ++itemsRequestSeq;
   const list = $('itemList');
   if (itemSkip === 0) { render(list, spinner()); lastItemBand = null; }


### PR DESCRIPTION
## What

Fixes the popup error a user hit when loading a feed — a toast reading roughly _"Cannot read properties of null (reading 'feed_name_hash')"_.

## Root cause

The infinite-scroll `IntersectionObserver` in `bindControls()` watches the load-more button for the entire session. Once you view a feed with enough items to reveal that button (`loadMoreBtn` loses its `hidden` class), navigating to the dashboard and then into **another** feed leaves the button visible while `showFeed()` is still `await`ing `sdk.feedGet(...)`. During that await `currentFeed` is still `null`, so the observer can auto-click the button → `loadFeedItems()` → `currentFeed.feed_name_hash` throws. The `catch` in `loadFeedItems` then surfaces the `TypeError` message as an `alert-error` toast.

## Fix

- `loadFeedItems()` now bails early (hiding the button) when `currentFeed` is null, so a stray observer/click can never dereference it.
- `showFeed()` hides `loadMoreBtn` up front, before the `feedGet` await, so a button left visible by a previously-viewed feed can't race the fetch.

## Not changed (external, not app bugs)

The other console output in the report comes from outside this codebase and isn't fixable here:

- **YouTube CORS / `postMessage` errors** — emitted from inside YouTube's own embedded player iframe (`www-widgetapi.js`, `youtube-nocookie.com`), not our origin.
- **`content.js` TIMEOUT errors** — from a browser extension (`chrome-extension://mnjggc...`).
- **`beforeinstallprompt` "Banner not shown"** — expected: `pwa.js` intentionally `preventDefault()`s the mini-infobar to offer a custom Install button.

## Testing

- `node --check` passes on `app.js`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019mT9W2G4nAZM7WLYL6xFJ4)_