### PR TITLE
Add pluggable ingest backends: video listings, headless scraping, RSSHub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,5 +34,28 @@ IMAGE_EMBED_TIMEOUT_SECONDS=30
 # structured JSON output works; it is pulled automatically on first use.
 OLLAMA_ANALYSIS_MODEL=qwen3:4b
 
+# --- Ingest backends beyond RSS ---
+# All three are wired up by docker-compose; these settings only need changing
+# if you run a service elsewhere, or comment the service out to disable it.
+
+# Metadata-only extraction for video sites (aggy-ytdlp). Lets a source be a
+# channel, user, playlist, or search-results page on a site that publishes no
+# feed. Nothing is downloaded: listings are read as metadata, and a playable
+# URL is resolved per playback because the ones sites hand out expire.
+# YTDLP_HOST=aggy-ytdlp
+# YTDLP_PORT=8000
+
+# Headless Chromium (aggy-render), used when a page only shows its articles
+# after its JavaScript has run. When it is unset, analysis and scraping fall
+# back to a plain HTTP fetch.
+# RENDER_HOST=aggy-render
+# RENDER_PORT=8000
+
+# RSSHub (aggy-rsshub), a second bridge alongside rss-bridge covering a
+# different and much larger set of sites. Its route catalog is imported into
+# the source-template search every 12 hours.
+# RSSHUB_HOST=aggy-rsshub
+# RSSHUB_PORT=1200
+
 # Set to false to disable new account creation
 SIGNUP_ENABLED=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,10 @@ jobs:
             context: ./src/api/db/migrations
           - service: image-embed
             context: ./src/image_embed
+          - service: ytdlp
+            context: ./src/ytdlp
+          - service: render
+            context: ./src/render
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Aggy works for any type of content. Whether it’s specific animals, hobbies, ne
 
 Aggy currently supports:
 
-- **RSS sources** via templates powered by [RSS-Bridge](https://github.com/RSS-Bridge/rss-bridge)
+- **RSS sources** via templates powered by [RSS-Bridge](https://github.com/RSS-Bridge/rss-bridge) and [RSSHub](https://github.com/DIYgod/RSSHub)
+- **Video sites**, via [yt-dlp](https://github.com/yt-dlp/yt-dlp): point a source at a channel, user, playlist, or search-results page and Aggy reads it as a feed. Metadata only — nothing is downloaded, and playback streams from the source site
+- **JavaScript-heavy pages**, rendered in a headless browser before Aggy applies your CSS selectors
 
 Upcoming integrations:
 
@@ -31,7 +33,8 @@ Aggy uses **content embeddings** to understand the types of content you enjoy. A
 ### Available now:
 
 - **RSS source support** with predefined templates for faster setup
-- **Any website as a source**: paste a URL and a local Ollama model works out the CSS selectors (via RSS-Bridge), with a live preview to fine-tune before saving
+- **Any website as a source**: paste a URL and a local Ollama model works out the CSS selectors, with a live preview to fine-tune before saving. Pages that build themselves in the browser are rendered headlessly first, so client-side listings and lazy-loaded thumbnails work too
+- **Pluggable ingest backends**: every source names how it is read (`rss`, `ytdlp`, `html`), so reaching a new kind of site means adding a backend rather than bending everything through a feed
 - **Bulk subscription import** from Reddit, YouTube, Bluesky, and any OPML export (Feedly, Inoreader, podcast apps), with per-source feed assignment
 - **Embedding generation** for text to improve content relevance
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,27 @@ services:
     image: ghcr.io/mullinmax/aggy/aggy-bridge:latest
     restart: unless-stopped
 
+  # Metadata-only extraction for video sites: enumerates channel, user,
+  # playlist, and search pages, and resolves a playable URL per playback.
+  # Nothing is ever downloaded or stored.
+  aggy-ytdlp:
+    image: ghcr.io/mullinmax/aggy/aggy-ytdlp:latest
+    restart: unless-stopped
+
+  # Headless Chromium, for pages that only show their articles after their
+  # JavaScript has run.
+  aggy-render:
+    image: ghcr.io/mullinmax/aggy/aggy-render:latest
+    restart: unless-stopped
+
+  # A second bridge alongside rss-bridge, covering a different (and much
+  # larger) set of sites. Its route catalog is imported as source templates.
+  aggy-rsshub:
+    image: diygod/rsshub:latest
+    restart: unless-stopped
+    environment:
+      - NODE_ENV=production
+
   aggy-ollama:
     image: ollama/ollama:latest
     restart: unless-stopped
@@ -60,6 +81,12 @@ services:
       - DB_NAME=aggy
       - RSS_BRIDGE_HOST=aggy-bridge
       - RSS_BRIDGE_PORT=80
+      - RSSHUB_HOST=aggy-rsshub
+      - RSSHUB_PORT=1200
+      - YTDLP_HOST=aggy-ytdlp
+      - YTDLP_PORT=8000
+      - RENDER_HOST=aggy-render
+      - RENDER_PORT=8000
       - EXTRACT_HOST=aggy-extract
       - EXTRACT_PORT=3000
       - OLLAMA_HOST=aggy-ollama
@@ -83,6 +110,12 @@ services:
       aggy-bridge:
         condition: service_started
       aggy-image-embed:
+        condition: service_started
+      aggy-ytdlp:
+        condition: service_started
+      aggy-render:
+        condition: service_started
+      aggy-rsshub:
         condition: service_started
 
   cloudflared:

--- a/src/api/bridge/extract.py
+++ b/src/api/bridge/extract.py
@@ -1,0 +1,120 @@
+"""Turn a page's HTML into feed entries using CSS selectors.
+
+rss-bridge's CSS Selector bridge does this too, but only over HTML it fetched
+itself with a plain HTTP GET. Doing the extraction in-process means the same
+selectors can be applied to HTML that came from the headless renderer, and
+that the preview a user approves is produced by exactly the code that later
+ingests the source.
+"""
+
+from datetime import datetime
+from typing import List, Optional
+from urllib.parse import urljoin
+
+from bs4 import BeautifulSoup
+
+from bridge.analyze import (
+    _entry_link,
+    _sample_text,
+    _select,
+    _time_value,
+    php_time_format_to_strptime,
+)
+
+DEFAULT_LIMIT = 20
+# Same ceiling the analyzer uses when validating an entry selector: past this
+# the selector is matching navigation or a tag cloud, not an article list.
+MAX_ENTRIES = 300
+
+
+def _image(entry) -> Optional[str]:
+    """The entry's thumbnail, including the lazy-loading spellings of `src`.
+
+    Listing pages very often carry the real thumbnail in a data attribute and
+    leave `src` as a placeholder until the image scrolls into view.
+    """
+    for img in _select(entry, "img"):
+        for attribute in ("src", "data-src", "data-original", "data-thumb"):
+            value = (img.get(attribute) or "").strip()
+            if value and not value.startswith("data:"):
+                return value
+        srcset = (img.get("srcset") or "").strip()
+        if srcset:
+            first = srcset.split(",")[0].strip().split(" ")[0]
+            if first:
+                return first
+    return None
+
+
+def _published(entry, selector: str, php_format: str) -> Optional[datetime]:
+    if not selector or not php_format:
+        return None
+    matches = _select(entry, selector)
+    if not matches:
+        return None
+    value = " ".join(_time_value(matches[0]).split())
+    try:
+        return datetime.strptime(value, php_time_format_to_strptime(php_format))
+    except ValueError:
+        return None
+
+
+def extract_entries(html: str, base_url: str, selectors: dict) -> List[dict]:
+    """Apply a source's stored selectors to a page.
+
+    Returns dicts of ``{url, title, text, author, date_published, image}``;
+    entries without a link are dropped, since there'd be nothing to open or
+    dedupe on. ``text`` is the entry's own visible text, which stands in for
+    the article body until the per-item scrapers fetch the real one.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    entry_selector = (selectors.get("entry_element_selector") or "").strip()
+    if not entry_selector:
+        raise Exception("This source has no entry selector configured")
+
+    url_selector = (selectors.get("url_selector") or "a").strip() or "a"
+    title_selector = (selectors.get("title_selector") or "").strip()
+    author_selector = (selectors.get("author_selector") or "").strip()
+    time_selector = (selectors.get("time_selector") or "").strip()
+    time_format = (selectors.get("time_format") or "").strip()
+
+    try:
+        limit = int(selectors.get("limit") or DEFAULT_LIMIT)
+    except (TypeError, ValueError):
+        limit = DEFAULT_LIMIT
+    limit = max(1, min(limit, MAX_ENTRIES))
+
+    entries = []
+    for element in _select(soup, entry_selector)[:limit]:
+        link = _entry_link(element, url_selector)
+        if link is None:
+            continue
+
+        title = None
+        if title_selector:
+            matches = _select(element, title_selector)
+            if matches:
+                title = _sample_text(matches[0]) or None
+        if not title:
+            title = _sample_text(link) or None
+
+        author = None
+        if author_selector:
+            matches = _select(element, author_selector)
+            if matches:
+                author = _sample_text(matches[0]) or None
+
+        image = _image(element)
+        entries.append(
+            {
+                "url": urljoin(base_url, link.get("href", "")),
+                "title": title,
+                "text": _sample_text(element) or None,
+                "author": author,
+                "date_published": _published(element, time_selector, time_format),
+                "image": urljoin(base_url, image) if image else None,
+            }
+        )
+
+    return entries

--- a/src/api/bridge/render.py
+++ b/src/api/bridge/render.py
@@ -1,0 +1,64 @@
+"""Client for the ``aggy-render`` sidecar (headless Chromium).
+
+A plain HTTP GET only sees what the server sent. A growing share of listing
+pages build themselves in the browser, keep their thumbnails in data
+attributes until they scroll into view, or hide everything behind a consent
+or age interstitial. For those, the HTML worth scraping only exists after the
+page has run — which is what this service provides.
+"""
+
+import logging
+from typing import Optional
+
+import requests
+
+from config import config
+
+RENDER_TIMEOUT_SECONDS = 90
+
+
+def is_configured() -> bool:
+    return config.get("RENDER_HOST", None) is not None
+
+
+def render_page(
+    url: str,
+    cookie: str = "",
+    wait_for: Optional[str] = None,
+    scroll: bool = True,
+) -> str:
+    """The page's HTML after scripts have run. Raises on failure."""
+    payload = {"url": url, "scroll": scroll}
+    if cookie:
+        payload["cookie"] = cookie
+    if wait_for:
+        payload["wait_for"] = wait_for
+
+    response = requests.post(
+        "http://{host}:{port}/render".format(
+            host=config.get("RENDER_HOST"), port=config.get("RENDER_PORT")
+        ),
+        json=payload,
+        timeout=RENDER_TIMEOUT_SECONDS,
+    )
+    if response.status_code != 200:
+        raise Exception(
+            f"Renderer returned HTTP {response.status_code}: "
+            f"{response.text.strip()[:300]}"
+        )
+    return response.json()["html"]
+
+
+def render_page_or_none(url: str, cookie: str = "") -> Optional[str]:
+    """Render, or return None when the renderer is absent or fails.
+
+    Callers use this to upgrade a plain fetch when the service happens to be
+    running, without making it a hard dependency.
+    """
+    if not is_configured():
+        return None
+    try:
+        return render_page(url, cookie=cookie)
+    except Exception as e:
+        logging.warning(f"Headless render of {url} failed, falling back: {e}")
+        return None

--- a/src/api/bridge/rsshub.py
+++ b/src/api/bridge/rsshub.py
@@ -1,0 +1,156 @@
+"""Import the bundled RSSHub instance's route catalog as source templates.
+
+RSSHub is a second bridge next to rss-bridge: same idea (parameters in, a feed
+out), a different and much larger set of sites. Its instance publishes every
+route it knows at ``/api/namespace``, which maps cleanly onto Aggy's source
+templates — so the routes become searchable in the same catalog as everything
+else instead of the user having to hand-write route paths.
+
+Imported templates are marked with a ``rsshub:`` prefix in
+``bridge_short_name`` so they can be told apart from rss-bridge's (and cleaned
+up when RSSHub goes away).
+"""
+
+import logging
+import re
+from typing import Optional
+
+import requests
+
+from config import config
+from db.base import get_db_con
+from db.source_template import SourceTemplate, SourceTemplateParameter
+
+MARKER_PREFIX = "rsshub:"
+CATALOG_TIMEOUT_SECONDS = 60
+# A route needing more than this many values is more of a form than a
+# template; the generic "RSSHub Route" template still covers it.
+MAX_ROUTE_PARAMETERS = 5
+
+# ":name" and ":name?" path segments are RSSHub's route parameters.
+_PARAMETER_PATTERN = re.compile(r":([A-Za-z0-9_]+)(\??)")
+
+
+def is_configured() -> bool:
+    return config.get("RSSHUB_HOST", None) is not None
+
+
+def _base_url() -> str:
+    return "http://{host}:{port}".format(
+        host=config.get("RSSHUB_HOST"), port=config.get("RSSHUB_PORT")
+    )
+
+
+def _parameter_description(raw, name: str) -> str:
+    """RSSHub describes parameters as either a string or an object."""
+    if isinstance(raw, dict):
+        entry = raw.get(name)
+        if isinstance(entry, dict):
+            return str(entry.get("description") or "")
+        if entry:
+            return str(entry)
+    return ""
+
+
+def route_to_template(
+    namespace: str, namespace_info: dict, path: str, route: dict
+) -> Optional[SourceTemplate]:
+    """One catalog route -> a source template, or None if it can't be one."""
+    if "*" in path:
+        # wildcard routes take a free-form remainder, which has no sensible
+        # parameter form; the generic route template covers them
+        return None
+
+    matches = _PARAMETER_PATTERN.findall(path)
+    if len(matches) > MAX_ROUTE_PARAMETERS:
+        return None
+
+    raw_parameters = route.get("parameters") or {}
+    parameters = {}
+    for name, optional_marker in matches:
+        description = _parameter_description(raw_parameters, name)
+        parameters[name] = SourceTemplateParameter(
+            name=name.replace("_", " ").title(),
+            title=description,
+            required=optional_marker != "?",
+            type="text",
+            # each value is one path segment and must stay in its place
+            quote="strict",
+        )
+
+    # ":uid" -> "{uid}", so the template can format the route itself. Only the
+    # route is substituted: the base URL carries a port, which looks exactly
+    # like a route parameter.
+    route_path = _PARAMETER_PATTERN.sub(r"{\1}", f"/{namespace}{path}")
+    url_template = f"{_base_url()}{route_path}"
+
+    site = (namespace_info.get("url") or "").strip()
+    name = (route.get("name") or "").strip() or path.strip("/") or namespace
+
+    return SourceTemplate(
+        name=name,
+        bridge_short_name=f"{MARKER_PREFIX}{namespace}{path}",
+        url=f"https://{site}" if site else "https://docs.rsshub.app",
+        description=(
+            route.get("description") or namespace_info.get("description") or name
+        )[:2000],
+        context=(namespace_info.get("name") or namespace).strip(),
+        parameters=parameters,
+        url_template=url_template,
+    )
+
+
+def _drop_imported_templates() -> None:
+    with get_db_con() as cur:
+        cur.execute(
+            "DELETE FROM source_templates WHERE bridge_short_name LIKE %s",
+            (f"{MARKER_PREFIX}%",),
+        )
+
+
+def rsshub_get_templates_job() -> None:
+    if not is_configured():
+        # RSSHub was removed from the deployment: take its routes out of the
+        # catalog rather than leave templates that can no longer be fetched.
+        try:
+            _drop_imported_templates()
+        except Exception as e:
+            logging.error(f"Failed to drop RSSHub templates: {e}")
+        return
+
+    try:
+        response = requests.get(
+            f"{_base_url()}/api/namespace", timeout=CATALOG_TIMEOUT_SECONDS
+        )
+        response.raise_for_status()
+        namespaces = response.json()
+    except requests.RequestException as e:
+        logging.warning(f"Could not read the RSSHub route catalog: {e}")
+        return
+    except ValueError as e:
+        # an instance that doesn't serve the catalog answers with HTML; the
+        # generic "RSSHub Route" template still works, so this isn't fatal
+        logging.warning(f"RSSHub route catalog was not JSON: {e}")
+        return
+
+    if not isinstance(namespaces, dict):
+        logging.warning("RSSHub route catalog had an unexpected shape")
+        return
+
+    imported = 0
+    for namespace, namespace_info in namespaces.items():
+        if not isinstance(namespace_info, dict):
+            continue
+        for path, route in (namespace_info.get("routes") or {}).items():
+            if not isinstance(route, dict):
+                continue
+            try:
+                template = route_to_template(namespace, namespace_info, path, route)
+                if template is None:
+                    continue
+                template.create()
+                imported += 1
+            except Exception as e:
+                logging.debug(f"Skipped RSSHub route {namespace}{path}: {e}")
+
+    logging.info(f"Imported {imported} RSSHub route(s) as source templates")

--- a/src/api/bridge/rsshub.py
+++ b/src/api/bridge/rsshub.py
@@ -7,8 +7,9 @@ templates — so the routes become searchable in the same catalog as everything
 else instead of the user having to hand-write route paths.
 
 Imported templates are marked with a ``rsshub:`` prefix in
-``bridge_short_name`` so they can be told apart from rss-bridge's (and cleaned
-up when RSSHub goes away).
+``bridge_short_name`` so they can be told apart from rss-bridge's — which is
+what the catalog's provider label reads, and what lets them be cleaned up when
+RSSHub goes away.
 """
 
 import logging
@@ -18,10 +19,10 @@ from typing import Optional
 import requests
 
 from config import config
+from constants import RSSHUB_TEMPLATE_PREFIX as MARKER_PREFIX
 from db.base import get_db_con
 from db.source_template import SourceTemplate, SourceTemplateParameter
 
-MARKER_PREFIX = "rsshub:"
 CATALOG_TIMEOUT_SECONDS = 60
 # A route needing more than this many values is more of a form than a
 # template; the generic "RSSHub Route" template still covers it.

--- a/src/api/bridge/rsshub.py
+++ b/src/api/bridge/rsshub.py
@@ -14,6 +14,7 @@ RSSHub goes away.
 
 import logging
 import re
+import urllib.parse
 from typing import Optional
 
 import requests
@@ -42,15 +43,61 @@ def _base_url() -> str:
     )
 
 
-def _parameter_description(raw, name: str) -> str:
-    """RSSHub describes parameters as either a string or an object."""
-    if isinstance(raw, dict):
-        entry = raw.get(name)
-        if isinstance(entry, dict):
-            return str(entry.get("description") or "")
-        if entry:
-            return str(entry)
-    return ""
+def _parameter_meta(raw, name: str) -> dict:
+    """What the catalog says about one route parameter.
+
+    RSSHub describes a parameter as either a bare description string or an
+    object that can also carry a default and the values it accepts. Returns
+    ``{description, default, options}`` with whatever was available.
+    """
+    meta = {"description": "", "default": None, "options": None}
+    entry = raw.get(name) if isinstance(raw, dict) else None
+
+    if isinstance(entry, str):
+        meta["description"] = entry
+        return meta
+    if not isinstance(entry, dict):
+        return meta
+
+    meta["description"] = str(entry.get("description") or "")
+    if entry.get("default") not in (None, ""):
+        meta["default"] = str(entry["default"])
+
+    options = entry.get("options")
+    if isinstance(options, dict):
+        meta["options"] = {str(k): str(v) for k, v in options.items()}
+    elif isinstance(options, list):
+        # [{value, label}, ...]
+        pairs = {
+            str(o["value"]): str(o.get("label") or o["value"])
+            for o in options
+            if isinstance(o, dict) and o.get("value") is not None
+        }
+        meta["options"] = pairs or None
+
+    return meta
+
+
+def _examples_from_route(namespace: str, path: str, example: str) -> dict:
+    """Per-parameter example values, read out of the route's example URL.
+
+    A route path like ``/user/:uid/:language?`` alongside the example
+    ``/example/user/12345/en`` gives ``{"uid": "12345", "language": "en"}``.
+    Without this a user has to guess what a segment wants, and a wrong guess
+    is often accepted by the route and only fails when the feed is fetched.
+    """
+    if not example:
+        return {}
+
+    route_segments = f"/{namespace}{path}".strip("/").split("/")
+    example_segments = example.strip("/").split("/")
+
+    examples = {}
+    for route_segment, example_segment in zip(route_segments, example_segments):
+        match = _PARAMETER_PATTERN.fullmatch(route_segment)
+        if match and example_segment:
+            examples[match.group(1)] = urllib.parse.unquote(example_segment)
+    return examples
 
 
 def route_to_template(
@@ -67,14 +114,22 @@ def route_to_template(
         return None
 
     raw_parameters = route.get("parameters") or {}
+    examples = _examples_from_route(namespace, path, str(route.get("example") or ""))
+
     parameters = {}
     for name, optional_marker in matches:
-        description = _parameter_description(raw_parameters, name)
+        meta = _parameter_meta(raw_parameters, name)
+        options = meta["options"]
         parameters[name] = SourceTemplateParameter(
             name=name.replace("_", " ").title(),
-            title=description,
+            title=meta["description"],
             required=optional_marker != "?",
-            type="text",
+            # a parameter with a known set of values becomes a dropdown, so a
+            # value the route would reject can't be typed in the first place
+            type="select" if options else "text",
+            options=options,
+            default=meta["default"],
+            example=examples.get(name),
             # each value is one path segment and must stay in its place
             quote="strict",
         )

--- a/src/api/builtin_templates.py
+++ b/src/api/builtin_templates.py
@@ -1,5 +1,6 @@
 import logging
 
+from config import config
 from db.source_template import SourceTemplate, SourceTemplateParameter
 
 
@@ -84,6 +85,79 @@ BUILTIN_TEMPLATES = [
 ]
 
 
+def ytdlp_template() -> SourceTemplate:
+    return SourceTemplate(
+        name="Video Site Listing",
+        url="https://github.com/yt-dlp/yt-dlp",
+        kind="ytdlp",
+        url_template="{url}",
+        description=(
+            "Any channel, user, playlist, or search-results page on a video "
+            "site, for the very many sites yt-dlp supports. Reads metadata "
+            "only — nothing is downloaded, and playback streams from the site "
+            "itself. Use this for sites that publish no feed, paginate their "
+            "listings, or hide them behind an age or consent gate."
+        ),
+        parameters={
+            "url": SourceTemplateParameter(
+                name="Listing URL",
+                title=(
+                    "URL of a channel, user, playlist, or search-results page "
+                    "— not a single item"
+                ),
+                required=True,
+                type="text",
+                quote="none",
+                example="https://www.youtube.com/@Computerphile/videos",
+            ),
+        },
+    )
+
+
+def rsshub_template() -> SourceTemplate:
+    return SourceTemplate(
+        name="RSSHub Route",
+        url="https://docs.rsshub.app",
+        url_template="http://{host}:{port}/{{route}}".format(
+            host=config.get("RSSHUB_HOST", "aggy-rsshub"),
+            port=config.get("RSSHUB_PORT"),
+        ),
+        description=(
+            "Any route on the bundled RSSHub instance, given as a path. Browse "
+            "the routes at docs.rsshub.app; the catalog importer also adds them "
+            "here as individual templates."
+        ),
+        parameters={
+            "route": SourceTemplateParameter(
+                name="Route",
+                title="Route path, without the leading slash",
+                required=True,
+                type="text",
+                quote="path",
+                example="github/issue/RSS-Bridge/rss-bridge",
+            ),
+        },
+    )
+
+
+# Templates that only work when their backing service is running: added when
+# it's configured, removed when it isn't, so the catalog never offers a source
+# that could not possibly ingest.
+OPTIONAL_TEMPLATES = (
+    ("YTDLP_HOST", ytdlp_template),
+    ("RSSHUB_HOST", rsshub_template),
+)
+
+
+def optional_templates() -> list:
+    """The optional templates whose service is configured."""
+    return [
+        build()
+        for host_key, build in OPTIONAL_TEMPLATES
+        if config.get(host_key, None) is not None
+    ]
+
+
 def builtin_template(name: str) -> SourceTemplate:
     """Look up a built-in template by its (context-free) name."""
     for template in BUILTIN_TEMPLATES:
@@ -94,11 +168,29 @@ def builtin_template(name: str) -> SourceTemplate:
 
 def create_builtin_source_templates() -> None:
     """Upsert Aggy's built-in (non-rss-bridge) source templates."""
-    for template in BUILTIN_TEMPLATES:
+    optional = optional_templates()
+
+    for template in BUILTIN_TEMPLATES + optional:
         try:
             template.create()
             logging.info(f"builtin template created: {template.user_friendly_name}")
         except Exception as e:
             logging.error(
                 f"Failed to create builtin template {template.user_friendly_name}: {e}"
+            )
+
+    # Drop templates for services that are no longer configured, so the
+    # catalog can't offer a source that would fail on its first ingest.
+    # Sources already built from them keep working.
+    configured = {t.name_hash for t in optional}
+    for _, build in OPTIONAL_TEMPLATES:
+        template = build()
+        if template.name_hash in configured:
+            continue
+        try:
+            template.delete()
+        except Exception as e:
+            logging.error(
+                f"Failed to drop unconfigured template "
+                f"{template.user_friendly_name}: {e}"
             )

--- a/src/api/config.py
+++ b/src/api/config.py
@@ -29,6 +29,18 @@ KNOWN_CONFIG_VALUES = [
     "OLLAMA_ANALYSIS_NUM_CTX",
     "RSS_BRIDGE_HOST",
     "RSS_BRIDGE_PORT",
+    # Second bridge: RSSHub covers a different (much larger) set of sites than
+    # rss-bridge. Optional; unset means its templates simply aren't offered.
+    "RSSHUB_HOST",
+    "RSSHUB_PORT",
+    # Metadata-only video-site extraction (src/ytdlp). Optional; unset means
+    # "ytdlp" sources can't be created or ingested.
+    "YTDLP_HOST",
+    "YTDLP_PORT",
+    # Headless browser used to render pages before scraping them (src/render).
+    # Optional; unset falls back to a plain HTTP fetch everywhere.
+    "RENDER_HOST",
+    "RENDER_PORT",
     "BUILD_VERSION",
     "JWT_EXPIRATION_DAYS",
     "SIGNUP_ENABLED",
@@ -70,6 +82,9 @@ DEFAULT_CONFIG = {
     # the thinking trace on reasoning models.
     "OLLAMA_ANALYSIS_NUM_CTX": 32768,
     "RSS_BRIDGE_PORT": 80,
+    "RSSHUB_PORT": 1200,
+    "YTDLP_PORT": 8000,
+    "RENDER_PORT": 8000,
     "BUILD_VERSION": "0.0.0-beta",
     "DB_PORT": 5432,
     "DB_USER": "aggy",

--- a/src/api/config.py
+++ b/src/api/config.py
@@ -3,6 +3,10 @@ import os
 KNOWN_CONFIG_VALUES = [
     "SOURCE_READ_INTERVAL_MINUTES",
     "SOURCE_INGESTION_RUN_INTERVAL_SECONDS",
+    # How many sources may be ingested at once. One slow source (a video
+    # listing walking result pages, a headless render) otherwise holds up
+    # every other source's turn.
+    "SOURCE_INGESTION_MAX_CONCURRENCY",
     "PYTEST_RUNTIME_TYPE",
     "JWT_ALGORITHM",
     "JWT_SECRET",
@@ -56,6 +60,9 @@ KNOWN_CONFIG_VALUES = [
 DEFAULT_CONFIG = {
     "SOURCE_READ_INTERVAL_MINUTES": 60,
     "SOURCE_INGESTION_RUN_INTERVAL_SECONDS": 15,
+    # Each run picks one due source with FOR UPDATE SKIP LOCKED, so runs never
+    # collide over the same source; this just lets a few overlap.
+    "SOURCE_INGESTION_MAX_CONCURRENCY": 3,
     "PYTEST_RUNTIME_TYPE": "local",
     "JWT_ALGORITHM": "HS256",
     "OLLAMA_PORT": 11434,

--- a/src/api/constants.py
+++ b/src/api/constants.py
@@ -1,5 +1,25 @@
 from config import config
 
+# Templates imported from RSSHub's route catalog carry this prefix in their
+# bridge_short_name, which is what tells them apart from rss-bridge's (and
+# what lets them be cleaned up when RSSHub goes away).
+RSSHUB_TEMPLATE_PREFIX = "rsshub:"
+
+# Where a template's feed comes from, shown as a label in the catalog.
+PROVIDER_BUILTIN = "Built-in"
+PROVIDER_RSS_BRIDGE = "RSS-Bridge"
+PROVIDER_RSSHUB = "RSSHub"
+
+# Browse order when nothing is being searched, and the tiebreak between
+# equally-good matches when something is. Aggy's own templates are the most
+# reliable (they fetch the site directly), and RSSHub's catalog is far the
+# largest, so without this its thousands of routes bury everything else.
+PROVIDER_RANK = {
+    PROVIDER_BUILTIN: 0,
+    PROVIDER_RSS_BRIDGE: 1,
+    PROVIDER_RSSHUB: 2,
+}
+
 # Server-wide default for how often sources are checked; individual sources
 # can override it via sources.ingest_interval_minutes.
 SOURCE_READ_INTERVAL_MINUTES = config.get_int("SOURCE_READ_INTERVAL_MINUTES")

--- a/src/api/db/feed.py
+++ b/src/api/db/feed.py
@@ -77,8 +77,8 @@ class Feed(ItemCollection):
         # fan-out, never fetched, so the ingest scheduler skips them here.
         with self.db_con() as cur:
             cur.execute(
-                "SELECT user_hash, feed_hash, name_hash, name, url, color "
-                "FROM sources "
+                "SELECT user_hash, feed_hash, name_hash, name, url, color, "
+                "kind, config FROM sources "
                 "WHERE user_hash = %s AND feed_hash = %s "
                 "AND source_feed_hash IS NULL",
                 (self.user_hash, self.name_hash),
@@ -92,6 +92,8 @@ class Feed(ItemCollection):
                 name=row["name"],
                 url=row["url"],
                 color=row["color"],
+                kind=row["kind"],
+                config=row["config"],
             )
             for row in rows
         ]
@@ -106,7 +108,7 @@ class Feed(ItemCollection):
             cur.execute(
                 "SELECT s.name, s.url, s.name_hash, s.feed_hash, s.last_ingested_at, "
                 "s.last_ingest_error, s.template_name_hash, s.template_parameters, "
-                "s.ingest_interval_minutes, s.color, s.source_feed_hash, "
+                "s.ingest_interval_minutes, s.color, s.source_feed_hash, s.kind, "
                 "sf.name AS source_feed_name, "
                 "(SELECT COUNT(*) FROM source_items si "
                 " WHERE si.user_hash = s.user_hash AND si.feed_hash = s.feed_hash "
@@ -210,9 +212,7 @@ class Feed(ItemCollection):
         # Prediction-ranked sorts stay strictly monotonic (see MONOTONIC_SORTS);
         # the browse sorts interleave sources by round-robin rank first.
         outer_sort = (
-            outer_order
-            if sort in MONOTONIC_SORTS
-            else f"q.source_rank, {outer_order}"
+            outer_order if sort in MONOTONIC_SORTS else f"q.source_rank, {outer_order}"
         )
         sql = f"SELECT * FROM ({sql}) q ORDER BY {outer_sort}"
         if limit is not None and limit >= 0:

--- a/src/api/db/item.py
+++ b/src/api/db/item.py
@@ -185,8 +185,13 @@ class ItemBase(AggyBaseModel):
     @classmethod
     def remove_html_tags(cls, v):
         if v:
-            return clean(
-                str(html.unescape(v)), tags=[], attributes={}, strip=True
+            # Unescape last: clean() escapes as part of sanitizing, so
+            # unescaping first only fed it an "&" to turn back into "&amp;",
+            # and the entity was displayed literally. These fields are
+            # rendered as text, never as markup, so plain characters are what
+            # they should hold.
+            return html.unescape(
+                clean(str(v), tags=[], attributes={}, strip=True)
             ).strip()
         return v
 

--- a/src/api/db/migrations/V14__source_ingest_backends.sql
+++ b/src/api/db/migrations/V14__source_ingest_backends.sql
@@ -1,0 +1,14 @@
+-- Sources used to be, without exception, "a URL that returns RSS/Atom".
+-- They now name the backend that turns them into items, so aggy can gather
+-- articles from places that don't publish a feed at all:
+--   'rss'   - fetch the URL and parse it as RSS/Atom (the existing behaviour)
+--   'ytdlp' - enumerate a channel/user/playlist/search page of a video site
+--   'html'  - render the page in a headless browser, then apply CSS selectors
+-- `config` carries whatever settings that backend needs (CSS selectors, a
+-- cookie header, an entry limit); NULL for plain RSS sources.
+ALTER TABLE sources ADD COLUMN kind TEXT NOT NULL DEFAULT 'rss';
+ALTER TABLE sources ADD COLUMN config JSONB;
+
+-- Templates declare which backend the sources they create should use, so a
+-- template can point at a video site or a scraped page rather than a feed.
+ALTER TABLE source_templates ADD COLUMN kind TEXT NOT NULL DEFAULT 'rss';

--- a/src/api/db/migrations/V15__source_kind_from_template.sql
+++ b/src/api/db/migrations/V15__source_kind_from_template.sql
@@ -1,0 +1,10 @@
+-- Sources created from a template took the default kind ('rss') instead of the
+-- template's, so a video listing was handed to the feed parser as if it were
+-- RSS and failed on its first fetch. The creation paths now carry the kind
+-- through; this repairs the sources made before they did.
+UPDATE sources s
+SET kind = t.kind
+FROM source_templates t
+WHERE s.template_name_hash = t.name_hash
+  AND s.kind = 'rss'
+  AND t.kind <> 'rss';

--- a/src/api/db/source.py
+++ b/src/api/db/source.py
@@ -1,6 +1,6 @@
 import json
 import random
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from pydantic import StringConstraints, HttpUrl
 from typing_extensions import Annotated
@@ -24,6 +24,7 @@ FEED_SOURCE_URL_PREFIX = "https://feed.aggy.local/"
 
 def feed_source_url(feed_hash: str) -> str:
     return f"{FEED_SOURCE_URL_PREFIX}{feed_hash}"
+
 
 # Default palette for per-source colors: distinct mid-tone hues that read
 # well as badge accents on both light and dark surfaces.
@@ -62,6 +63,13 @@ class Source(ItemCollection):
     # When set, this source mirrors another of the user's feeds instead of an
     # RSS URL (see propagation.py). Ordinary RSS sources leave it None.
     source_feed_hash: Optional[str] = None
+    # Which ingest backend turns this source into items (see ingest/backends).
+    # "rss" fetches the URL and parses it as a feed, which is what every source
+    # did before the other backends existed.
+    kind: str = "rss"
+    # Backend-specific settings: CSS selectors for "html", an entry limit and
+    # cookie for "ytdlp", and so on. None for plain RSS sources.
+    config: Optional[Dict[str, Any]] = None
 
     @property
     def name_hash(self):
@@ -124,8 +132,9 @@ class Source(ItemCollection):
             cur.execute(
                 "INSERT INTO sources (user_hash, feed_hash, name_hash, name, url, "
                 "template_name_hash, template_parameters, ingest_interval_minutes, "
-                "color, source_feed_hash, next_ingest_at) "
-                f"VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, {next_ingest_sql})",
+                "color, source_feed_hash, kind, config, next_ingest_at) "
+                f"VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, "
+                f"{next_ingest_sql})",
                 (
                     self.user_hash,
                     self.feed_hash,
@@ -139,6 +148,8 @@ class Source(ItemCollection):
                     self.ingest_interval_minutes,
                     self.color,
                     self.source_feed_hash,
+                    self.kind,
+                    json.dumps(self.config) if self.config is not None else None,
                 ),
             )
 
@@ -149,6 +160,7 @@ class Source(ItemCollection):
         template_parameters=None,
         ingest_interval=_UNSET,
         color=_UNSET,
+        config=_UNSET,
     ):
         """Update this source in place. Renaming changes name_hash; the
         source_items FK cascades so existing items stay attached. Resets
@@ -166,6 +178,11 @@ class Source(ItemCollection):
         if color is not _UNSET and color is not None:
             interval_sql += "color = %s, "
             interval_params = interval_params + (color,)
+        if config is not _UNSET:
+            interval_sql += "config = %s, "
+            interval_params = interval_params + (
+                json.dumps(config) if config is not None else None,
+            )
         with self.db_con() as cur:
             cur.execute(
                 "UPDATE sources SET name = %s, name_hash = %s, url = %s, "
@@ -196,6 +213,8 @@ class Source(ItemCollection):
             self.ingest_interval_minutes = ingest_interval
         if color is not _UNSET and color is not None:
             self.color = color
+        if config is not _UNSET:
+            self.config = config
 
     def delete(self):
         with self.db_con() as cur:
@@ -262,7 +281,7 @@ class Source(ItemCollection):
         with cls.db_con() as cur:
             cur.execute(
                 "SELECT name, url, template_name_hash, template_parameters, "
-                "ingest_interval_minutes, color, source_feed_hash "
+                "ingest_interval_minutes, color, source_feed_hash, kind, config "
                 "FROM sources "
                 "WHERE user_hash = %s AND feed_hash = %s AND name_hash = %s",
                 (user_hash, feed_hash, source_hash),
@@ -280,6 +299,8 @@ class Source(ItemCollection):
                 ingest_interval_minutes=row["ingest_interval_minutes"],
                 color=row["color"],
                 source_feed_hash=row["source_feed_hash"],
+                kind=row["kind"],
+                config=row["config"],
             )
         raise ValueError("Source not found")
 

--- a/src/api/db/source_template.py
+++ b/src/api/db/source_template.py
@@ -10,6 +10,12 @@ from config import config
 from utils import skip_limit_to_start_end
 
 
+def _escape(value: str, policy: str) -> str:
+    if policy == "none":
+        return value
+    return urllib.parse.quote(value, safe="/" if policy == "path" else "")
+
+
 class SourceTemplateParameterType(Enum):
     text = "text"
     select = "select"
@@ -25,6 +31,14 @@ class SourceTemplateParameter(AggyBaseModel):
     example: Optional[str] = None
     title: Optional[str] = None
     options: Optional[Dict[str, str]] = None
+    # How the value is escaped into a template's url_template:
+    #   "strict" - a single value; everything but unreserved characters is
+    #              encoded, so it can't escape its position in the URL
+    #   "path"   - a path fragment ("github/issues/owner/repo"), so slashes
+    #              survive encoding
+    #   "none"   - the value IS a complete URL and is used verbatim (it is
+    #              checked to be http(s) instead)
+    quote: str = "strict"
 
 
 class SourceTemplate(AggyBaseModel):
@@ -37,6 +51,10 @@ class SourceTemplate(AggyBaseModel):
     # Built-in (non-rss-bridge) templates: a python format string with
     # {parameter} placeholders, e.g. "https://www.reddit.com/r/{subreddit}/{sort}.rss"
     url_template: Optional[str] = None
+    # Ingest backend the sources built from this template should use. "rss"
+    # (the default) means the URL is fetched and parsed as a feed; see
+    # ingest/backends for the rest.
+    kind: str = "rss"
 
     @property
     def key(self):
@@ -87,11 +105,23 @@ class SourceTemplate(AggyBaseModel):
                 validation_issues.append(
                     f"Parameter {name} is not defined in the template"
                 )
+            # unescaped parameters go into the URL verbatim, so they have to
+            # be a URL themselves rather than arbitrary text
+            elif self.parameters[name].quote == "none" and value:
+                if not str(value).lower().startswith(("http://", "https://")):
+                    validation_issues.append(
+                        f"Parameter {name} must be a http:// or https:// URL"
+                    )
 
         if validation_issues:
             raise Exception(f"Validation issues: {', '.join(validation_issues)}")
 
-    def create_rss_url(self, **kwargs) -> str:
+    def create_source_url(self, **kwargs) -> str:
+        """The URL a source built from this template should point at.
+
+        For ``kind == "rss"`` that's a feed URL (rss-bridge's, or a site's own);
+        for the other backends it's the page the backend goes on to work with.
+        """
         if kwargs is None:
             kwargs = {}
 
@@ -106,7 +136,9 @@ class SourceTemplate(AggyBaseModel):
                     values[name] = kwargs[name]
                 elif parameter.default is not None:
                     values[name] = parameter.default
-            quoted = {k: urllib.parse.quote(str(v), safe="") for k, v in values.items()}
+            quoted = {
+                k: _escape(str(v), self.parameters[k].quote) for k, v in values.items()
+            }
             return self.url_template.format(**quoted)
 
         url_params = {
@@ -130,6 +162,10 @@ class SourceTemplate(AggyBaseModel):
             query=urllib.parse.urlencode(url_params),
         )
 
+    # Templates produced feed URLs exclusively before the other ingest
+    # backends existed; keep the old name working for existing callers.
+    create_rss_url = create_source_url
+
     def exists(self) -> bool:
         with self.db_con() as cur:
             cur.execute(
@@ -145,14 +181,14 @@ class SourceTemplate(AggyBaseModel):
         with self.db_con() as cur:
             cur.execute(
                 "INSERT INTO source_templates (name_hash, name, bridge_short_name, "
-                "url, description, context, parameters, url_template) "
-                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) "
+                "url, description, context, parameters, url_template, kind) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) "
                 "ON CONFLICT (name_hash) DO UPDATE SET "
                 "name = EXCLUDED.name, "
                 "bridge_short_name = EXCLUDED.bridge_short_name, "
                 "url = EXCLUDED.url, description = EXCLUDED.description, "
                 "context = EXCLUDED.context, parameters = EXCLUDED.parameters, "
-                "url_template = EXCLUDED.url_template",
+                "url_template = EXCLUDED.url_template, kind = EXCLUDED.kind",
                 (
                     self.name_hash,
                     self.name,
@@ -162,6 +198,7 @@ class SourceTemplate(AggyBaseModel):
                     self.context,
                     params_json,
                     self.url_template,
+                    self.kind,
                 ),
             )
 
@@ -188,6 +225,7 @@ class SourceTemplate(AggyBaseModel):
             context=row["context"],
             parameters=parameters,
             url_template=row.get("url_template"),
+            kind=row.get("kind") or "rss",
         )
 
     @classmethod
@@ -195,7 +233,7 @@ class SourceTemplate(AggyBaseModel):
         with cls.db_con() as cur:
             cur.execute(
                 "SELECT name, bridge_short_name, url, description, context, "
-                "parameters, url_template FROM source_templates WHERE name_hash = %s",
+                "parameters, url_template, kind FROM source_templates WHERE name_hash = %s",
                 (name_hash,),
             )
             row = cur.fetchone()
@@ -211,7 +249,7 @@ class SourceTemplate(AggyBaseModel):
         with cls.db_con() as cur:
             cur.execute(
                 "SELECT name, bridge_short_name, url, description, context, "
-                "parameters, url_template FROM source_templates "
+                "parameters, url_template, kind FROM source_templates "
                 "WHERE bridge_short_name = %s LIMIT 1",
                 (bridge_short_name,),
             )
@@ -226,7 +264,7 @@ class SourceTemplate(AggyBaseModel):
         with cls.db_con() as cur:
             cur.execute(
                 "SELECT name, bridge_short_name, url, description, context, "
-                "parameters, url_template FROM source_templates"
+                "parameters, url_template, kind FROM source_templates"
             )
             rows = cur.fetchall()
 

--- a/src/api/db/source_template.py
+++ b/src/api/db/source_template.py
@@ -5,6 +5,13 @@ import urllib
 import json
 from rapidfuzz import fuzz
 
+from constants import (
+    PROVIDER_BUILTIN,
+    PROVIDER_RANK,
+    PROVIDER_RSSHUB,
+    PROVIDER_RSS_BRIDGE,
+    RSSHUB_TEMPLATE_PREFIX,
+)
 from db.base import AggyBaseModel
 from config import config
 from utils import skip_limit_to_start_end
@@ -71,6 +78,46 @@ class SourceTemplate(AggyBaseModel):
         if self.context:
             return f"{self.name} ({self.context})"
         return self.name
+
+    @computed_field
+    @property
+    def provider(self) -> str:
+        """Which service produces this template's feed.
+
+        Derived from what the template already carries rather than stored, so
+        a re-import can't leave the label disagreeing with the template.
+        """
+        if not self.bridge_short_name:
+            return PROVIDER_BUILTIN
+        if self.bridge_short_name.startswith(RSSHUB_TEMPLATE_PREFIX):
+            return PROVIDER_RSSHUB
+        return PROVIDER_RSS_BRIDGE
+
+    @computed_field
+    @property
+    def site_domain(self) -> str:
+        """The site this template pulls from, e.g. "bilibili.com".
+
+        Imported route names are often just "User posts", which says nothing
+        about which site's users; the domain is what makes a result legible.
+        """
+        host = urllib.parse.urlparse(str(self.url)).netloc
+        return host[4:] if host.startswith("www.") else host
+
+    @computed_field
+    @property
+    def required_parameters(self) -> List[str]:
+        """Names of the values a user must supply before this can be saved."""
+        return [
+            parameter.name or key
+            for key, parameter in self.parameters.items()
+            if parameter.required
+        ]
+
+    @computed_field
+    @property
+    def optional_parameter_count(self) -> int:
+        return sum(1 for p in self.parameters.values() if not p.required)
 
     def validate_parameters(self, **kwargs) -> None:
         validation_issues = []
@@ -282,7 +329,12 @@ class SourceTemplate(AggyBaseModel):
         skip: Union[int, None] = None,
         limit: Union[int, None] = None,
     ) -> List["SourceTemplate"]:
-        templates = sorted(cls.read_all(), key=lambda t: t.user_friendly_name.lower())
+        def browse_order(t: "SourceTemplate"):
+            # Aggy's own handful of templates first, then rss-bridge, then
+            # RSSHub's thousands — otherwise browsing is just RSSHub.
+            return (PROVIDER_RANK.get(t.provider, 99), t.user_friendly_name.lower())
+
+        templates = sorted(cls.read_all(), key=browse_order)
         query = (query or "").strip().lower()
 
         if query:
@@ -290,14 +342,19 @@ class SourceTemplate(AggyBaseModel):
             def score(t: "SourceTemplate") -> float:
                 # description matches are weighted below name matches so a
                 # template whose name matches always outranks one where the
-                # query only appears in the description
+                # query only appears in the description. The provider and site
+                # are matchable too, so "rsshub" or a bare domain both work.
                 return max(
                     fuzz.WRatio(query, t.user_friendly_name.lower()),
+                    fuzz.WRatio(query, t.site_domain.lower()),
+                    fuzz.WRatio(query, t.provider.lower()),
                     fuzz.WRatio(query, (t.description or "").lower()) * 0.6,
                 )
 
+            # equal matches break toward the more reliable provider
             scored = sorted(
-                ((t, score(t)) for t in templates), key=lambda x: x[1], reverse=True
+                ((t, score(t)) for t in templates),
+                key=lambda x: (-x[1], PROVIDER_RANK.get(x[0].provider, 99)),
             )
             templates = [
                 t

--- a/src/api/ingest/backends/__init__.py
+++ b/src/api/ingest/backends/__init__.py
@@ -32,14 +32,14 @@ class Backend:
         # looked up on the module per call, so a backend stays substitutable
         return self.module.fetch_items(source)
 
-    def enrich_new_item(self, item):
-        """A backend's own chance to top up an item it has just discovered.
+    def enrich_item(self, item):
+        """A backend's own chance to top up an item.
 
-        Only called for items not already stored, so the cost is paid once per
-        article rather than on every check. Backends that have nothing to add
-        don't define it.
+        Called when an item is first seen, and again on an explicit
+        re-collect — never on every check, since it costs a request per
+        article. Backends with nothing to add don't define it.
         """
-        hook = getattr(self.module, "enrich_new_item", None)
+        hook = getattr(self.module, "enrich_item", None)
         if hook is None:
             return None
         try:

--- a/src/api/ingest/backends/__init__.py
+++ b/src/api/ingest/backends/__init__.py
@@ -9,6 +9,7 @@ Adding a backend means writing a module with a ``fetch_items(source)`` and
 registering it here.
 """
 
+import logging
 from types import ModuleType
 from typing import List
 
@@ -30,6 +31,22 @@ class Backend:
     def fetch_items(self, source: Source) -> List[ItemLoose]:
         # looked up on the module per call, so a backend stays substitutable
         return self.module.fetch_items(source)
+
+    def enrich_new_item(self, item):
+        """A backend's own chance to top up an item it has just discovered.
+
+        Only called for items not already stored, so the cost is paid once per
+        article rather than on every check. Backends that have nothing to add
+        don't define it.
+        """
+        hook = getattr(self.module, "enrich_new_item", None)
+        if hook is None:
+            return None
+        try:
+            return hook(item)
+        except Exception as e:
+            logging.error(f"Enriching {item.url} failed: {e}")
+            return None
 
 
 BACKENDS = {

--- a/src/api/ingest/backends/__init__.py
+++ b/src/api/ingest/backends/__init__.py
@@ -1,0 +1,51 @@
+"""Ingest backends: the different ways a source becomes a list of items.
+
+A source names its backend in ``Source.kind``. Each backend is responsible
+only for producing candidate :class:`ItemLoose` objects; deduplication,
+scraping, embedding, and storage are the shared pipeline in
+``ingest.source.ingest_source``.
+
+Adding a backend means writing a module with a ``fetch_items(source)`` and
+registering it here.
+"""
+
+from types import ModuleType
+from typing import List
+
+from db.item import ItemLoose
+from db.source import Source
+
+from . import html, rss, ytdlp
+
+
+class Backend:
+    def __init__(self, module: ModuleType, enrich: bool):
+        self.module = module
+        # Whether to run the per-item scrapers (reddit / open graph / mercury)
+        # over what this backend produced. Backends that already return
+        # complete metadata for sites that refuse anonymous scraping switch it
+        # off rather than spend a request per item to learn nothing.
+        self.enrich = enrich
+
+    def fetch_items(self, source: Source) -> List[ItemLoose]:
+        # looked up on the module per call, so a backend stays substitutable
+        return self.module.fetch_items(source)
+
+
+BACKENDS = {
+    "rss": Backend(module=rss, enrich=True),
+    "ytdlp": Backend(module=ytdlp, enrich=False),
+    "html": Backend(module=html, enrich=True),
+}
+
+DEFAULT_KIND = "rss"
+
+
+def get_backend(kind: str) -> Backend:
+    backend = BACKENDS.get(kind)
+    if backend is None:
+        raise Exception(
+            f"Unknown source kind '{kind}' "
+            f"(expected one of {', '.join(sorted(BACKENDS))})"
+        )
+    return backend

--- a/src/api/ingest/backends/html.py
+++ b/src/api/ingest/backends/html.py
@@ -1,0 +1,57 @@
+"""Ingest a plain web page by applying stored CSS selectors to it.
+
+Sources of this kind keep their selectors in ``Source.config``, the same set
+the analyzer suggested and the user approved in the preview. When the source
+is marked ``render``, the page comes from the headless renderer instead of a
+plain GET, so JavaScript-built listings work.
+"""
+
+import logging
+from typing import List
+from urllib.parse import urlparse
+
+from bridge.analyze import fetch_page
+from bridge.extract import extract_entries
+from bridge.render import render_page
+from db.item import ItemLoose
+from db.source import Source
+
+
+def fetch_items(source: Source) -> List[ItemLoose]:
+    source_config = source.config or {}
+    url = str(source.url)
+    cookie = source_config.get("cookie") or ""
+
+    if source_config.get("render"):
+        html = render_page(url, cookie=cookie)
+    else:
+        html = fetch_page(url, cookie=cookie)
+
+    entries = extract_entries(html, url, source_config)
+    if not entries:
+        raise Exception(
+            "The page had no entries matching this source's selectors. "
+            "The site's markup may have changed."
+        )
+
+    logging.info(f"Source '{source.name}': page has {len(entries)} entries")
+
+    items = []
+    for entry in entries:
+        # ItemStrict insists on excerpt/content, and a listing page rarely
+        # carries the article body: fall back to the entry's own text (and
+        # then its title) so the item survives until a scraper finds better.
+        text = entry["text"] or entry["title"]
+        items.append(
+            ItemLoose(
+                url=entry["url"],
+                title=entry["title"],
+                author=entry["author"],
+                date_published=entry["date_published"],
+                domain=urlparse(entry["url"]).netloc or None,
+                image_url=entry["image"],
+                excerpt=text,
+                content=text,
+            )
+        )
+    return items

--- a/src/api/ingest/backends/rss.py
+++ b/src/api/ingest/backends/rss.py
@@ -1,6 +1,7 @@
 """The original ingest backend: fetch a URL and parse it as RSS/Atom."""
 
 import logging
+import re
 from typing import List
 
 import feedparser
@@ -29,6 +30,15 @@ def feed_headers() -> dict:
 # explanation, not enough to put a stack trace in the sources list.
 ERROR_MESSAGE_MAX_CHARS = 300
 
+# Bridges wrap their failures in a whole error page — a greeting, an apology,
+# then the node version and git hash. The one line worth showing a user is
+# labelled, so pull that out and drop the rest of the furniture.
+_LABELLED_ERROR = re.compile(
+    r"error message:\s*(?P<message>.+?)"
+    r"(?=\s+(?:route|full route|node version|git hash|git date|path):|$)",
+    re.IGNORECASE,
+)
+
 
 def _response_message(response) -> str:
     """The human-readable part of a failed response body, if there is one."""
@@ -44,6 +54,11 @@ def _response_message(response) -> str:
         body = BeautifulSoup(body, "html.parser").get_text(" ", strip=True)
 
     message = " ".join(body.split())
+
+    labelled = _LABELLED_ERROR.search(message)
+    if labelled:
+        message = labelled.group("message").strip()
+
     if len(message) > ERROR_MESSAGE_MAX_CHARS:
         message = message[: ERROR_MESSAGE_MAX_CHARS - 1] + "…"
     return message

--- a/src/api/ingest/backends/rss.py
+++ b/src/api/ingest/backends/rss.py
@@ -1,0 +1,68 @@
+"""The original ingest backend: fetch a URL and parse it as RSS/Atom."""
+
+import logging
+from typing import List
+
+import feedparser
+import requests
+
+from config import config
+from db.item import ItemLoose
+from db.source import Source
+from ingest.item.rss import ingest_rss_item
+from ingest.reddit_rate_limit import is_reddit_url, reddit_get
+
+
+def feed_headers() -> dict:
+    # A descriptive User-Agent matters: reddit.com and others rate-limit
+    # anonymous/default agents far more aggressively.
+    return {
+        "User-Agent": (
+            f"aggy/{config.get('BUILD_VERSION')} "
+            "(self-hosted feed aggregator; +https://github.com/mullinmax/aggy)"
+        )
+    }
+
+
+def fetch_items(source: Source) -> List[ItemLoose]:
+    # Fetch the feed ourselves so failures produce a useful error instead of
+    # feedparser silently returning zero entries (rss-bridge answers bad
+    # parameters with an HTML error page, for example).
+    #
+    # reddit.com requests share a global adaptive throttle so all ingest jobs
+    # stay under one budget and back off together on 429s.
+    fetch = reddit_get if is_reddit_url(source.url) else requests.get
+    try:
+        response = fetch(str(source.url), timeout=60, headers=feed_headers())
+    except requests.RequestException as e:
+        raise Exception(f"Could not fetch feed: {e}") from e
+
+    if response.status_code == 429:
+        retry_after = response.headers.get("Retry-After")
+        detail = f", retry after {retry_after}s" if retry_after else ""
+        raise Exception(f"Rate limited by feed server (HTTP 429{detail})")
+
+    if response.status_code != 200:
+        raise Exception(f"Feed request returned HTTP {response.status_code}")
+
+    parsed = feedparser.parse(response.content)
+    entries = parsed.entries
+
+    if not entries:
+        detail = ""
+        if parsed.bozo and parsed.get("bozo_exception"):
+            detail = f" ({parsed.bozo_exception})"
+        raise Exception(f"Feed returned no entries{detail}")
+
+    # rss-bridge reports bridge failures as a 200 OK feed containing a single
+    # item titled "Bridge returned error <code>! (<id>)". Treat that as a
+    # failed ingest instead of ingesting the error as an article.
+    bridge_errors = [
+        e for e in entries if str(e.get("title", "")).startswith("Bridge returned error")
+    ]
+    if bridge_errors:
+        raise Exception(f"rss-bridge failed: {bridge_errors[0].get('title')}")
+
+    logging.info(f"Source '{source.name}': feed has {len(entries)} entries")
+
+    return [ingest_rss_item(entry) for entry in entries if entry.get("link")]

--- a/src/api/ingest/backends/rss.py
+++ b/src/api/ingest/backends/rss.py
@@ -5,6 +5,7 @@ from typing import List
 
 import feedparser
 import requests
+from bs4 import BeautifulSoup
 
 from config import config
 from db.item import ItemLoose
@@ -22,6 +23,30 @@ def feed_headers() -> dict:
             "(self-hosted feed aggregator; +https://github.com/mullinmax/aggy)"
         )
     }
+
+
+# How much of a failed response to quote back. Enough for a bridge's one-line
+# explanation, not enough to put a stack trace in the sources list.
+ERROR_MESSAGE_MAX_CHARS = 300
+
+
+def _response_message(response) -> str:
+    """The human-readable part of a failed response body, if there is one."""
+    try:
+        body = response.text[:4000]
+    except Exception:
+        return ""
+    if not body.strip():
+        return ""
+
+    content_type = response.headers.get("Content-Type", "")
+    if "html" in content_type or body.lstrip().startswith("<"):
+        body = BeautifulSoup(body, "html.parser").get_text(" ", strip=True)
+
+    message = " ".join(body.split())
+    if len(message) > ERROR_MESSAGE_MAX_CHARS:
+        message = message[: ERROR_MESSAGE_MAX_CHARS - 1] + "…"
+    return message
 
 
 def fetch_items(source: Source) -> List[ItemLoose]:
@@ -43,7 +68,14 @@ def fetch_items(source: Source) -> List[ItemLoose]:
         raise Exception(f"Rate limited by feed server (HTTP 429{detail})")
 
     if response.status_code != 200:
-        raise Exception(f"Feed request returned HTTP {response.status_code}")
+        # Bridges put the real reason in the body — "this route is empty",
+        # "route not found", a stack trace — and the status code alone
+        # ("HTTP 503") tells a user nothing they can act on.
+        detail = _response_message(response)
+        raise Exception(
+            f"Feed request returned HTTP {response.status_code}"
+            + (f": {detail}" if detail else "")
+        )
 
     parsed = feedparser.parse(response.content)
     entries = parsed.entries
@@ -58,7 +90,9 @@ def fetch_items(source: Source) -> List[ItemLoose]:
     # item titled "Bridge returned error <code>! (<id>)". Treat that as a
     # failed ingest instead of ingesting the error as an article.
     bridge_errors = [
-        e for e in entries if str(e.get("title", "")).startswith("Bridge returned error")
+        e
+        for e in entries
+        if str(e.get("title", "")).startswith("Bridge returned error")
     ]
     if bridge_errors:
         raise Exception(f"rss-bridge failed: {bridge_errors[0].get('title')}")

--- a/src/api/ingest/backends/ytdlp.py
+++ b/src/api/ingest/backends/ytdlp.py
@@ -1,0 +1,170 @@
+"""Ingest a video site's channel / user / playlist / search page.
+
+The heavy lifting happens in the ``aggy-ytdlp`` sidecar, which enumerates the
+page with yt-dlp in metadata-only mode. Nothing is ever downloaded: the
+listing pass returns titles, thumbnails, and page URLs, and the playable
+stream URL is resolved on demand (and never stored, since it expires) by
+``/item/stream_url`` when a viewer actually presses play.
+
+This reaches sites that publish no feed at all, paginate their listings, and
+gate them behind an age or consent interstitial that a plain HTTP fetch never
+gets past.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import List, Optional
+from urllib.parse import urlparse
+
+import requests
+
+from config import config
+from db.item import ItemLoose
+from db.source import Source
+
+# Fetching the listing is slower than an RSS GET: the sidecar may walk several
+# pages of results, each needing its own request to the site.
+EXTRACT_TIMEOUT_SECONDS = 180
+DEFAULT_MAX_ENTRIES = 30
+
+
+def is_configured() -> bool:
+    return config.get("YTDLP_HOST", None) is not None
+
+
+def _service_url(path: str) -> str:
+    return "http://{host}:{port}{path}".format(
+        host=config.get("YTDLP_HOST"),
+        port=config.get("YTDLP_PORT"),
+        path=path,
+    )
+
+
+def _published(entry: dict) -> Optional[datetime]:
+    timestamp = entry.get("timestamp")
+    if timestamp:
+        try:
+            return datetime.fromtimestamp(int(timestamp), tz=timezone.utc)
+        except (TypeError, ValueError, OSError):
+            pass
+    upload_date = entry.get("upload_date")  # "YYYYMMDD"
+    if upload_date:
+        try:
+            return datetime.strptime(str(upload_date), "%Y%m%d").replace(
+                tzinfo=timezone.utc
+            )
+        except ValueError:
+            pass
+    return None
+
+
+def entry_to_item(entry: dict) -> Optional[ItemLoose]:
+    """One sidecar entry -> an item, or None when it has no usable URL."""
+    url = entry.get("url")
+    if not url:
+        return None
+
+    thumbnail = entry.get("thumbnail")
+    # A listing pass returns no description for most sites, and ItemStrict
+    # requires excerpt/content, so the title stands in for the body.
+    description = entry.get("description") or entry.get("title")
+    return ItemLoose(
+        url=url,
+        title=entry.get("title"),
+        author=entry.get("uploader"),
+        date_published=_published(entry),
+        domain=urlparse(url).netloc or None,
+        excerpt=description,
+        content=description,
+        image_url=thumbnail,
+        # "stream" tells the UI to ask the API for a playable URL when the
+        # viewer opens the item. Storing one here instead would bake in a
+        # signed URL that stops working within hours.
+        media=[{"type": "stream", "url": url, "poster": thumbnail}],
+    )
+
+
+def is_supported(url: str) -> dict:
+    """Whether the sidecar has a real extractor for this URL.
+
+    Pattern matching only — the site is never contacted — so this is cheap
+    enough to run while a user is pasting a URL. Returns
+    ``{"supported": bool, "extractor": str | None}``, and simply says no when
+    the service isn't running.
+    """
+    if not is_configured():
+        return {"supported": False, "extractor": None}
+
+    try:
+        response = requests.post(
+            _service_url("/supported"), json={"url": url}, timeout=15
+        )
+        if response.status_code != 200:
+            return {"supported": False, "extractor": None}
+        return response.json()
+    except (requests.RequestException, ValueError) as e:
+        logging.warning(f"Could not check extractor support for {url}: {e}")
+        return {"supported": False, "extractor": None}
+
+
+def fetch_items(source: Source) -> List[ItemLoose]:
+    if not is_configured():
+        raise Exception(
+            "This source needs the aggy-ytdlp service, which isn't configured "
+            "(set YTDLP_HOST)"
+        )
+
+    source_config = source.config or {}
+    payload = {
+        "url": str(source.url),
+        "limit": int(source_config.get("limit") or DEFAULT_MAX_ENTRIES),
+    }
+    if source_config.get("cookie"):
+        payload["cookie"] = source_config["cookie"]
+
+    try:
+        response = requests.post(
+            _service_url("/extract"),
+            json=payload,
+            timeout=EXTRACT_TIMEOUT_SECONDS,
+        )
+    except requests.RequestException as e:
+        raise Exception(f"Could not reach the extraction service: {e}") from e
+
+    if response.status_code != 200:
+        detail = response.text.strip()[:300]
+        raise Exception(f"Extraction failed (HTTP {response.status_code}): {detail}")
+
+    entries = response.json().get("entries") or []
+    if not entries:
+        raise Exception(
+            "No entries found at that URL. It may need a channel, playlist, or "
+            "search-results page rather than a single item."
+        )
+
+    logging.info(f"Source '{source.name}': listing has {len(entries)} entries")
+
+    items = [entry_to_item(entry) for entry in entries]
+    return [item for item in items if item is not None]
+
+
+def resolve_stream(url: str, cookie: Optional[str] = None) -> dict:
+    """A currently-playable media URL for a page URL.
+
+    Called per playback rather than at ingest time; the returned URL is
+    typically signed and short-lived, so it is deliberately never persisted.
+    """
+    if not is_configured():
+        raise Exception("The aggy-ytdlp service isn't configured (set YTDLP_HOST)")
+
+    payload = {"url": url}
+    if cookie:
+        payload["cookie"] = cookie
+
+    response = requests.post(
+        _service_url("/resolve"), json=payload, timeout=EXTRACT_TIMEOUT_SECONDS
+    )
+    if response.status_code != 200:
+        detail = response.text.strip()[:300]
+        raise Exception(f"Could not resolve a playable URL (HTTP {response.status_code}): {detail}")
+    return response.json()

--- a/src/api/ingest/backends/ytdlp.py
+++ b/src/api/ingest/backends/ytdlp.py
@@ -148,7 +148,7 @@ def fetch_items(source: Source) -> List[ItemLoose]:
     return [item for item in items if item is not None]
 
 
-def enrich_new_item(item):
+def enrich_item(item):
     """Fill in what a listing pass didn't carry, for an item just discovered.
 
     Flat extraction is cheap because it never visits the items themselves, so

--- a/src/api/ingest/backends/ytdlp.py
+++ b/src/api/ingest/backends/ytdlp.py
@@ -148,6 +148,64 @@ def fetch_items(source: Source) -> List[ItemLoose]:
     return [item for item in items if item is not None]
 
 
+def enrich_new_item(item):
+    """Fill in what a listing pass didn't carry, for an item just discovered.
+
+    Flat extraction is cheap because it never visits the items themselves, so
+    on many sites an entry arrives with a URL and a title and nothing else —
+    no thumbnail, which leaves a card with an empty frame. This visits the
+    item once, the first time it's seen, and is skipped entirely when the
+    listing already gave us a picture.
+    """
+    if not is_configured() or item.image_url:
+        return None
+
+    try:
+        response = requests.post(
+            _service_url("/metadata"),
+            json={"url": str(item.url)},
+            timeout=EXTRACT_TIMEOUT_SECONDS,
+        )
+        if response.status_code != 200:
+            logging.info(
+                f"No metadata for {item.url} "
+                f"(HTTP {response.status_code}); keeping the listing's version"
+            )
+            return None
+        data = response.json()
+    except (requests.RequestException, ValueError) as e:
+        logging.warning(f"Metadata lookup failed for {item.url}: {e}")
+        return None
+
+    thumbnail = data.get("thumbnail")
+    if not thumbnail:
+        return None
+
+    updates = {"image_url": thumbnail}
+
+    # the stream entry's poster is the same picture; without it the player
+    # shows a blank box until it's told to play
+    if item.media:
+        updates["media"] = [
+            {**entry, "poster": entry.get("poster") or thumbnail}
+            if entry.get("type") == "stream"
+            else entry
+            for entry in item.media
+        ]
+
+    if item.date_published is None:
+        published = _published(data)
+        if published is not None:
+            updates["date_published"] = published
+
+    description = (data.get("description") or "").strip()
+    if description and item.excerpt == item.title:
+        updates["excerpt"] = description
+        updates["content"] = description
+
+    return item.model_copy(update=updates)
+
+
 def resolve_stream(url: str, cookie: Optional[str] = None) -> dict:
     """A currently-playable media URL for a page URL.
 
@@ -166,5 +224,7 @@ def resolve_stream(url: str, cookie: Optional[str] = None) -> dict:
     )
     if response.status_code != 200:
         detail = response.text.strip()[:300]
-        raise Exception(f"Could not resolve a playable URL (HTTP {response.status_code}): {detail}")
+        raise Exception(
+            f"Could not resolve a playable URL (HTTP {response.status_code}): {detail}"
+        )
     return response.json()

--- a/src/api/ingest/jobs.py
+++ b/src/api/ingest/jobs.py
@@ -5,6 +5,7 @@ from db.base import get_db_con
 from db.feed import Feed
 from db.item import ItemLoose
 from db.source import Source
+from ingest.backends import get_backend
 from ingest.source import ingest_source
 from ingest.item.reddit import ingest_reddit_item
 from ingest.item.open_graph import ingest_open_graph_item
@@ -128,6 +129,7 @@ def rescrape_source(source: Source) -> None:
     """
     from ranking.engine import rank_feed  # local import avoids an import cycle
 
+    backend = get_backend(source.kind)
     embedding_model = config.get("OLLAMA_EMBEDDING_MODEL", None)
     image_embed_host = config.get("IMAGE_EMBED_HOST", None)
     image_embed_model = config.get("IMAGE_EMBED_MODEL")
@@ -137,31 +139,37 @@ def rescrape_source(source: Source) -> None:
         try:
             before = {f: getattr(item, f) for f in _RESCRAPE_FIELDS}
 
-            merged = ItemLoose.merge_instances(
-                items=[
-                    item,
-                    ingest_reddit_item(item),
-                    ingest_open_graph_item(item),
-                    ingest_mercury_item(item),
-                ]
-            )
+            if backend.enrich:
+                merged = ItemLoose.merge_instances(
+                    items=[
+                        item,
+                        ingest_reddit_item(item),
+                        ingest_open_graph_item(item),
+                        ingest_mercury_item(item),
+                    ]
+                )
+            else:
+                # the generic scrapers have nothing to offer a backend that
+                # says so, and the sites it reaches refuse them anyway
+                merged = ItemLoose(**item.dict())
             # merge_instances doesn't carry embeddings over; keep the existing
             # ones so a re-scrape never drops them
             merged.embeddings = item.embeddings
             merged.image_embeddings = item.image_embeddings
 
+            # a re-collect is the one other time a backend gets to top an item
+            # up, which is how items stored before it could do so get their
+            # pictures
+            merged = backend.enrich_item(merged) or merged
+
             after = {f: getattr(merged, f) for f in _RESCRAPE_FIELDS}
-            text_changed = any(
-                after[f] != before[f] for f in _EMBEDDING_TEXT_FIELDS
-            )
+            text_changed = any(after[f] != before[f] for f in _EMBEDDING_TEXT_FIELDS)
             image_changed = after["image_url"] != before["image_url"]
 
             embedding_changed = False
             if text_changed and embedding_model is not None:
                 try:
-                    merged.add_embedding(
-                        model_name=embedding_model, force_refresh=True
-                    )
+                    merged.add_embedding(model_name=embedding_model, force_refresh=True)
                     embedding_changed = merged.embeddings != item.embeddings
                 except Exception as e:
                     logging.error(f"Error re-embedding item {item.url}: {e}")
@@ -196,7 +204,9 @@ def rescrape_source(source: Source) -> None:
         try:
             rank_feed(feed)
         except Exception as e:
-            logging.exception(f"Re-ranking feed {feed.name} after re-scrape failed: {e}")
+            logging.exception(
+                f"Re-ranking feed {feed.name} after re-scrape failed: {e}"
+            )
 
     logging.info(
         f"Re-scraped source '{source.name}': "
@@ -253,4 +263,6 @@ def backfill_image_embeddings_job() -> None:
         except Exception as e:
             logging.error(f"Error backfilling image embedding for {item.url}: {e}")
 
-    logging.info(f"Image embedding backfill complete: {done}/{len(url_hashes)} embedded.")
+    logging.info(
+        f"Image embedding backfill complete: {done}/{len(url_hashes)} embedded."
+    )

--- a/src/api/ingest/source.py
+++ b/src/api/ingest/source.py
@@ -1,77 +1,40 @@
 import logging
-import feedparser
-import requests
+
 from config import config
 from db.item import ItemLoose, ItemStrict
 from db.source import Source
 from db.feed import Feed
 from db.propagation import propagate_items
-from ingest.item.rss import ingest_rss_item
+from ingest.backends import get_backend
 from ingest.item.reddit import ingest_reddit_item, is_reddit_post
-from ingest.reddit_rate_limit import is_reddit_url, reddit_get
 from ingest.item.open_graph import ingest_open_graph_item
 from ingest.item.mercury import ingest_mercury_item
 
 
 def ingest_source(source: Source) -> None:
-    # Fetch the feed ourselves so failures produce a useful error instead of
-    # feedparser silently returning zero entries (rss-bridge answers bad
-    # parameters with an HTML error page, for example). A descriptive
-    # User-Agent matters: reddit.com and others rate-limit anonymous/default
-    # agents far more aggressively.
-    headers = {
-        "User-Agent": (
-            f"aggy/{config.get('BUILD_VERSION')} "
-            "(self-hosted feed aggregator; +https://github.com/mullinmax/aggy)"
-        )
-    }
-    # reddit.com requests share a global adaptive throttle so all ingest jobs
-    # stay under one budget and back off together on 429s.
-    fetch = reddit_get if is_reddit_url(source.url) else requests.get
-    try:
-        response = fetch(str(source.url), timeout=60, headers=headers)
-    except requests.RequestException as e:
-        raise Exception(f"Could not fetch feed: {e}") from e
+    """Fetch a source through its backend and store what comes back.
 
-    if response.status_code == 429:
-        retry_after = response.headers.get("Retry-After")
-        detail = f", retry after {retry_after}s" if retry_after else ""
-        raise Exception(f"Rate limited by feed server (HTTP 429{detail})")
+    The backend (see ``ingest.backends``) decides *how* a source becomes a
+    list of items — a feed, a video site's listing, a scraped page. Everything
+    after that is common to all of them: skip what's already stored, enrich
+    with the per-item scrapers, embed, and attach to the source and feed.
+    """
+    backend = get_backend(source.kind)
+    candidates = backend.fetch_items(source)
 
-    if response.status_code != 200:
-        raise Exception(f"Feed request returned HTTP {response.status_code}")
-
-    parsed = feedparser.parse(response.content)
-    entries = parsed.entries
-
-    if not entries:
-        detail = ""
-        if parsed.bozo and parsed.get("bozo_exception"):
-            detail = f" ({parsed.bozo_exception})"
-        raise Exception(f"Feed returned no entries{detail}")
-
-    # rss-bridge reports bridge failures as a 200 OK feed containing a single
-    # item titled "Bridge returned error <code>! (<id>)". Treat that as a
-    # failed ingest instead of ingesting the error as an article.
-    bridge_errors = [
-        e for e in entries if str(e.get("title", "")).startswith("Bridge returned error")
-    ]
-    if bridge_errors:
-        raise Exception(f"rss-bridge failed: {bridge_errors[0].get('title')}")
-
-    logging.info(f"Source '{source.name}': feed has {len(entries)} entries")
+    if not candidates:
+        raise Exception("Source returned no entries")
 
     feed = Feed.read(user_hash=source.user_hash, name_hash=source.feed_hash)
     ingested_url_hashes: list[str] = []
 
-    for entry in entries:
+    for candidate in candidates:
         # if the item already exists in the database, skip scraping
-        temp_item = ItemLoose(url=entry.link)
-        if temp_item.exists():
-            logging.info(f"Item already exists in database: {entry.link}")
+        if candidate.exists():
+            logging.info(f"Item already exists in database: {candidate.url}")
 
             # TODO check how long ago we ingested this item and re-ingest if it's been long enough
-            final_item = ItemStrict.read(url_hash=temp_item.url_hash)
+            final_item = ItemStrict.read(url_hash=candidate.url_hash)
             if final_item is None:
                 continue
 
@@ -87,17 +50,20 @@ def ingest_source(source: Source) -> None:
                         image_url=reddit_item.image_url or final_item.image_url,
                     )
         else:
-            rss_item = ingest_rss_item(entry)
-            # reddit's post JSON has full-res images, gifs, videos, and
-            # galleries that the RSS feed only thumbnails; merge it in ahead
-            # of open graph so its media wins
-            reddit_item = ingest_reddit_item(rss_item)
-            open_graph_item = ingest_open_graph_item(rss_item)
-            mercury_item = ingest_mercury_item(rss_item)
-
-            best_item = ItemLoose.merge_instances(
-                items=[rss_item, reddit_item, open_graph_item, mercury_item]
-            )
+            if backend.enrich:
+                # reddit's post JSON has full-res images, gifs, videos, and
+                # galleries that the RSS feed only thumbnails; merge it in ahead
+                # of open graph so its media wins
+                best_item = ItemLoose.merge_instances(
+                    items=[
+                        candidate,
+                        ingest_reddit_item(candidate),
+                        ingest_open_graph_item(candidate),
+                        ingest_mercury_item(candidate),
+                    ]
+                )
+            else:
+                best_item = candidate
 
             # Attempt to make strict item from best of all
             try:

--- a/src/api/ingest/source.py
+++ b/src/api/ingest/source.py
@@ -30,7 +30,8 @@ def ingest_source(source: Source) -> None:
 
     for candidate in candidates:
         # if the item already exists in the database, skip scraping
-        if candidate.exists():
+        already_stored = candidate.exists()
+        if already_stored:
             logging.info(f"Item already exists in database: {candidate.url}")
 
             # TODO check how long ago we ingested this item and re-ingest if it's been long enough
@@ -92,11 +93,17 @@ def ingest_source(source: Source) -> None:
             except Exception as e:
                 logging.error(f"Error adding image embedding to item: {e}")
 
-        # write item to db
+        # write item to db. An item already in the table is updated rather than
+        # inserted: create() refuses to overwrite, and treating that as a
+        # failure used to skip the attachment below — so an article another
+        # source had already stored never showed up in this one's feed.
         try:
-            final_item.create()
+            if already_stored:
+                final_item.update()
+            else:
+                final_item.create()
         except Exception as e:
-            logging.error(f"Error creating item: {e}")
+            logging.error(f"Error storing item {final_item.url}: {e}")
             continue
 
         source.add_items(final_item)

--- a/src/api/ingest/source.py
+++ b/src/api/ingest/source.py
@@ -77,7 +77,7 @@ def ingest_source(source: Source) -> None:
 
             # the backend's own turn to fill gaps, now that we know this
             # article is new and worth spending a request on
-            final_item = backend.enrich_new_item(final_item) or final_item
+            final_item = backend.enrich_item(final_item) or final_item
 
         # generate embedding if a model is configured and it doesn't exist yet
         embedding_model = config.get("OLLAMA_EMBEDDING_MODEL", None)

--- a/src/api/ingest/source.py
+++ b/src/api/ingest/source.py
@@ -75,6 +75,10 @@ def ingest_source(source: Source) -> None:
                 # TODO make sure we don't attempt this url over and over
                 continue
 
+            # the backend's own turn to fill gaps, now that we know this
+            # article is new and worth spending a request on
+            final_item = backend.enrich_new_item(final_item) or final_item
+
         # generate embedding if a model is configured and it doesn't exist yet
         embedding_model = config.get("OLLAMA_EMBEDDING_MODEL", None)
         if embedding_model is not None:

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -33,6 +33,7 @@ from routers.item import item_router
 from routers.list import list_router
 from routers.web import web_router
 from bridge.jobs import rss_bridge_get_templates_job
+from bridge.rsshub import rsshub_get_templates_job
 from builtin_templates import create_builtin_source_templates
 from ingest.jobs import (
     source_ingestion_scheduling_job,
@@ -83,6 +84,16 @@ async def app_lifespan(app: FastAPI):
         trigger="interval",
         seconds=60 * 60 * 12,
         id="rss_bridge_get_templates_job",
+        replace_existing=False,
+        next_run_time=datetime.now(),
+    )
+
+    # and the same for the RSSHub route catalog, when that service is running
+    scheduler.add_job(
+        func=rsshub_get_templates_job,
+        trigger="interval",
+        seconds=60 * 60 * 12,
+        id="rsshub_get_templates_job",
         replace_existing=False,
         next_run_time=datetime.now(),
     )

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -68,13 +68,16 @@ async def app_lifespan(app: FastAPI):
         next_run_time=datetime.now(),
     )
 
-    # add scheduler job for ingesting sources every n seconds
+    # add scheduler job for ingesting sources every n seconds. Several may run
+    # at once: a video listing or a headless render takes far longer than the
+    # interval, and with a single instance one slow source stalls the queue.
     scheduler.add_job(
         func=source_ingestion_job,
         trigger="interval",
         seconds=config.get_int("SOURCE_INGESTION_RUN_INTERVAL_SECONDS"),
         id="source_ingestion_job",
         replace_existing=False,
+        max_instances=config.get_int("SOURCE_INGESTION_MAX_CONCURRENCY"),
         next_run_time=datetime.now(),
     )
 

--- a/src/api/route_models/source.py
+++ b/src/api/route_models/source.py
@@ -22,6 +22,8 @@ class SourceRouteModel(BaseRouteModel):
     # Set when this source mirrors another feed instead of an RSS URL.
     source_feed_hash: Optional[str] = None
     source_feed_name: Optional[str] = None
+    # Which ingest backend reads this source: "rss", "ytdlp", or "html".
+    source_kind: str = "rss"
 
     @classmethod
     def from_db_model(cls, db_model: Source):
@@ -35,6 +37,7 @@ class SourceRouteModel(BaseRouteModel):
             source_ingest_interval_minutes=db_model.ingest_interval_minutes,
             source_color=db_model.color,
             source_feed_hash=db_model.source_feed_hash,
+            source_kind=db_model.kind,
         )
 
     @classmethod
@@ -53,4 +56,5 @@ class SourceRouteModel(BaseRouteModel):
             source_color=row.get("color"),
             source_feed_hash=row.get("source_feed_hash"),
             source_feed_name=row.get("source_feed_name"),
+            source_kind=row.get("kind") or "rss",
         )

--- a/src/api/route_models/source_analyze.py
+++ b/src/api/route_models/source_analyze.py
@@ -15,13 +15,18 @@ class AnalyzeRequest(BaseRouteModel):
 
 
 class DetectResponse(BaseRouteModel):
-    # "feed" when the URL is (or advertises) an RSS/Atom feed, else "html"
+    # "feed" when the URL is (or advertises) an RSS/Atom feed, "video" when a
+    # video-site extractor can enumerate it, else "html" (needs selectors)
     kind: str
     # the feed to subscribe to when kind == "feed"; may differ from the input
     # URL when auto-discovered from an HTML page's <link> tags
     feed_url: Optional[str] = None
     # friendly default source name from the page/feed title or domain
     suggested_source_name: str
+    # template to create the source from, when kind == "video"
+    template_name_hash: Optional[str] = None
+    # which extractor claimed the URL, for kind == "video"
+    extractor: Optional[str] = None
 
 
 class SelectorCandidate(BaseRouteModel):
@@ -41,6 +46,10 @@ class AnalyzeResponse(BaseRouteModel):
     suggested_source_name: str
     # template used to create the source (CSS Selector Complex bridge)
     template_name_hash: str
+    # True when the selectors were found in headless-rendered HTML rather than
+    # the raw response. Such a source has to keep rendering to see its
+    # articles, so it is saved as a scraped source instead of an rss-bridge one.
+    rendered: bool = False
     # candidates per bridge parameter: entry_element_selector, title_selector,
     # url_selector, time_selector, author_selector
     candidates: Dict[str, List[SelectorCandidate]]
@@ -63,6 +72,9 @@ class AnalyzeJobStatus(BaseRouteModel):
 class PreviewRequest(BaseRouteModel):
     # CssSelectorComplexBridge parameters (home_page, entry_element_selector, ...)
     parameters: Dict[str, str]
+    # Preview the page as the headless renderer sees it, and extract the
+    # entries in-process, exactly as a scraped source would at ingest time.
+    rendered: bool = False
 
     model_config = {
         "json_schema_extra": {

--- a/src/api/route_models/source_scraped.py
+++ b/src/api/route_models/source_scraped.py
@@ -1,0 +1,31 @@
+from typing import Dict
+
+from .base import BaseRouteModel
+
+
+class ScrapedSourceCreate(BaseRouteModel):
+    feed_hash: str
+    source_name: str
+    # The selectors approved in the analysis preview: home_page,
+    # entry_element_selector, title_selector, url_selector, and friends.
+    parameters: Dict[str, str]
+    # Whether the page has to go through the headless renderer to show its
+    # articles. Set by the analyzer when the raw HTML had none.
+    rendered: bool = True
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "feed_hash": "feed_hash_456",
+                "source_name": "Example Blog",
+                "parameters": {
+                    "home_page": "https://example.com/blog/",
+                    "entry_element_selector": "div.article",
+                    "title_selector": "h2",
+                    "url_selector": "a",
+                    "limit": "10",
+                },
+                "rendered": True,
+            }
+        }
+    }

--- a/src/api/route_models/stream.py
+++ b/src/api/route_models/stream.py
@@ -1,0 +1,15 @@
+from typing import Optional
+
+from .base import BaseRouteModel
+
+
+class StreamUrlResponse(BaseRouteModel):
+    # A playable media URL, freshly resolved. Usually signed and short-lived,
+    # so it is meant to be used immediately and never stored.
+    url: str
+    ext: Optional[str] = None
+    height: Optional[int] = None
+    protocol: Optional[str] = None
+    title: Optional[str] = None
+    duration: Optional[float] = None
+    poster: Optional[str] = None

--- a/src/api/routers/bulk_import.py
+++ b/src/api/routers/bulk_import.py
@@ -138,6 +138,8 @@ def bulk_create_sources(
                 url=url,
                 template_name_hash=template.name_hash if template else None,
                 template_parameters=row.template_parameters if template else None,
+                # a template's sources are read the way the template says
+                kind=template.kind if template else "rss",
             )
         except Exception as e:
             result(row, BulkCreateResultStatus.error, str(e))

--- a/src/api/routers/item.py
+++ b/src/api/routers/item.py
@@ -3,9 +3,12 @@ from pydantic import confloat
 from typing import Optional
 
 from routers.auth import authenticate
+from db.item import ItemLoose
 from db.item_state import ItemState
 from db.feed import Feed
 from db.user import User
+from ingest.backends import ytdlp
+from route_models.stream import StreamUrlResponse
 
 item_router = APIRouter()
 
@@ -63,3 +66,37 @@ def get_state(
 # Outdated: 🕰️
 # Offensive: 🤡
 # Promotional: 📢
+
+
+@item_router.get(
+    "/stream_url",
+    summary="Resolve a currently-playable media URL for a video item",
+    response_model=StreamUrlResponse,
+)
+def stream_url(
+    item_url_hash: str,
+    user: User = Depends(authenticate),
+) -> StreamUrlResponse:
+    """Ask the extraction service for a URL the browser can play right now.
+
+    Video items store no playable URL: the ones sites hand out are signed and
+    expire within hours, so a stored one would be broken by the time anyone
+    pressed play. Instead the item keeps its page URL and this resolves a
+    fresh stream per playback. Nothing is downloaded or proxied — the browser
+    streams from the origin.
+    """
+    item = ItemLoose.read(url_hash=item_url_hash)
+    if item is None:
+        raise HTTPException(status_code=404, detail="Item not found")
+
+    if not any((entry or {}).get("type") == "stream" for entry in item.media or []):
+        raise HTTPException(
+            status_code=422, detail="This item has no resolvable stream"
+        )
+
+    try:
+        resolved = ytdlp.resolve_stream(str(item.url))
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=str(e))
+
+    return StreamUrlResponse(**resolved)

--- a/src/api/routers/source.py
+++ b/src/api/routers/source.py
@@ -10,10 +10,15 @@ from ingest.jobs import ingest_source_now, rescrape_source
 from route_models.item import ItemResponse
 from route_models.acknowledge import AcknowledgeResponse
 from route_models.source import SourceRouteModel
+from route_models.source_scraped import ScrapedSourceCreate
 from route_models.source_update import SourceUpdate
 from routers.auth import authenticate
 
 source_router = APIRouter()
+
+# Distinguishes "leave config alone" from an explicit new value, mirroring
+# Source.update()'s own sentinel.
+_UNSET = object()
 
 
 @source_router.post(
@@ -46,6 +51,55 @@ def create_source(
     # kick off the first ingest right away instead of waiting for the schedule
     background_tasks.add_task(ingest_source_now, source)
     return AcknowledgeResponse()
+
+
+@source_router.post(
+    "/create_scraped",
+    summary="Create a source that scrapes a web page with CSS selectors",
+    response_model=SourceRouteModel,
+)
+def create_scraped_source(
+    request: ScrapedSourceCreate,
+    background_tasks: BackgroundTasks,
+    user: User = Depends(authenticate),
+) -> SourceRouteModel:
+    """Save the selectors a user approved in the analysis preview.
+
+    Unlike a template source, this one carries its own selectors and is
+    extracted in-process, so a page that only exists after JavaScript runs can
+    be ingested the same way it was previewed.
+    """
+    feed = Feed.read(user_hash=user.name_hash, name_hash=request.feed_hash)
+    if feed is None:
+        raise HTTPException(status_code=404, detail="Feed not found")
+
+    page_url = request.parameters.get("home_page")
+    if not page_url:
+        raise HTTPException(
+            status_code=422, detail="A page URL (home_page) is required"
+        )
+
+    source = Source(
+        user_hash=user.name_hash,
+        feed_hash=request.feed_hash,
+        name=request.source_name,
+        url=page_url,
+        kind="html",
+        config={**request.parameters, "render": request.rendered},
+    )
+    if source.exists():
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f'A source named "{request.source_name}" already exists in '
+                "this feed. Pick a different name."
+            ),
+        )
+
+    feed.add_source(source)
+    # kick off the first ingest right away instead of waiting for the schedule
+    background_tasks.add_task(ingest_source_now, source)
+    return SourceRouteModel.from_db_model(source)
 
 
 @source_router.post(
@@ -113,7 +167,13 @@ def update_source(
 
     new_url = str(source.url)
     new_parameters = None
-    if source.template_name_hash and update.parameters is not None:
+    new_config = _UNSET
+    if source.kind == "html" and update.parameters is not None:
+        # Scraped sources keep their selectors in `config`, and the page they
+        # scrape is one of those selectors' values.
+        new_config = dict(update.parameters)
+        new_url = new_config.get("home_page") or new_url
+    elif source.template_name_hash and update.parameters is not None:
         template = SourceTemplate.read(name_hash=source.template_name_hash)
         if not template:
             raise HTTPException(status_code=404, detail="Source template not found")
@@ -133,6 +193,8 @@ def update_source(
         update_kwargs["ingest_interval"] = update.ingest_interval_minutes
     if update.source_color is not None:
         update_kwargs["color"] = update.source_color
+    if new_config is not _UNSET:
+        update_kwargs["config"] = new_config
     source.update(
         name=new_name,
         url=new_url,

--- a/src/api/routers/source_analyze.py
+++ b/src/api/routers/source_analyze.py
@@ -19,6 +19,11 @@ from bridge.analyze import (
     suggest_source_name,
     validate_suggestions,
 )
+from bridge.extract import extract_entries
+from bridge.render import is_configured as renderer_configured
+from bridge.render import render_page
+from builtin_templates import ytdlp_template
+from ingest.backends import ytdlp
 from db.source_template import SourceTemplate
 from db.user import User
 from route_models.source_analyze import (
@@ -64,8 +69,22 @@ JOB_TTL_SECONDS = 15 * 60
 
 def _analyze(url: str, template_name_hash: str, cookie: str) -> AnalyzeResponse:
     html = fetch_page(url, cookie=cookie)
-    raw = request_selector_suggestions(url, html)
-    candidates = validate_suggestions(html, url, raw)
+    rendered = False
+
+    try:
+        raw = request_selector_suggestions(url, html)
+        candidates = validate_suggestions(html, url, raw)
+    except AnalyzeError:
+        # Nothing article-shaped in the server's HTML. When the page builds
+        # itself in the browser that's expected, so try again with what the
+        # headless renderer sees before giving up.
+        if not renderer_configured():
+            raise
+        logging.info(f"no entries in the raw HTML of {url}; retrying rendered")
+        html = render_page(url, cookie=cookie)
+        rendered = True
+        raw = request_selector_suggestions(url, html)
+        candidates = validate_suggestions(html, url, raw)
 
     def best(field: str) -> str:
         return candidates[field][0].selector if candidates[field] else ""
@@ -75,6 +94,7 @@ def _analyze(url: str, template_name_hash: str, cookie: str) -> AnalyzeResponse:
         page_title=title or None,
         suggested_source_name=suggest_source_name(title, url),
         template_name_hash=template_name_hash,
+        rendered=rendered,
         candidates=candidates,
         # author/time start disabled even when candidates exist: they're
         # nice-to-haves, and a bad time selector can break the whole feed
@@ -123,10 +143,36 @@ def _drop_stale_jobs() -> None:
 def detect_source(
     request: AnalyzeRequest, user: User = Depends(authenticate)
 ) -> DetectResponse:
+    fetch_error = None
     try:
         result = detect_source_type(request.url, request.cookie or "")
     except AnalyzeError as e:
-        raise HTTPException(status_code=e.status_code, detail=str(e))
+        # A site that refuses anonymous fetches is exactly the case the video
+        # extractor handles, so a failure here isn't the end of the road.
+        result = None
+        fetch_error = e
+
+    # A real feed beats extraction: it's lighter on the site and needs no
+    # extra service. Only when there isn't one is the video path considered.
+    if result is None or result["kind"] != "feed":
+        supported = ytdlp.is_supported(request.url)
+        if supported.get("supported"):
+            name = (
+                result["suggested_source_name"]
+                if result
+                else suggest_source_name("", request.url)
+            )
+            return DetectResponse(
+                kind="video",
+                suggested_source_name=name,
+                template_name_hash=ytdlp_template().name_hash,
+                extractor=supported.get("extractor"),
+            )
+
+    if result is None:
+        raise HTTPException(
+            status_code=fetch_error.status_code, detail=str(fetch_error)
+        )
     return DetectResponse(**result)
 
 
@@ -196,6 +242,46 @@ def _entry_excerpt(content_html: str):
     return text or None
 
 
+def _preview_rendered(parameters: dict) -> PreviewResponse:
+    """Preview a scraped source the way its ingest will actually run it.
+
+    Same renderer, same extractor: what the user approves here is what the
+    source produces, rather than an rss-bridge rendition of it.
+    """
+    url = parameters.get("home_page") or ""
+    if not url:
+        raise HTTPException(status_code=422, detail="A page URL is required")
+
+    try:
+        html = render_page(url, cookie=parameters.get("cookie") or "")
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Couldn't render the page: {e}")
+
+    try:
+        entries = extract_entries(html, url, parameters)
+    except Exception as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+    return PreviewResponse(
+        feed_title=page_title(html) or None,
+        items=[
+            PreviewItem(
+                title=entry["title"],
+                url=entry["url"],
+                author=entry["author"],
+                date_published=(
+                    entry["date_published"].isoformat()
+                    if entry["date_published"]
+                    else None
+                ),
+                excerpt=entry["text"],
+                image=entry["image"],
+            )
+            for entry in entries
+        ],
+    )
+
+
 @source_analyze_router.post(
     "/preview",
     summary="Preview the feed produced by a set of CSS selectors",
@@ -204,6 +290,9 @@ def _entry_excerpt(content_html: str):
 def preview_selectors(
     request: PreviewRequest, user: User = Depends(authenticate)
 ) -> PreviewResponse:
+    if request.rendered:
+        return _preview_rendered(request.parameters)
+
     template = _css_selector_template()
 
     try:

--- a/src/api/routers/source_template.py
+++ b/src/api/routers/source_template.py
@@ -76,6 +76,9 @@ def create_source_from_template(
         url=source_url,
         template_name_hash=source_template.name_hash,
         template_parameters=sf_template.parameters,
+        # the template decides how its sources are read; without this a video
+        # listing would be handed to the feed parser as if it were RSS
+        kind=source_template.kind,
     )
     if source.exists():
         # add_source() silently no-ops on duplicates, which used to leave the

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -1109,7 +1109,15 @@ function streamPlayer(m, itemHash) {
         onclick: (ev) => ev.stopPropagation(),
       }));
     } catch (err) {
-      render(wrap, poster());
+      // Not every item has a rendition a browser can play, and a site can
+      // simply refuse the lookup. Offer the page itself rather than leaving
+      // a play button that does nothing.
+      render(wrap, poster(),
+        h('a', {
+          class: 'absolute inset-x-0 bottom-0 bg-base-100/90 text-xs text-primary px-3 py-2 flex items-center gap-1.5',
+          href: m.url, target: '_blank', rel: 'noopener',
+          onclick: (ev) => ev.stopPropagation(),
+        }, openInNewTabIcon(), h('span', {}, "Can't play here — open on the site")));
       toast(err.message, 'alert-error');
     } finally {
       wrap._loading = false;

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -2505,6 +2505,55 @@ function renderImportResults(response) {
 }
 
 // ---------- source templates ----------
+
+// Which service produces a template's feed. Aggy's own templates fetch the
+// site directly; the other two go through a bridge, and RSSHub's imported
+// catalog is large enough that saying so matters.
+const PROVIDER_BADGE = {
+  'Built-in': 'badge-primary',
+  'RSS-Bridge': 'badge-secondary',
+  'RSSHub': 'badge-accent',
+};
+
+// How the source will be read, when it isn't a plain feed.
+const KIND_BADGE = {
+  ytdlp: { label: 'Video', title: 'Read with yt-dlp: metadata only, nothing is downloaded' },
+  html: { label: 'Scraped', title: 'Read by applying CSS selectors to the page' },
+};
+
+function templateBadges(t) {
+  const badges = [];
+  if (t.provider) {
+    badges.push(h('span', {
+      class: `badge badge-sm ${PROVIDER_BADGE[t.provider] || 'badge-ghost'}`,
+      title: `Feed provided by ${t.provider}`,
+    }, t.provider));
+  }
+  const kind = KIND_BADGE[t.kind];
+  if (kind) {
+    badges.push(h('span', { class: 'badge badge-sm badge-outline', title: kind.title }, kind.label));
+  }
+  return badges;
+}
+
+// The line under a template's name: which site it pulls from, and what it
+// will ask for. Imported route names are often just "User posts", so the
+// domain is what tells two of them apart.
+function templateMeta(t) {
+  const bits = [];
+  if (t.site_domain) bits.push(t.site_domain);
+  const required = t.required_parameters || [];
+  if (required.length) {
+    bits.push(`needs ${required.join(', ')}`);
+  } else {
+    bits.push('no setup needed');
+  }
+  if (t.optional_parameter_count) {
+    bits.push(`${t.optional_parameter_count} optional`);
+  }
+  return h('div', { class: 'text-xs text-base-content/40 mt-0.5' }, bits.join(' · '));
+}
+
 function openAddSourceModal() {
   showModal('addSourceModal');
   clearTemplateSelection();
@@ -2528,7 +2577,10 @@ async function searchTemplates() {
         class: 'p-3 border-b border-base-300 last:border-b-0 cursor-pointer hover:bg-base-300 transition-colors',
         onclick: () => selectTemplate(t.name_hash),
       },
-        h('div', { class: 'font-medium text-sm' }, t.user_friendly_name || t.name),
+        h('div', { class: 'flex items-center gap-2 flex-wrap' },
+          h('span', { class: 'font-medium text-sm' }, t.user_friendly_name || t.name),
+          ...templateBadges(t)),
+        templateMeta(t),
         t.description && h('div', { class: 'text-xs text-base-content/50 line-clamp-2 mt-0.5' }, t.description))));
   } catch (err) {
     toast(err.message, 'alert-error');
@@ -2541,6 +2593,12 @@ async function selectTemplate(hash) {
     selectedTemplate = tmpl;
     // swap the modal from browse mode to a clean configure view
     $('addSourceTitle').textContent = `Configure ${tmpl.user_friendly_name || tmpl.name}`;
+    // keep the provenance visible while configuring: which service will fetch
+    // this, from which site, and how it will be read
+    render($('templateAbout'),
+      h('div', { class: 'flex items-center gap-2 flex-wrap' }, ...templateBadges(tmpl)),
+      tmpl.site_domain && h('div', { class: 'text-xs text-base-content/40 mt-1' }, tmpl.site_domain),
+      tmpl.description && h('div', { class: 'text-xs text-base-content/50 mt-1' }, tmpl.description));
     $('sourceTabs').classList.add('hidden');
     $('templateSearch').classList.add('hidden');
     $('templateList').classList.add('hidden');

--- a/src/api/static/js/app.js
+++ b/src/api/static/js/app.js
@@ -1075,12 +1075,57 @@ function linkCard(m) {
       h('div', { class: 'text-sm text-primary break-all line-clamp-2' }, m.url)));
 }
 
+// Video-site items keep no playable URL: the ones sites hand out are signed
+// and expire within hours, so one stored at ingest time would already be dead.
+// The thumbnail stands in until the viewer presses play, and only then does
+// the API resolve a stream that plays straight from the origin.
+function streamPlayer(m, itemHash) {
+  const wrap = h('div', { class: 'relative aspect-video w-full bg-base-300 cursor-pointer' });
+
+  const poster = () => [
+    m.poster && h('img', {
+      class: 'absolute inset-0 w-full h-full object-cover',
+      src: m.poster, alt: '', loading: 'lazy',
+      onerror: (e) => e.target.remove(),
+    }),
+    h('div', { class: 'absolute inset-0 grid place-items-center pointer-events-none' },
+      h('div', { class: 'aggy-play-badge' })),
+  ];
+
+  render(wrap, poster());
+  wrap.onclick = async (e) => {
+    e.stopPropagation(); // don't open the reader behind the player
+    if (wrap._loading || wrap._playing) return;
+    wrap._loading = true;
+    render(wrap, h('div', { class: 'absolute inset-0 grid place-items-center' }, spinner()));
+    try {
+      const stream = await sdk.itemStreamUrl({ item_url_hash: itemHash });
+      wrap._playing = true;
+      wrap.classList.remove('cursor-pointer');
+      render(wrap, h('video', {
+        class: 'absolute inset-0 w-full h-full', src: stream.url,
+        poster: stream.poster || m.poster || null,
+        controls: true, autoplay: true, playsinline: true,
+        onclick: (ev) => ev.stopPropagation(),
+      }));
+    } catch (err) {
+      render(wrap, poster());
+      toast(err.message, 'alert-error');
+    } finally {
+      wrap._loading = false;
+    }
+  };
+  return wrap;
+}
+
 // One media entry ({type, url, poster?}) -> element. Gifs autoplay muted
 // and loop like the reddit app; videos get controls, so their clicks must
 // reach the player instead of opening the reader.
-function mediaElement(m, cls = 'w-full max-h-[70vh] object-contain') {
+function mediaElement(m, cls = 'w-full max-h-[70vh] object-contain', itemHash = null) {
   // reddit link posts point off-site: show a preview card, not a media frame
   if (m.type === 'link') return linkCard(m);
+  // a video site's item: resolved to a playable URL on demand
+  if (m.type === 'stream') return streamPlayer(m, itemHash);
   // third-party players (e.g. redgifs) embed as an iframe; their clicks
   // never bubble, so they don't open the reader
   if (m.type === 'embed') {
@@ -1109,15 +1154,15 @@ function mediaElement(m, cls = 'w-full max-h-[70vh] object-contain') {
 
 // A media list -> single element or a swipeable snap-scrolling gallery
 // strip with an index badge.
-function mediaGallery(mediaList) {
-  if (mediaList.length === 1) return mediaElement(mediaList[0]);
+function mediaGallery(mediaList, itemHash = null) {
+  if (mediaList.length === 1) return mediaElement(mediaList[0], undefined, itemHash);
   const counter = h('div', {
     class: 'badge badge-neutral badge-sm absolute top-2 right-2 pointer-events-none',
   }, `1/${mediaList.length}`);
   const strip = h('div', { class: 'flex overflow-x-auto snap-x snap-mandatory' },
     mediaList.map((m) =>
       h('div', { class: 'w-full flex-none snap-center flex items-center justify-center bg-base-300' },
-        mediaElement(m))));
+        mediaElement(m, undefined, itemHash))));
   strip.addEventListener('scroll', () => {
     const index = Math.min(Math.round(strip.scrollLeft / strip.clientWidth) + 1, mediaList.length);
     counter.textContent = `${index}/${mediaList.length}`;
@@ -1139,7 +1184,7 @@ function itemCard(item, { listMode = false } = {}) {
   const mediaBlock = ytId
     ? h('figure', { class: 'bg-base-300 aggy-card-media' }, youtubeEmbed(ytId))
     : media
-    ? h('figure', { class: 'bg-base-300 aggy-card-media' }, mediaGallery(media))
+    ? h('figure', { class: 'bg-base-300 aggy-card-media' }, mediaGallery(media, item.item_hash))
     : imageUrl
       ? h('figure', { class: 'bg-base-300 aggy-card-media' },
           h('img', {
@@ -1482,7 +1527,7 @@ function openReader(item) {
     // the content's thumbnails would just duplicate the player
     parsed.root.querySelectorAll('img').forEach((img) => (img.closest('a') || img).remove());
   } else if (media.length) {
-    render(mediaHost, mediaGallery(media));
+    render(mediaHost, mediaGallery(media, item.item_hash));
   } else if (heroUrl) {
     render(mediaHost, h('img', {
       src: heroUrl, class: 'rounded-lg max-w-full max-h-[60vh] object-contain mx-auto',
@@ -1823,7 +1868,7 @@ const ANALYZE_FIELDS = [
 
 let analyzeState = null; // { suggestion, params } while the result step is open
 let analyzePreviewSeq = 0; // ignore out-of-order preview responses
-let detectedFeed = null; // { feed_url } while the feed-confirm step is open
+let detectedFeed = null; // { kind, url, template_name_hash } while the confirm step is open
 
 function resetAnalyzeTab() {
   analyzeState = null;
@@ -1870,10 +1915,21 @@ async function handleAddByUrl(e) {
     // First find out what we're dealing with: an RSS/Atom feed we can add
     // straight away, or a website that needs the selector analysis.
     const detected = await sdk.sourceAnalyzeDetect({ body: { url, cookie } });
-    if (detected.kind === 'feed') {
-      detectedFeed = { feed_url: detected.feed_url || url };
+    // Both a real feed and a recognized video listing skip the selector
+    // analysis entirely — they just need a name and a confirmation.
+    if (detected.kind === 'feed' || detected.kind === 'video') {
+      const isVideo = detected.kind === 'video';
+      detectedFeed = {
+        kind: detected.kind,
+        url: isVideo ? url : (detected.feed_url || url),
+        template_name_hash: detected.template_name_hash,
+      };
+      $('analyzeFeedNotice').textContent = isVideo
+        ? '✓ Recognized as a video listing — read as metadata only, nothing is downloaded.'
+        : '✓ Detected an RSS/Atom feed — no scraping needed.';
+      $('analyzeFeedUrlLabel').textContent = isVideo ? 'Listing URL' : 'Feed URL';
       $('analyzeFeedName').value = detected.suggested_source_name || '';
-      $('analyzeFeedUrl').textContent = detectedFeed.feed_url;
+      $('analyzeFeedUrl').textContent = detectedFeed.url;
       $('analyzeInputStep').classList.add('hidden');
       $('analyzeFeedStep').classList.remove('hidden');
       return;
@@ -1907,11 +1963,22 @@ async function handleAddDetectedFeed() {
   const btn = $('analyzeFeedAddBtn');
   btn.disabled = true;
   try {
-    await sdk.sourceCreate({
-      feed_name_hash: currentFeed.feed_name_hash,
-      source_name: name,
-      source_url: detectedFeed.feed_url,
-    });
+    if (detectedFeed.kind === 'video') {
+      await sdk.sourceTemplateCreate({
+        body: {
+          source_template_name_hash: detectedFeed.template_name_hash,
+          feed_hash: currentFeed.feed_name_hash,
+          source_name: name,
+          parameters: { url: detectedFeed.url },
+        },
+      });
+    } else {
+      await sdk.sourceCreate({
+        feed_name_hash: currentFeed.feed_name_hash,
+        source_name: name,
+        source_url: detectedFeed.url,
+      });
+    }
     closeModal('addSourceModal');
     toast(`Source "${name}" added`);
     resetAnalyzeTab();
@@ -2011,11 +2078,14 @@ const scheduleAnalyzePreview = debounce(loadAnalyzePreview, 500);
 async function loadAnalyzePreview() {
   if (!analyzeState) return;
   const seq = ++analyzePreviewSeq;
-  $('analyzePreviewStatus').textContent = 'rendering via rss-bridge…';
+  const rendered = !!analyzeState.suggestion.rendered;
+  $('analyzePreviewStatus').textContent = rendered
+    ? 'rendering in a headless browser…'
+    : 'rendering via rss-bridge…';
   render($('analyzePreview'), h('div', { class: 'p-6' }, spinner()));
   try {
     const preview = await sdk.sourceAnalyzePreview({
-      body: { parameters: analyzeState.params },
+      body: { parameters: analyzeState.params, rendered },
     });
     if (seq !== analyzePreviewSeq || !analyzeState) return;
     $('analyzePreviewStatus').textContent =
@@ -2054,14 +2124,27 @@ async function handleCreateAnalyzedSource() {
   const btn = $('analyzeAddBtn');
   btn.disabled = true;
   try {
-    await sdk.sourceTemplateCreate({
-      body: {
-        source_template_name_hash: analyzeState.suggestion.template_name_hash,
-        feed_hash: currentFeed.feed_name_hash,
-        source_name: name,
-        parameters: analyzeState.params,
-      },
-    });
+    if (analyzeState.suggestion.rendered) {
+      // the articles only exist after the page runs, so the source keeps its
+      // selectors and is scraped by aggy itself rather than by rss-bridge
+      await sdk.sourceCreateScraped({
+        body: {
+          feed_hash: currentFeed.feed_name_hash,
+          source_name: name,
+          parameters: analyzeState.params,
+          rendered: true,
+        },
+      });
+    } else {
+      await sdk.sourceTemplateCreate({
+        body: {
+          source_template_name_hash: analyzeState.suggestion.template_name_hash,
+          feed_hash: currentFeed.feed_name_hash,
+          source_name: name,
+          parameters: analyzeState.params,
+        },
+      });
+    }
     closeModal('addSourceModal');
     toast(`Source "${name}" added`);
     resetAnalyzeTab();

--- a/src/api/static/js/sdk.js
+++ b/src/api/static/js/sdk.js
@@ -145,6 +145,11 @@ class AggySDK {
     return this._request("POST", "/item/set_state", { query: { feed_hash, item_url_hash, score, is_read } });
   }
 
+  /** Resolve a currently-playable media URL for a video item */
+  async itemStreamUrl({ item_url_hash }) {
+    return this._request("GET", "/item/stream_url", { query: { item_url_hash } });
+  }
+
   /** Create a list */
   async listCreate({ list_name }) {
     return this._request("POST", "/list/create", { query: { list_name } });
@@ -183,6 +188,11 @@ class AggySDK {
   /** Add another feed as a source (shares its items and votes) */
   async sourceCreateFeed({ feed_name_hash, source_feed_name_hash }) {
     return this._request("POST", "/source/create_feed", { query: { feed_name_hash, source_feed_name_hash } });
+  }
+
+  /** Create a source that scrapes a web page with CSS selectors */
+  async sourceCreateScraped({ body }) {
+    return this._request("POST", "/source/create_scraped", { body });
   }
 
   /** Delete a source */

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -360,7 +360,7 @@
 
       <!-- Shown when the URL is detected to be an RSS/Atom feed -->
       <div id="analyzeFeedStep" class="hidden">
-        <p class="text-sm text-success mb-3">
+        <p class="text-sm text-success mb-3" id="analyzeFeedNotice">
           ✓ Detected an RSS/Atom feed — no scraping needed.
         </p>
         <div class="form-control mb-3">
@@ -368,7 +368,7 @@
           <input type="text" class="input input-bordered w-full" id="analyzeFeedName" placeholder="e.g. Hacker News" required>
         </div>
         <div class="form-control mb-3">
-          <label class="label"><span class="label-text">Feed URL</span></label>
+          <label class="label"><span class="label-text" id="analyzeFeedUrlLabel">Feed URL</span></label>
           <div class="text-xs text-base-content/50 break-all font-mono border border-base-300 rounded-lg p-2" id="analyzeFeedUrl"></div>
         </div>
         <div class="flex gap-2 justify-end mt-4">

--- a/src/api/templates/app.html
+++ b/src/api/templates/app.html
@@ -297,9 +297,10 @@
 
     <!-- Template Tab -->
     <div id="sourceTabTemplate">
-      <input type="text" class="input input-bordered w-full mb-3" id="templateSearch" placeholder="Search templates (e.g. Reddit, YouTube...)">
+      <input type="text" class="input input-bordered w-full mb-3" id="templateSearch" placeholder="Search templates by name, site, or provider (Reddit, youtube.com, RSSHub...)">
       <div class="max-h-[60vh] overflow-y-auto border border-base-300 rounded-lg" id="templateList"></div>
       <div id="templateParams" class="hidden mt-3">
+        <div id="templateAbout" class="mb-3"></div>
         <div class="form-control mb-3">
           <label class="label" for="templateSourceName"><span class="label-text">Source Name</span></label>
           <input type="text" class="input input-bordered w-full" id="templateSourceName" placeholder="Give this source a name" required>

--- a/src/api/tests/bridge/extract_test.py
+++ b/src/api/tests/bridge/extract_test.py
@@ -1,0 +1,122 @@
+from bridge.extract import extract_entries
+
+
+LISTING_HTML = """
+<html><body>
+  <nav><a href="/about">About</a></nav>
+  <div class="feed">
+    <article class="card">
+      <a class="link" href="/posts/one"><h3>First post</h3></a>
+      <img data-src="/thumbs/one.jpg" src="data:image/gif;base64,placeholder">
+      <span class="by">Alice</span>
+      <time datetime="2026-01-01T10:00:00+00:00">Jan 1</time>
+      <p>Some words about the first post.</p>
+    </article>
+    <article class="card">
+      <a class="link" href="https://elsewhere.example/two"><h3>Second post</h3></a>
+      <img srcset="https://cdn.example.com/two-small.jpg 400w, https://cdn.example.com/two.jpg 800w">
+      <span class="by">Bob</span>
+      <time datetime="2026-01-02T10:00:00+00:00">Jan 2</time>
+    </article>
+    <article class="card">
+      <h3>Third post, with no link at all</h3>
+    </article>
+  </div>
+</body></html>
+"""
+
+BASE_URL = "https://example.com/blog/"
+
+SELECTORS = {
+    "entry_element_selector": "article.card",
+    "title_selector": "h3",
+    "url_selector": "a.link",
+    "author_selector": "span.by",
+    "time_selector": "time",
+    "time_format": "Y-m-d\\TH:i:sP",
+}
+
+
+def test_extracts_titles_authors_and_absolute_urls():
+    entries = extract_entries(LISTING_HTML, BASE_URL, SELECTORS)
+
+    assert [entry["title"] for entry in entries] == ["First post", "Second post"]
+    assert [entry["author"] for entry in entries] == ["Alice", "Bob"]
+    # relative against the page, absolute left alone
+    assert entries[0]["url"] == "https://example.com/posts/one"
+    assert entries[1]["url"] == "https://elsewhere.example/two"
+
+
+def test_drops_entries_without_a_link():
+    """There'd be nothing to open, and nothing to deduplicate on."""
+    entries = extract_entries(LISTING_HTML, BASE_URL, SELECTORS)
+
+    assert all("no link at all" not in (entry["title"] or "") for entry in entries)
+
+
+def test_finds_lazy_loaded_thumbnails():
+    """Listing pages routinely leave `src` as a placeholder until the image
+    scrolls into view, with the real one in a data attribute."""
+    entries = extract_entries(LISTING_HTML, BASE_URL, SELECTORS)
+
+    assert entries[0]["image"] == "https://example.com/thumbs/one.jpg"
+
+
+def test_reads_the_first_srcset_candidate_when_there_is_no_src():
+    entries = extract_entries(LISTING_HTML, BASE_URL, SELECTORS)
+
+    assert entries[1]["image"] == "https://cdn.example.com/two-small.jpg"
+
+
+def test_parses_times_with_the_php_format_the_analyzer_chose():
+    entries = extract_entries(LISTING_HTML, BASE_URL, SELECTORS)
+
+    assert entries[0]["date_published"].year == 2026
+    assert entries[0]["date_published"].month == 1
+
+
+def test_a_time_format_that_does_not_parse_is_left_empty():
+    """Better a missing date than a wrong one; the bridge would abort the
+    whole render here."""
+    entries = extract_entries(
+        LISTING_HTML, BASE_URL, {**SELECTORS, "time_format": "d/m/Y"}
+    )
+
+    assert entries[0]["date_published"] is None
+
+
+def test_falls_back_to_the_link_text_when_the_title_selector_misses():
+    entries = extract_entries(
+        LISTING_HTML, BASE_URL, {**SELECTORS, "title_selector": "h9.nope"}
+    )
+
+    assert entries[0]["title"] == "First post"
+
+
+def test_entry_text_stands_in_for_the_article_body():
+    entries = extract_entries(LISTING_HTML, BASE_URL, SELECTORS)
+
+    assert "Some words about the first post." in entries[0]["text"]
+
+
+def test_limit_caps_the_entries_returned():
+    entries = extract_entries(LISTING_HTML, BASE_URL, {**SELECTORS, "limit": "1"})
+
+    assert len(entries) == 1
+
+
+def test_requires_an_entry_selector():
+    try:
+        extract_entries(LISTING_HTML, BASE_URL, {"title_selector": "h3"})
+    except Exception as e:
+        assert "entry selector" in str(e)
+    else:  # pragma: no cover - the call above must raise
+        raise AssertionError("expected a missing-selector error")
+
+
+def test_an_invalid_selector_matches_nothing_instead_of_raising():
+    entries = extract_entries(
+        LISTING_HTML, BASE_URL, {**SELECTORS, "entry_element_selector": "article.["}
+    )
+
+    assert entries == []

--- a/src/api/tests/bridge/rsshub_test.py
+++ b/src/api/tests/bridge/rsshub_test.py
@@ -119,3 +119,108 @@ def test_a_non_json_catalog_is_survivable(monkeypatch):
     monkeypatch.setattr(rsshub.requests, "get", lambda *a, **kw: _HtmlResponse())
 
     rsshub.rsshub_get_templates_job()
+
+
+# ---------- what a route's parameters should tell the user ----------
+
+
+def test_example_values_are_read_out_of_the_routes_example(monkeypatch):
+    """Without these a user has to guess what a segment wants, and a wrong
+    guess is often accepted by the route and only fails when it's fetched."""
+    monkeypatch.setattr(rsshub, "_base_url", lambda: "http://rsshub:1200")
+
+    template = rsshub.route_to_template(
+        "example",
+        NAMESPACE,
+        "/user/:uid/:language?",
+        {"name": "User posts", "example": "/example/user/12345/en"},
+    )
+
+    assert template.parameters["uid"].example == "12345"
+    assert template.parameters["language"].example == "en"
+
+
+def test_example_values_are_url_decoded(monkeypatch):
+    monkeypatch.setattr(rsshub, "_base_url", lambda: "http://rsshub:1200")
+
+    template = rsshub.route_to_template(
+        "example",
+        NAMESPACE,
+        "/category/:path",
+        {"name": "Category", "example": "/example/category/videos%2Frecent"},
+    )
+
+    assert template.parameters["path"].example == "videos/recent"
+
+
+def test_a_shorter_example_leaves_the_rest_without_one(monkeypatch):
+    """Examples routinely omit optional trailing segments."""
+    monkeypatch.setattr(rsshub, "_base_url", lambda: "http://rsshub:1200")
+
+    template = rsshub.route_to_template(
+        "example",
+        NAMESPACE,
+        "/user/:uid/:language?",
+        {"name": "User posts", "example": "/example/user/12345"},
+    )
+
+    assert template.parameters["uid"].example == "12345"
+    assert template.parameters["language"].example is None
+
+
+def test_a_parameter_with_known_values_becomes_a_dropdown(monkeypatch):
+    """So a value the route would reject can't be typed in the first place."""
+    monkeypatch.setattr(rsshub, "_base_url", lambda: "http://rsshub:1200")
+
+    template = rsshub.route_to_template(
+        "example",
+        NAMESPACE,
+        "/user/:language",
+        {
+            "name": "User posts",
+            "parameters": {
+                "language": {
+                    "description": "site language",
+                    "default": "www",
+                    "options": [
+                        {"value": "www", "label": "English"},
+                        {"value": "de", "label": "German"},
+                    ],
+                }
+            },
+        },
+    )
+
+    parameter = template.parameters["language"]
+    assert parameter.type.value == "select"
+    assert parameter.options == {"www": "English", "de": "German"}
+    assert parameter.default == "www"
+
+
+def test_options_given_as_a_mapping_are_understood(monkeypatch):
+    monkeypatch.setattr(rsshub, "_base_url", lambda: "http://rsshub:1200")
+
+    template = rsshub.route_to_template(
+        "example",
+        NAMESPACE,
+        "/user/:sort",
+        {"name": "User posts", "parameters": {"sort": {"options": {"new": "Newest"}}}},
+    )
+
+    assert template.parameters["sort"].options == {"new": "Newest"}
+
+
+def test_a_plain_string_parameter_description_still_works(monkeypatch):
+    monkeypatch.setattr(rsshub, "_base_url", lambda: "http://rsshub:1200")
+
+    template = rsshub.route_to_template(
+        "example",
+        NAMESPACE,
+        "/user/:uid",
+        {"name": "User posts", "parameters": {"uid": "the user's numeric id"}},
+    )
+
+    parameter = template.parameters["uid"]
+    assert parameter.title == "the user's numeric id"
+    assert parameter.type.value == "text"
+    assert parameter.options is None

--- a/src/api/tests/bridge/rsshub_test.py
+++ b/src/api/tests/bridge/rsshub_test.py
@@ -1,0 +1,121 @@
+from bridge import rsshub
+
+
+NAMESPACE = {
+    "name": "Example Site",
+    "url": "example.com",
+    "description": "An example namespace",
+}
+
+
+def _template(path, route=None, monkeypatch=None):
+    return rsshub.route_to_template(
+        "example", NAMESPACE, path, route or {"name": "User posts"}
+    )
+
+
+def test_route_parameters_become_template_parameters(monkeypatch):
+    monkeypatch.setattr(rsshub, "_base_url", lambda: "http://rsshub:1200")
+
+    template = _template("/user/:uid")
+
+    assert set(template.parameters) == {"uid"}
+    assert template.parameters["uid"].required is True
+    assert template.url_template == "http://rsshub:1200/example/user/{uid}"
+
+
+def test_optional_route_parameters_are_not_required(monkeypatch):
+    monkeypatch.setattr(rsshub, "_base_url", lambda: "http://rsshub:1200")
+
+    template = _template("/user/:uid/:category?")
+
+    assert template.parameters["uid"].required is True
+    assert template.parameters["category"].required is False
+
+
+def test_parameter_descriptions_are_carried_over(monkeypatch):
+    monkeypatch.setattr(rsshub, "_base_url", lambda: "http://rsshub:1200")
+
+    template = rsshub.route_to_template(
+        "example",
+        NAMESPACE,
+        "/user/:uid",
+        {"name": "User posts", "parameters": {"uid": "the user's numeric id"}},
+    )
+
+    assert template.parameters["uid"].title == "the user's numeric id"
+
+
+def test_object_shaped_parameter_descriptions_are_understood(monkeypatch):
+    monkeypatch.setattr(rsshub, "_base_url", lambda: "http://rsshub:1200")
+
+    template = rsshub.route_to_template(
+        "example",
+        NAMESPACE,
+        "/user/:uid",
+        {"name": "User posts", "parameters": {"uid": {"description": "numeric id"}}},
+    )
+
+    assert template.parameters["uid"].title == "numeric id"
+
+
+def test_the_namespace_becomes_the_template_context(monkeypatch):
+    """So the catalog reads "User posts (Example Site)", like rss-bridge's."""
+    monkeypatch.setattr(rsshub, "_base_url", lambda: "http://rsshub:1200")
+
+    template = _template("/user/:uid")
+
+    assert template.user_friendly_name == "User posts (Example Site)"
+
+
+def test_imported_templates_are_marked_so_they_can_be_cleaned_up(monkeypatch):
+    monkeypatch.setattr(rsshub, "_base_url", lambda: "http://rsshub:1200")
+
+    template = _template("/user/:uid")
+
+    assert template.bridge_short_name == "rsshub:example/user/:uid"
+
+
+def test_wildcard_routes_are_skipped(monkeypatch):
+    """Their free-form remainder has no sensible parameter form."""
+    monkeypatch.setattr(rsshub, "_base_url", lambda: "http://rsshub:1200")
+
+    assert _template("/user/*") is None
+
+
+def test_routes_with_too_many_parameters_are_skipped(monkeypatch):
+    monkeypatch.setattr(rsshub, "_base_url", lambda: "http://rsshub:1200")
+
+    assert _template("/a/:b/:c/:d/:e/:f/:g") is None
+
+
+def test_the_catalog_job_is_a_no_op_without_the_service(monkeypatch):
+    monkeypatch.setattr(rsshub, "is_configured", lambda: False)
+    dropped = []
+    monkeypatch.setattr(
+        rsshub, "_drop_imported_templates", lambda: dropped.append(True)
+    )
+
+    rsshub.rsshub_get_templates_job()
+
+    # the routes go away with the service rather than lingering as templates
+    # that could never be fetched
+    assert dropped == [True]
+
+
+def test_a_non_json_catalog_is_survivable(monkeypatch):
+    """Instances that don't serve the catalog answer with HTML; the generic
+    route template still works, so this must not raise."""
+    monkeypatch.setattr(rsshub, "is_configured", lambda: True)
+    monkeypatch.setattr(rsshub, "_base_url", lambda: "http://rsshub:1200")
+
+    class _HtmlResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            raise ValueError("not json")
+
+    monkeypatch.setattr(rsshub.requests, "get", lambda *a, **kw: _HtmlResponse())
+
+    rsshub.rsshub_get_templates_job()

--- a/src/api/tests/db/item_test.py
+++ b/src/api/tests/db/item_test.py
@@ -299,3 +299,35 @@ def test_add_image_embedding_skips_when_already_present(
     unique_item_strict.add_image_embedding("clip-model")
 
     post.assert_not_called()
+
+
+def test_titles_keep_their_ampersands(unique_item_strict):
+    """Sanitizing escapes as it goes, so unescaping first only handed it an
+    "&" to turn back into "&amp;" — which was then shown literally."""
+    item = unique_item_strict.model_copy(
+        update={"title": "Rock &amp; Roll &mdash; a history"}
+    )
+    item = ItemStrict(**item.dict())
+
+    assert item.title == "Rock & Roll — a history"
+
+
+def test_titles_still_have_their_markup_stripped(unique_item_strict):
+    item = ItemStrict(
+        **unique_item_strict.model_copy(
+            update={"title": "<b>Bold</b> and <i>italic</i>"}
+        ).dict()
+    )
+
+    assert item.title == "Bold and italic"
+
+
+def test_excerpts_and_authors_are_unescaped_too(unique_item_strict):
+    item = ItemStrict(
+        **unique_item_strict.model_copy(
+            update={"excerpt": "Ben &amp; Jerry", "author": "R&amp;D team"}
+        ).dict()
+    )
+
+    assert item.excerpt == "Ben & Jerry"
+    assert item.author == "R&D team"

--- a/src/api/tests/db/source_kind_test.py
+++ b/src/api/tests/db/source_kind_test.py
@@ -1,0 +1,148 @@
+import pytest
+
+from db.source import Source
+from db.source_template import SourceTemplate, SourceTemplateParameter
+
+
+def test_sources_are_rss_unless_told_otherwise(existing_source):
+    """Every source predating the other backends is a feed URL, and the
+    column default has to keep them that way."""
+    stored = Source.read(
+        user_hash=existing_source.user_hash,
+        feed_hash=existing_source.feed_hash,
+        source_hash=existing_source.name_hash,
+    )
+
+    assert stored.kind == "rss"
+    assert stored.config is None
+
+
+def test_kind_and_config_survive_a_round_trip(existing_feed):
+    selectors = {
+        "home_page": "https://example.com/blog/",
+        "entry_element_selector": "article.card",
+        "render": True,
+    }
+    source = Source(
+        user_hash=existing_feed.user_hash,
+        feed_hash=existing_feed.name_hash,
+        name="Scraped source",
+        url="https://example.com/blog/",
+        kind="html",
+        config=selectors,
+    )
+    source.create()
+
+    stored = Source.read(
+        user_hash=source.user_hash,
+        feed_hash=source.feed_hash,
+        source_hash=source.name_hash,
+    )
+
+    assert stored.kind == "html"
+    assert stored.config == selectors
+
+
+def test_update_replaces_a_scraped_sources_selectors(existing_feed):
+    source = Source(
+        user_hash=existing_feed.user_hash,
+        feed_hash=existing_feed.name_hash,
+        name="Scraped source",
+        url="https://example.com/blog/",
+        kind="html",
+        config={"entry_element_selector": "article.card"},
+    )
+    source.create()
+
+    source.update(
+        name=source.name,
+        url=str(source.url),
+        config={"entry_element_selector": "li.post"},
+    )
+
+    stored = Source.read(
+        user_hash=source.user_hash,
+        feed_hash=source.feed_hash,
+        source_hash=source.name_hash,
+    )
+    assert stored.config == {"entry_element_selector": "li.post"}
+
+
+def test_update_leaves_config_alone_when_it_is_not_given(existing_feed):
+    source = Source(
+        user_hash=existing_feed.user_hash,
+        feed_hash=existing_feed.name_hash,
+        name="Scraped source",
+        url="https://example.com/blog/",
+        kind="html",
+        config={"entry_element_selector": "article.card"},
+    )
+    source.create()
+
+    source.update(name="Renamed", url=str(source.url))
+
+    stored = Source.read(
+        user_hash=source.user_hash,
+        feed_hash=source.feed_hash,
+        source_hash=source.name_hash,
+    )
+    assert stored.config == {"entry_element_selector": "article.card"}
+
+
+# ---------- template parameter escaping ----------
+
+
+def _template(quote: str, url_template: str) -> SourceTemplate:
+    return SourceTemplate(
+        name=f"Test {quote}",
+        url="https://example.com",
+        url_template=url_template,
+        description="test",
+        parameters={
+            "value": SourceTemplateParameter(
+                name="Value", required=True, type="text", quote=quote
+            )
+        },
+    )
+
+
+def test_strict_parameters_cannot_escape_their_place_in_the_url():
+    template = _template("strict", "https://example.com/{value}/feed")
+
+    url = template.create_source_url(value="../../admin")
+
+    assert url == "https://example.com/..%2F..%2Fadmin/feed"
+
+
+def test_path_parameters_keep_their_slashes():
+    """A route is several path segments and has to stay that way."""
+    template = _template("path", "http://rsshub:1200/{value}")
+
+    url = template.create_source_url(value="github/issue/owner/repo")
+
+    assert url == "http://rsshub:1200/github/issue/owner/repo"
+
+
+def test_whole_url_parameters_are_used_verbatim():
+    template = _template("none", "{value}")
+
+    url = template.create_source_url(value="https://videos.example.com/c/x?sort=new")
+
+    assert url == "https://videos.example.com/c/x?sort=new"
+
+
+def test_whole_url_parameters_must_actually_be_urls():
+    """They skip escaping, so anything else would land in the URL unchecked."""
+    template = _template("none", "{value}")
+
+    with pytest.raises(Exception, match="must be a http"):
+        template.create_source_url(value="javascript:alert(1)")
+
+
+def test_template_kind_round_trips(unique_source_template):
+    unique_source_template.kind = "ytdlp"
+    unique_source_template.create()
+
+    stored = SourceTemplate.read(name_hash=unique_source_template.name_hash)
+
+    assert stored.kind == "ytdlp"

--- a/src/api/tests/db/source_template_catalog_test.py
+++ b/src/api/tests/db/source_template_catalog_test.py
@@ -1,0 +1,127 @@
+"""The catalog's labels: where a template comes from and what it will ask for.
+
+With RSSHub's route catalog imported alongside rss-bridge's bridges, the
+catalog holds templates from three different services, many with terse names
+like "User posts". These are what let a result be told apart from its
+neighbours.
+"""
+
+from constants import PROVIDER_BUILTIN, PROVIDER_RSSHUB, PROVIDER_RSS_BRIDGE
+from db.source_template import SourceTemplate, SourceTemplateParameter
+
+
+def _template(name, **kwargs) -> SourceTemplate:
+    defaults = {
+        "url": "https://example.com",
+        "description": "an example template",
+        "parameters": {},
+    }
+    return SourceTemplate(name=name, **{**defaults, **kwargs})
+
+
+# ---------- provider ----------
+
+
+def test_templates_without_a_bridge_are_aggys_own():
+    template = _template("Reddit Subreddit", url_template="https://reddit.com/r/{x}")
+
+    assert template.provider == PROVIDER_BUILTIN
+
+
+def test_bridge_templates_are_labelled_rss_bridge():
+    template = _template("Some Bridge", bridge_short_name="SomeBridge")
+
+    assert template.provider == PROVIDER_RSS_BRIDGE
+
+
+def test_imported_routes_are_labelled_rsshub():
+    template = _template("User posts", bridge_short_name="rsshub:example/user/:uid")
+
+    assert template.provider == PROVIDER_RSSHUB
+
+
+# ---------- the rest of the label ----------
+
+
+def test_site_domain_drops_the_www():
+    template = _template("Example", url="https://www.example.com/some/path")
+
+    assert template.site_domain == "example.com"
+
+
+def test_required_and_optional_parameters_are_counted_separately():
+    template = _template(
+        "Example",
+        parameters={
+            "uid": SourceTemplateParameter(name="User ID", required=True, type="text"),
+            "sort": SourceTemplateParameter(name="Sort", required=False, type="text"),
+            "limit": SourceTemplateParameter(name="Limit", required=False, type="text"),
+        },
+    )
+
+    assert template.required_parameters == ["User ID"]
+    assert template.optional_parameter_count == 2
+
+
+def test_a_template_needing_nothing_reports_no_required_parameters():
+    assert _template("Example").required_parameters == []
+
+
+def test_labels_are_serialized_for_the_catalog():
+    """The search endpoint returns the model itself, so the UI only sees
+    fields that serialize."""
+    template = _template("User posts", bridge_short_name="rsshub:example/user/:uid")
+
+    dumped = template.model_dump()
+
+    assert dumped["provider"] == PROVIDER_RSSHUB
+    assert dumped["site_domain"] == "example.com"
+    assert dumped["required_parameters"] == []
+
+
+# ---------- ordering ----------
+
+
+def _seed_catalog():
+    _template(
+        "Aardvark Feed",
+        bridge_short_name="rsshub:aardvark/feed",
+        url="https://aardvark.example",
+    ).create()
+    _template("Zebra Bridge", bridge_short_name="ZebraBridge").create()
+    _template("Zebra Builtin", url_template="https://zebra.example/{x}").create()
+
+
+def test_browsing_leads_with_aggys_own_templates():
+    """Alphabetical order alone buries six built-ins under thousands of
+    imported routes."""
+    _seed_catalog()
+
+    providers = [t.provider for t in SourceTemplate.search()]
+
+    assert providers == [PROVIDER_BUILTIN, PROVIDER_RSS_BRIDGE, PROVIDER_RSSHUB]
+
+
+def test_equally_good_matches_break_toward_the_more_reliable_provider():
+    _seed_catalog()
+
+    results = SourceTemplate.search("Zebra")
+
+    assert results[0].name == "Zebra Builtin"
+    assert results[1].name == "Zebra Bridge"
+
+
+def test_templates_are_searchable_by_provider():
+    _seed_catalog()
+
+    results = SourceTemplate.search("RSSHub")
+
+    assert results[0].provider == PROVIDER_RSSHUB
+
+
+def test_templates_are_searchable_by_site():
+    _seed_catalog()
+
+    results = SourceTemplate.search("aardvark.example")
+
+    assert results[0].name == "Aardvark Feed"

--- a/src/api/tests/ingest/backends_test.py
+++ b/src/api/tests/ingest/backends_test.py
@@ -370,3 +370,56 @@ def test_a_failed_feed_with_an_empty_body_still_reports_its_status(monkeypatch):
                 url="http://bridge.local/some/route",
             )
         )
+
+
+def test_a_bridge_error_page_is_reduced_to_its_error_line(monkeypatch):
+    """Bridges answer with a whole error page — greeting, apology, node
+    version, git hash. Only the labelled line is worth showing."""
+    monkeypatch.setattr(
+        rss_backend.requests,
+        "get",
+        lambda *a, **kw: _ErrorResponse(
+            503,
+            "<html><body>"
+            "<h1>Welcome to the bridge!</h1><p>Looks like something went wrong</p>"
+            "<p>Helpful Information</p>"
+            "<p>Error Message: TypeError: Cannot read properties of undefined</p>"
+            "<p>Route: /example/category/:cat</p>"
+            "<p>Node Version: v24.18.0</p>"
+            "<p>Git Hash: c0825f01</p>"
+            "</body></html>",
+        ),
+    )
+
+    with pytest.raises(Exception) as failure:
+        rss_backend.fetch_items(
+            Source(
+                user_hash="user",
+                feed_hash="feed",
+                name="Example",
+                url="http://bridge.local/example/category/public",
+            )
+        )
+
+    message = str(failure.value)
+    assert "TypeError: Cannot read properties of undefined" in message
+    assert "Welcome to the bridge" not in message
+    assert "Node Version" not in message
+
+
+def test_an_unlabelled_error_body_is_quoted_as_is(monkeypatch):
+    monkeypatch.setattr(
+        rss_backend.requests,
+        "get",
+        lambda *a, **kw: _ErrorResponse(500, "upstream refused the connection"),
+    )
+
+    with pytest.raises(Exception, match="upstream refused the connection"):
+        rss_backend.fetch_items(
+            Source(
+                user_hash="user",
+                feed_hash="feed",
+                name="Example",
+                url="http://bridge.local/some/route",
+            )
+        )

--- a/src/api/tests/ingest/backends_test.py
+++ b/src/api/tests/ingest/backends_test.py
@@ -459,7 +459,7 @@ def test_a_new_item_without_a_thumbnail_is_looked_up(monkeypatch):
 
     monkeypatch.setattr(ytdlp_backend.requests, "post", fake_post)
 
-    enriched = ytdlp_backend.enrich_new_item(_new_video_item())
+    enriched = ytdlp_backend.enrich_item(_new_video_item())
 
     assert captured["url"].endswith("/metadata")
     assert enriched.image_url == "https://videos.example.com/thumbs/abc123.jpg"
@@ -481,7 +481,7 @@ def test_an_item_that_already_has_a_thumbnail_is_left_alone(monkeypatch):
         update={"image_url": "https://videos.example.com/from-the-listing.jpg"}
     )
 
-    assert ytdlp_backend.enrich_new_item(item) is None
+    assert ytdlp_backend.enrich_item(item) is None
 
 
 def test_a_failed_lookup_keeps_the_item_as_it_was(monkeypatch):
@@ -493,7 +493,7 @@ def test_a_failed_lookup_keeps_the_item_as_it_was(monkeypatch):
         lambda *a, **kw: _FakeResponse({}, status_code=422, text="no metadata"),
     )
 
-    assert ytdlp_backend.enrich_new_item(_new_video_item()) is None
+    assert ytdlp_backend.enrich_item(_new_video_item()) is None
 
 
 def test_the_pipeline_only_enriches_items_it_has_not_seen(
@@ -511,7 +511,7 @@ def test_the_pipeline_only_enriches_items_it_has_not_seen(
     )
     monkeypatch.setattr(
         ytdlp_backend,
-        "enrich_new_item",
+        "enrich_item",
         lambda item: pytest.fail("a stored item should not be looked up again"),
     )
     monkeypatch.setattr(
@@ -523,4 +523,4 @@ def test_the_pipeline_only_enriches_items_it_has_not_seen(
 
 def test_a_backend_without_the_hook_is_fine(monkeypatch, existing_source):
     """Only some backends have anything to add."""
-    assert get_backend("rss").enrich_new_item(_new_video_item()) is None
+    assert get_backend("rss").enrich_item(_new_video_item()) is None

--- a/src/api/tests/ingest/backends_test.py
+++ b/src/api/tests/ingest/backends_test.py
@@ -1,0 +1,295 @@
+import pytest
+
+from db.item import ItemLoose
+from db.source import Source
+from ingest import source as ingest_source_module
+from ingest.backends import get_backend
+from ingest.backends import html as html_backend
+from ingest.backends import ytdlp as ytdlp_backend
+
+
+def test_get_backend_rejects_unknown_kind():
+    with pytest.raises(Exception, match="Unknown source kind"):
+        get_backend("carrier-pigeon")
+
+
+def test_rss_stays_the_default_backend():
+    assert get_backend("rss").enrich is True
+
+
+def test_video_backend_skips_per_item_scraping():
+    """Its listings already carry title/thumbnail/uploader, and the sites it
+    reaches refuse the anonymous fetches the scrapers would make."""
+    assert get_backend("ytdlp").enrich is False
+
+
+# ---------- video listings ----------
+
+
+SIDECAR_ENTRY = {
+    "url": "https://videos.example.com/watch/abc123",
+    "title": "An example upload",
+    "uploader": "Example Channel",
+    "thumbnail": "https://videos.example.com/thumbs/abc123.jpg",
+    "duration": 615,
+    "timestamp": 1767225600,
+    "view_count": 4096,
+}
+
+
+def test_entry_to_item_maps_listing_metadata():
+    item = ytdlp_backend.entry_to_item(SIDECAR_ENTRY)
+
+    assert str(item.url) == SIDECAR_ENTRY["url"]
+    assert item.title == "An example upload"
+    assert item.author == "Example Channel"
+    assert item.image_url == SIDECAR_ENTRY["thumbnail"]
+    assert item.domain == "videos.example.com"
+    assert item.date_published.year == 2026
+    # a listing pass has no description, so the title stands in for the body
+    # that ItemStrict requires
+    assert item.excerpt == "An example upload"
+
+
+def test_entry_to_item_stores_a_resolvable_stream_not_a_url():
+    """A stored media URL would be a signed URL that expires within hours, so
+    the item keeps its page URL and is resolved per playback instead."""
+    item = ytdlp_backend.entry_to_item(SIDECAR_ENTRY)
+
+    assert item.media == [
+        {
+            "type": "stream",
+            "url": SIDECAR_ENTRY["url"],
+            "poster": SIDECAR_ENTRY["thumbnail"],
+        }
+    ]
+
+
+def test_entry_to_item_falls_back_to_upload_date():
+    item = ytdlp_backend.entry_to_item(
+        {**SIDECAR_ENTRY, "timestamp": None, "upload_date": "20260114"}
+    )
+
+    assert (item.date_published.year, item.date_published.month) == (2026, 1)
+
+
+def test_entry_to_item_drops_entries_without_a_url():
+    assert ytdlp_backend.entry_to_item({"title": "no link"}) is None
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_code=200, text=""):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def _video_source(**kwargs) -> Source:
+    return Source(
+        user_hash="user",
+        feed_hash="feed",
+        name="Example listing",
+        url="https://videos.example.com/channel/example",
+        kind="ytdlp",
+        **kwargs,
+    )
+
+
+def test_video_backend_asks_the_sidecar_for_the_listing(monkeypatch):
+    monkeypatch.setattr(ytdlp_backend, "is_configured", lambda: True)
+    monkeypatch.setattr(ytdlp_backend.config, "get", lambda key, default=None: "svc")
+
+    captured = {}
+
+    def fake_post(url, json, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        return _FakeResponse({"entries": [SIDECAR_ENTRY]})
+
+    monkeypatch.setattr(ytdlp_backend.requests, "post", fake_post)
+
+    items = ytdlp_backend.fetch_items(_video_source(config={"limit": 5}))
+
+    assert captured["url"].endswith("/extract")
+    assert captured["json"]["url"] == "https://videos.example.com/channel/example"
+    assert captured["json"]["limit"] == 5
+    assert [item.title for item in items] == ["An example upload"]
+
+
+def test_video_backend_explains_an_unconfigured_service(monkeypatch):
+    monkeypatch.setattr(ytdlp_backend, "is_configured", lambda: False)
+
+    with pytest.raises(Exception, match="aggy-ytdlp"):
+        ytdlp_backend.fetch_items(_video_source())
+
+
+def test_video_backend_rejects_a_page_with_no_entries(monkeypatch):
+    monkeypatch.setattr(ytdlp_backend, "is_configured", lambda: True)
+    monkeypatch.setattr(ytdlp_backend.config, "get", lambda key, default=None: "svc")
+    monkeypatch.setattr(
+        ytdlp_backend.requests, "post", lambda *a, **kw: _FakeResponse({"entries": []})
+    )
+
+    with pytest.raises(Exception, match="No entries found"):
+        ytdlp_backend.fetch_items(_video_source())
+
+
+def test_is_supported_says_no_without_the_service(monkeypatch):
+    monkeypatch.setattr(ytdlp_backend, "is_configured", lambda: False)
+
+    assert ytdlp_backend.is_supported("https://videos.example.com/x") == {
+        "supported": False,
+        "extractor": None,
+    }
+
+
+# ---------- scraped pages ----------
+
+
+LISTING_HTML = """
+<html><body>
+  <div class="feed">
+    <article class="card">
+      <a class="link" href="/posts/one"><h3>First post</h3></a>
+      <img data-src="/thumbs/one.jpg" src="data:image/gif;base64,placeholder">
+      <span class="by">Alice</span>
+    </article>
+    <article class="card">
+      <a class="link" href="/posts/two"><h3>Second post</h3></a>
+      <img src="https://cdn.example.com/two.jpg">
+      <span class="by">Bob</span>
+    </article>
+  </div>
+</body></html>
+"""
+
+SELECTORS = {
+    "entry_element_selector": "article.card",
+    "title_selector": "h3",
+    "url_selector": "a.link",
+    "author_selector": "span.by",
+}
+
+
+def _scraped_source(config) -> Source:
+    return Source(
+        user_hash="user",
+        feed_hash="feed",
+        name="Example page",
+        url="https://example.com/blog/",
+        kind="html",
+        config=config,
+    )
+
+
+def test_scraped_backend_renders_when_the_source_says_so(monkeypatch):
+    rendered_for = []
+
+    def fake_render(url, cookie=""):
+        rendered_for.append((url, cookie))
+        return LISTING_HTML
+
+    monkeypatch.setattr(html_backend, "render_page", fake_render)
+
+    items = html_backend.fetch_items(
+        _scraped_source({**SELECTORS, "render": True, "cookie": "age=1"})
+    )
+
+    assert rendered_for == [("https://example.com/blog/", "age=1")]
+    assert [item.title for item in items] == ["First post", "Second post"]
+    # relative hrefs are resolved against the page
+    assert str(items[0].url) == "https://example.com/posts/one"
+    assert items[0].author == "Alice"
+
+
+def test_scraped_backend_fetches_plainly_when_rendering_is_off(monkeypatch):
+    monkeypatch.setattr(html_backend, "fetch_page", lambda url, cookie="": LISTING_HTML)
+    monkeypatch.setattr(
+        html_backend,
+        "render_page",
+        lambda *a, **kw: pytest.fail("should not have rendered"),
+    )
+
+    items = html_backend.fetch_items(_scraped_source(SELECTORS))
+
+    assert len(items) == 2
+
+
+def test_scraped_backend_reports_selectors_that_stopped_matching(monkeypatch):
+    monkeypatch.setattr(
+        html_backend, "fetch_page", lambda url, cookie="": "<html><body></body></html>"
+    )
+
+    with pytest.raises(Exception, match="no entries matching"):
+        html_backend.fetch_items(_scraped_source(SELECTORS))
+
+
+# ---------- the shared pipeline ----------
+
+
+def test_ingest_source_uses_the_backend_named_by_the_source(
+    monkeypatch, existing_source
+):
+    """The pipeline dispatches on the source's kind rather than assuming RSS."""
+    existing_source.kind = "ytdlp"
+    called = []
+
+    def fake_fetch(source):
+        called.append(source.name)
+        return [
+            ItemLoose(
+                url="https://videos.example.com/watch/xyz",
+                title="Fetched by the video backend",
+                domain="videos.example.com",
+                excerpt="x",
+                content="x",
+            )
+        ]
+
+    monkeypatch.setattr(ytdlp_backend, "fetch_items", fake_fetch)
+    # no embedding services configured in this test run
+    monkeypatch.setattr(
+        ingest_source_module.config, "get", lambda key, default=None: default
+    )
+
+    ingest_source_module.ingest_source(existing_source)
+
+    assert called == [existing_source.name]
+    assert [item.title for item in existing_source.query_items()] == [
+        "Fetched by the video backend"
+    ]
+
+
+def test_ingest_source_skips_scraping_for_backends_that_dont_want_it(
+    monkeypatch, existing_source
+):
+    existing_source.kind = "ytdlp"
+    monkeypatch.setattr(
+        ytdlp_backend,
+        "fetch_items",
+        lambda source: [
+            ItemLoose(
+                url="https://videos.example.com/watch/xyz",
+                title="Already complete",
+                domain="videos.example.com",
+                excerpt="x",
+                content="x",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        ingest_source_module.config, "get", lambda key, default=None: default
+    )
+    for scraper in ("ingest_open_graph_item", "ingest_mercury_item"):
+        monkeypatch.setattr(
+            ingest_source_module,
+            scraper,
+            lambda item: pytest.fail("enrichment should be skipped"),
+        )
+
+    ingest_source_module.ingest_source(existing_source)
+
+    assert len(existing_source.query_items()) == 1

--- a/src/api/tests/ingest/backends_test.py
+++ b/src/api/tests/ingest/backends_test.py
@@ -423,3 +423,104 @@ def test_an_unlabelled_error_body_is_quoted_as_is(monkeypatch):
                 url="http://bridge.local/some/route",
             )
         )
+
+
+# ---------- filling in what a listing pass didn't carry ----------
+
+
+def _new_video_item() -> ItemLoose:
+    return ItemLoose(
+        url="https://videos.example.com/watch/abc123",
+        title="An example upload",
+        domain="videos.example.com",
+        excerpt="An example upload",
+        content="An example upload",
+        media=[{"type": "stream", "url": "https://videos.example.com/watch/abc123"}],
+    )
+
+
+def test_a_new_item_without_a_thumbnail_is_looked_up(monkeypatch):
+    """Flat extraction is cheap because it never visits the items, so on many
+    sites an entry arrives with no picture at all."""
+    monkeypatch.setattr(ytdlp_backend, "is_configured", lambda: True)
+    monkeypatch.setattr(ytdlp_backend.config, "get", lambda key, default=None: "svc")
+
+    captured = {}
+
+    def fake_post(url, json, timeout):
+        captured["url"] = url
+        return _FakeResponse(
+            {
+                "thumbnail": "https://videos.example.com/thumbs/abc123.jpg",
+                "description": "A much better description",
+                "timestamp": 1767225600,
+            }
+        )
+
+    monkeypatch.setattr(ytdlp_backend.requests, "post", fake_post)
+
+    enriched = ytdlp_backend.enrich_new_item(_new_video_item())
+
+    assert captured["url"].endswith("/metadata")
+    assert enriched.image_url == "https://videos.example.com/thumbs/abc123.jpg"
+    # the player's poster is the same picture; without it the frame is blank
+    assert enriched.media[0]["poster"] == "https://videos.example.com/thumbs/abc123.jpg"
+    assert enriched.excerpt == "A much better description"
+    assert enriched.date_published.year == 2026
+
+
+def test_an_item_that_already_has_a_thumbnail_is_left_alone(monkeypatch):
+    monkeypatch.setattr(ytdlp_backend, "is_configured", lambda: True)
+    monkeypatch.setattr(
+        ytdlp_backend.requests,
+        "post",
+        lambda *a, **kw: pytest.fail("should not have looked anything up"),
+    )
+
+    item = _new_video_item().model_copy(
+        update={"image_url": "https://videos.example.com/from-the-listing.jpg"}
+    )
+
+    assert ytdlp_backend.enrich_new_item(item) is None
+
+
+def test_a_failed_lookup_keeps_the_item_as_it_was(monkeypatch):
+    monkeypatch.setattr(ytdlp_backend, "is_configured", lambda: True)
+    monkeypatch.setattr(ytdlp_backend.config, "get", lambda key, default=None: "svc")
+    monkeypatch.setattr(
+        ytdlp_backend.requests,
+        "post",
+        lambda *a, **kw: _FakeResponse({}, status_code=422, text="no metadata"),
+    )
+
+    assert ytdlp_backend.enrich_new_item(_new_video_item()) is None
+
+
+def test_the_pipeline_only_enriches_items_it_has_not_seen(
+    monkeypatch, existing_source, unique_item_strict
+):
+    """The visit costs a request per article, so it happens once — not on
+    every check of the listing."""
+    unique_item_strict.create()
+    existing_source.kind = "ytdlp"
+
+    monkeypatch.setattr(
+        ytdlp_backend,
+        "fetch_items",
+        lambda source: [ItemLoose(url=str(unique_item_strict.url))],
+    )
+    monkeypatch.setattr(
+        ytdlp_backend,
+        "enrich_new_item",
+        lambda item: pytest.fail("a stored item should not be looked up again"),
+    )
+    monkeypatch.setattr(
+        ingest_source_module.config, "get", lambda key, default=None: default
+    )
+
+    ingest_source_module.ingest_source(existing_source)
+
+
+def test_a_backend_without_the_hook_is_fine(monkeypatch, existing_source):
+    """Only some backends have anything to add."""
+    assert get_backend("rss").enrich_new_item(_new_video_item()) is None

--- a/src/api/tests/ingest/backends_test.py
+++ b/src/api/tests/ingest/backends_test.py
@@ -5,6 +5,7 @@ from db.source import Source
 from ingest import source as ingest_source_module
 from ingest.backends import get_backend
 from ingest.backends import html as html_backend
+from ingest.backends import rss as rss_backend
 from ingest.backends import ytdlp as ytdlp_backend
 
 
@@ -293,3 +294,79 @@ def test_ingest_source_skips_scraping_for_backends_that_dont_want_it(
     ingest_source_module.ingest_source(existing_source)
 
     assert len(existing_source.query_items()) == 1
+
+
+def test_ingest_source_attaches_an_item_another_source_already_stored(
+    monkeypatch, existing_source, unique_item_strict
+):
+    """Items are shared across sources, so one already in the table still has
+    to be attached here — it used to be dropped as a failed insert, leaving
+    the second source's feed empty."""
+    unique_item_strict.create()
+    assert existing_source.query_items() == []
+
+    monkeypatch.setattr(
+        rss_backend,
+        "fetch_items",
+        lambda source: [ItemLoose(url=str(unique_item_strict.url))],
+    )
+    monkeypatch.setattr(
+        ingest_source_module.config, "get", lambda key, default=None: default
+    )
+    for scraper in ("ingest_open_graph_item", "ingest_mercury_item"):
+        monkeypatch.setattr(ingest_source_module, scraper, lambda item: None)
+
+    ingest_source_module.ingest_source(existing_source)
+
+    assert [str(i.url) for i in existing_source.query_items()] == [
+        str(unique_item_strict.url)
+    ]
+
+
+# ---------- surfacing why a feed failed ----------
+
+
+class _ErrorResponse:
+    def __init__(self, status_code, text, content_type="text/html"):
+        self.status_code = status_code
+        self.text = text
+        self.content = text.encode()
+        self.headers = {"Content-Type": content_type}
+
+
+def test_a_failed_feed_quotes_what_the_server_said(monkeypatch):
+    """ "HTTP 503" alone tells a user nothing; bridges put the actual reason
+    in the body."""
+    monkeypatch.setattr(
+        rss_backend.requests,
+        "get",
+        lambda *a, **kw: _ErrorResponse(
+            503, "<html><body><p>this route is empty</p></body></html>"
+        ),
+    )
+
+    with pytest.raises(Exception, match="this route is empty"):
+        rss_backend.fetch_items(
+            Source(
+                user_hash="user",
+                feed_hash="feed",
+                name="Example",
+                url="http://bridge.local/some/route",
+            )
+        )
+
+
+def test_a_failed_feed_with_an_empty_body_still_reports_its_status(monkeypatch):
+    monkeypatch.setattr(
+        rss_backend.requests, "get", lambda *a, **kw: _ErrorResponse(502, "   ")
+    )
+
+    with pytest.raises(Exception, match="HTTP 502"):
+        rss_backend.fetch_items(
+            Source(
+                user_hash="user",
+                feed_hash="feed",
+                name="Example",
+                url="http://bridge.local/some/route",
+            )
+        )

--- a/src/api/tests/ingest/jobs_test.py
+++ b/src/api/tests/ingest/jobs_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from config import config
 from db.item import ItemLoose, ItemStrict
 from ingest import jobs
@@ -56,9 +58,7 @@ def test_rescrape_source_skips_unchanged_item(
     assert ranked == []
 
 
-def test_backfill_image_embeddings_embeds_missing(
-    monkeypatch, existing_item_strict
-):
+def test_backfill_image_embeddings_embeds_missing(monkeypatch, existing_item_strict):
     """The backfill embeds stored items whose preview image has no embedding for
     the current model, and persists the result."""
     config.set("IMAGE_EMBED_HOST", "image-embed")
@@ -92,3 +92,46 @@ def test_backfill_image_embeddings_noop_without_service(
     jobs.backfill_image_embeddings_job()
 
     assert called == []
+
+
+def test_rescrape_backfills_a_backends_own_metadata(
+    monkeypatch, existing_source, existing_item_strict
+):
+    """Items stored before the backend could top them up have no picture;
+    a re-collect is how they get one."""
+    existing_source.kind = "ytdlp"
+    existing_item_strict.update(image_url=None, media=[{"type": "stream", "url": "x"}])
+
+    from ingest.backends import ytdlp as ytdlp_backend
+
+    monkeypatch.setattr(
+        ytdlp_backend,
+        "enrich_item",
+        lambda item: item.model_copy(
+            update={"image_url": "https://videos.example.com/thumb.jpg"}
+        ),
+    )
+    monkeypatch.setattr(jobs.config, "get", lambda key, default=None: default)
+    monkeypatch.setattr("ranking.engine.rank_feed", lambda feed: None)
+
+    jobs.rescrape_source(existing_source)
+
+    assert (
+        ItemStrict.read(url_hash=existing_item_strict.url_hash).image_url
+        == "https://videos.example.com/thumb.jpg"
+    )
+
+
+def test_rescrape_skips_the_generic_scrapers_for_backends_that_refuse_them(
+    monkeypatch, existing_source, existing_item_strict
+):
+    existing_source.kind = "ytdlp"
+
+    for scraper in ("ingest_open_graph_item", "ingest_mercury_item"):
+        monkeypatch.setattr(
+            jobs, scraper, lambda item: pytest.fail("should not have scraped")
+        )
+    monkeypatch.setattr(jobs.config, "get", lambda key, default=None: default)
+    monkeypatch.setattr("ranking.engine.rank_feed", lambda feed: None)
+
+    jobs.rescrape_source(existing_source)

--- a/src/api/tests/routers/feed_test.py
+++ b/src/api/tests/routers/feed_test.py
@@ -230,6 +230,7 @@ def test_sources(client, existing_user, existing_feed, existing_source, token):
             "source_color": response.json()[0]["source_color"],
             "source_feed_hash": None,
             "source_feed_name": None,
+            "source_kind": "rss",
         }
     ]
     # a palette color was assigned at creation

--- a/src/api/tests/routers/source_backends_test.py
+++ b/src/api/tests/routers/source_backends_test.py
@@ -1,0 +1,323 @@
+import pytest
+
+from db.item import ItemStrict
+from db.source import Source
+from ingest.backends import ytdlp as ytdlp_backend
+from routers import source_analyze
+from tests.testing_utils import build_api_request_args
+
+
+@pytest.fixture(autouse=True)
+def _no_background_ingest(monkeypatch):
+    """Creating a source kicks off its first ingest; nothing here is about
+    that, and it would try to reach the network."""
+    monkeypatch.setattr("routers.source.ingest_source_now", lambda source: None)
+
+
+SELECTORS = {
+    "home_page": "https://example.com/blog/",
+    "entry_element_selector": "article.card",
+    "title_selector": "h3",
+    "url_selector": "a",
+    "limit": "10",
+}
+
+
+def test_create_scraped_source_stores_its_selectors(
+    client, existing_user, existing_feed, token
+):
+    args = build_api_request_args(
+        path="/source/create_scraped",
+        data={
+            "feed_hash": existing_feed.name_hash,
+            "source_name": "Example Blog",
+            "parameters": SELECTORS,
+            "rendered": True,
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+
+    assert response.status_code == 200
+    assert response.json()["source_kind"] == "html"
+
+    stored = Source.read(
+        user_hash=existing_user.name_hash,
+        feed_hash=existing_feed.name_hash,
+        source_hash=response.json()["source_name_hash"],
+    )
+    assert stored.kind == "html"
+    assert stored.config["entry_element_selector"] == "article.card"
+    # the page it scrapes is what gets fetched, and it must keep rendering
+    assert str(stored.url) == "https://example.com/blog/"
+    assert stored.config["render"] is True
+
+
+def test_create_scraped_source_needs_a_page_url(
+    client, existing_user, existing_feed, token
+):
+    args = build_api_request_args(
+        path="/source/create_scraped",
+        data={
+            "feed_hash": existing_feed.name_hash,
+            "source_name": "Example Blog",
+            "parameters": {"entry_element_selector": "article.card"},
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+
+    assert response.status_code == 422
+
+
+def test_create_scraped_source_rejects_a_duplicate_name(
+    client, existing_user, existing_feed, existing_source, token
+):
+    args = build_api_request_args(
+        path="/source/create_scraped",
+        data={
+            "feed_hash": existing_feed.name_hash,
+            "source_name": existing_source.name,
+            "parameters": SELECTORS,
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+
+    assert response.status_code == 409
+
+
+def test_updating_a_scraped_source_rewrites_its_selectors(
+    client, existing_user, existing_feed, token
+):
+    source = Source(
+        user_hash=existing_user.name_hash,
+        feed_hash=existing_feed.name_hash,
+        name="Example Blog",
+        url="https://example.com/blog/",
+        kind="html",
+        config={**SELECTORS, "render": True},
+    )
+    source.create()
+
+    args = build_api_request_args(
+        path="/source/update",
+        data={
+            "feed_name_hash": existing_feed.name_hash,
+            "source_name_hash": source.name_hash,
+            "source_name": "Example Blog",
+            "parameters": {**SELECTORS, "entry_element_selector": "li.post"},
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+
+    assert response.status_code == 200
+    stored = Source.read(
+        user_hash=existing_user.name_hash,
+        feed_hash=existing_feed.name_hash,
+        source_hash=source.name_hash,
+    )
+    assert stored.config["entry_element_selector"] == "li.post"
+
+
+# ---------- detection ----------
+
+
+def test_detect_offers_the_video_backend_for_a_recognized_listing(
+    client, existing_user, token, monkeypatch
+):
+    monkeypatch.setattr(
+        source_analyze,
+        "detect_source_type",
+        lambda url, cookie: {
+            "kind": "html",
+            "feed_url": None,
+            "suggested_source_name": "Example Channel",
+        },
+    )
+    monkeypatch.setattr(
+        source_analyze.ytdlp,
+        "is_supported",
+        lambda url: {"supported": True, "extractor": "ExampleSite"},
+    )
+
+    args = build_api_request_args(
+        path="/source_analyze/detect",
+        data={"url": "https://videos.example.com/c/example"},
+        token=token,
+    )
+    response = client.post(**args)
+
+    assert response.status_code == 200
+    assert response.json()["kind"] == "video"
+    assert response.json()["extractor"] == "ExampleSite"
+    assert response.json()["template_name_hash"]
+
+
+def test_detect_prefers_a_real_feed_over_extraction(
+    client, existing_user, token, monkeypatch
+):
+    """A feed is lighter on the site and needs no extra service."""
+    monkeypatch.setattr(
+        source_analyze,
+        "detect_source_type",
+        lambda url, cookie: {
+            "kind": "feed",
+            "feed_url": "https://videos.example.com/feed.xml",
+            "suggested_source_name": "Example Channel",
+        },
+    )
+    monkeypatch.setattr(
+        source_analyze.ytdlp,
+        "is_supported",
+        lambda url: pytest.fail("should not have asked about extraction"),
+    )
+
+    args = build_api_request_args(
+        path="/source_analyze/detect",
+        data={"url": "https://videos.example.com/c/example"},
+        token=token,
+    )
+    response = client.post(**args)
+
+    assert response.json()["kind"] == "feed"
+
+
+def test_detect_falls_back_to_extraction_when_the_page_cannot_be_fetched(
+    client, existing_user, token, monkeypatch
+):
+    """Sites that refuse anonymous fetches are exactly what the video backend
+    is for, so a failed fetch is not the end of the road."""
+
+    def refuse(url, cookie):
+        raise source_analyze.AnalyzeError("Couldn't fetch: 403", status_code=502)
+
+    monkeypatch.setattr(source_analyze, "detect_source_type", refuse)
+    monkeypatch.setattr(
+        source_analyze.ytdlp,
+        "is_supported",
+        lambda url: {"supported": True, "extractor": "ExampleSite"},
+    )
+
+    args = build_api_request_args(
+        path="/source_analyze/detect",
+        data={"url": "https://videos.example.com/c/example"},
+        token=token,
+    )
+    response = client.post(**args)
+
+    assert response.status_code == 200
+    assert response.json()["kind"] == "video"
+
+
+def test_detect_still_reports_a_fetch_failure_when_nothing_can_read_it(
+    client, existing_user, token, monkeypatch
+):
+    def refuse(url, cookie):
+        raise source_analyze.AnalyzeError("Couldn't fetch: 403", status_code=502)
+
+    monkeypatch.setattr(source_analyze, "detect_source_type", refuse)
+    monkeypatch.setattr(
+        source_analyze.ytdlp,
+        "is_supported",
+        lambda url: {"supported": False, "extractor": None},
+    )
+
+    args = build_api_request_args(
+        path="/source_analyze/detect",
+        data={"url": "https://example.com/blog"},
+        token=token,
+    )
+    response = client.post(**args)
+
+    assert response.status_code == 502
+
+
+# ---------- stream resolution ----------
+
+
+@pytest.fixture
+def video_item(existing_item_strict):
+    """An item as the video backend stores it: a page URL and a thumbnail,
+    with no playable URL of its own."""
+    existing_item_strict.update(
+        media=[
+            {
+                "type": "stream",
+                "url": str(existing_item_strict.url),
+                "poster": "https://videos.example.com/thumb.jpg",
+            }
+        ]
+    )
+    return ItemStrict.read(url_hash=existing_item_strict.url_hash)
+
+
+def test_stream_url_resolves_a_fresh_url_per_playback(
+    client, existing_user, video_item, token, monkeypatch
+):
+    monkeypatch.setattr(
+        ytdlp_backend,
+        "resolve_stream",
+        lambda url, cookie=None: {
+            "url": "https://cdn.example.com/signed.mp4?expires=soon",
+            "ext": "mp4",
+            "height": 720,
+        },
+    )
+
+    args = build_api_request_args(
+        path="/item/stream_url",
+        params={"item_url_hash": video_item.url_hash},
+        token=token,
+    )
+    response = client.get(**args)
+
+    assert response.status_code == 200
+    assert response.json()["url"] == "https://cdn.example.com/signed.mp4?expires=soon"
+    assert response.json()["height"] == 720
+
+
+def test_stream_url_refuses_items_that_have_no_stream(
+    client, existing_user, existing_item_strict, token
+):
+    args = build_api_request_args(
+        path="/item/stream_url",
+        params={"item_url_hash": existing_item_strict.url_hash},
+        token=token,
+    )
+    response = client.get(**args)
+
+    assert response.status_code == 422
+
+
+def test_stream_url_404s_for_an_unknown_item(client, existing_user, token):
+    args = build_api_request_args(
+        path="/item/stream_url", params={"item_url_hash": "nope"}, token=token
+    )
+    response = client.get(**args)
+
+    assert response.status_code == 404
+
+
+def test_stream_url_surfaces_a_resolution_failure(
+    client, existing_user, video_item, token, monkeypatch
+):
+    def fail(url, cookie=None):
+        raise Exception("No directly playable rendition is available")
+
+    monkeypatch.setattr(ytdlp_backend, "resolve_stream", fail)
+
+    args = build_api_request_args(
+        path="/item/stream_url",
+        params={"item_url_hash": video_item.url_hash},
+        token=token,
+    )
+    response = client.get(**args)
+
+    assert response.status_code == 502
+    assert "playable" in response.json()["detail"]

--- a/src/api/tests/routers/source_backends_test.py
+++ b/src/api/tests/routers/source_backends_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from db.item import ItemStrict
 from db.source import Source
+from db.source_template import SourceTemplate, SourceTemplateParameter
 from ingest.backends import ytdlp as ytdlp_backend
 from routers import source_analyze
 from tests.testing_utils import build_api_request_args
@@ -321,3 +322,122 @@ def test_stream_url_surfaces_a_resolution_failure(
 
     assert response.status_code == 502
     assert "playable" in response.json()["detail"]
+
+
+# ---------- a template's kind has to reach the source it creates ----------
+
+
+@pytest.fixture
+def video_template():
+    template = SourceTemplate(
+        name="Video Site Listing",
+        url="https://videos.example.com",
+        kind="ytdlp",
+        url_template="{url}",
+        description="a channel, playlist, or search page",
+        parameters={
+            "url": SourceTemplateParameter(
+                name="Listing URL", required=True, type="text", quote="none"
+            )
+        },
+    )
+    template.create()
+    yield template
+    template.delete()
+
+
+def test_a_video_template_creates_a_video_source(
+    client, existing_user, existing_feed, video_template, token
+):
+    """Without the kind, the listing page goes to the feed parser as if it
+    were RSS and the source fails on its first fetch."""
+    args = build_api_request_args(
+        path="/source_template/create",
+        data={
+            "source_template_name_hash": video_template.name_hash,
+            "feed_hash": existing_feed.name_hash,
+            "source_name": "Example channel",
+            "parameters": {"url": "https://videos.example.com/channel/example"},
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+
+    assert response.status_code == 200
+    assert response.json()["source_kind"] == "ytdlp"
+
+    stored = Source.read(
+        user_hash=existing_user.name_hash,
+        feed_hash=existing_feed.name_hash,
+        source_hash=response.json()["source_name_hash"],
+    )
+    assert stored.kind == "ytdlp"
+    assert str(stored.url) == "https://videos.example.com/channel/example"
+
+
+def test_a_feed_template_still_creates_a_feed_source(
+    client, existing_user, existing_feed, token
+):
+    template = SourceTemplate(
+        name="Example Feed",
+        url="https://example.com",
+        url_template="https://example.com/{path}/rss",
+        description="a plain feed",
+        parameters={
+            "path": SourceTemplateParameter(name="Path", required=True, type="text")
+        },
+    )
+    template.create()
+
+    args = build_api_request_args(
+        path="/source_template/create",
+        data={
+            "source_template_name_hash": template.name_hash,
+            "feed_hash": existing_feed.name_hash,
+            "source_name": "Example feed",
+            "parameters": {"path": "blog"},
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+
+    assert response.status_code == 200
+    assert response.json()["source_kind"] == "rss"
+
+
+def test_bulk_import_carries_a_templates_kind_too(
+    client, existing_user, existing_feed, video_template, token
+):
+    args = build_api_request_args(
+        path="/import/create",
+        data={
+            "sources": [
+                {
+                    "feed_name_hash": existing_feed.name_hash,
+                    "source_name": "Example channel",
+                    "template_name_hash": video_template.name_hash,
+                    "template_parameters": {
+                        "url": "https://videos.example.com/channel/example"
+                    },
+                }
+            ]
+        },
+        token=token,
+    )
+
+    response = client.post(**args)
+
+    assert response.status_code == 200
+    stored = Source.read(
+        user_hash=existing_user.name_hash,
+        feed_hash=existing_feed.name_hash,
+        source_hash=Source(
+            user_hash=existing_user.name_hash,
+            feed_hash=existing_feed.name_hash,
+            name="Example channel",
+            url="https://videos.example.com/channel/example",
+        ).name_hash,
+    )
+    assert stored.kind == "ytdlp"

--- a/src/render/app.py
+++ b/src/render/app.py
@@ -1,0 +1,133 @@
+"""Headless rendering service.
+
+Returns a page's HTML *after* its scripts have run. A plain HTTP GET only ever
+sees the server's response, which on a growing share of sites is an empty
+shell: the article list is built client-side, thumbnails sit in data
+attributes until they scroll into view, and a consent or age interstitial
+covers everything until it is dismissed.
+
+The service is internal: aggy-api is the only client, and it is not exposed
+in the bundled compose file.
+"""
+
+import logging
+import os
+from contextlib import asynccontextmanager
+from typing import Optional
+from urllib.parse import urlparse
+
+from fastapi import FastAPI, HTTPException
+from playwright.async_api import Error as PlaywrightError
+from playwright.async_api import async_playwright
+from pydantic import BaseModel
+
+DEFAULT_TIMEOUT_MS = 30_000
+MAX_TIMEOUT_MS = 60_000
+# Lazy-loading listings only fill in once the viewport passes them, so the
+# page is scrolled to the bottom in steps before its HTML is taken.
+SCROLL_STEPS = 8
+SCROLL_PAUSE_MS = 350
+
+USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/126.0 Safari/537.36"
+)
+
+_state: dict = {}
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    playwright = await async_playwright().start()
+    _state["playwright"] = playwright
+    # CHROMIUM_PATH points at a browser already on the machine, for images or
+    # hosts that ship their own instead of the one Playwright downloads.
+    executable = os.environ.get("CHROMIUM_PATH") or None
+    _state["browser"] = await playwright.chromium.launch(
+        args=["--no-sandbox", "--disable-dev-shm-usage"],
+        executable_path=executable,
+    )
+    logging.info("chromium launched")
+    yield
+    await _state["browser"].close()
+    await playwright.stop()
+
+
+app = FastAPI(title="aggy-render", lifespan=lifespan)
+
+
+class RenderRequest(BaseModel):
+    url: str
+    cookie: Optional[str] = None
+    # CSS selector to wait for before taking the HTML, when the caller knows
+    # which element carries the content.
+    wait_for: Optional[str] = None
+    scroll: bool = True
+    timeout_ms: int = DEFAULT_TIMEOUT_MS
+
+
+@app.get("/health")
+async def health() -> dict:
+    return {"status": "ok", "browser": bool(_state.get("browser"))}
+
+
+async def _scroll_through(page) -> None:
+    for step in range(1, SCROLL_STEPS + 1):
+        await page.evaluate(
+            "fraction => window.scrollTo(0, document.body.scrollHeight * fraction)",
+            step / SCROLL_STEPS,
+        )
+        await page.wait_for_timeout(SCROLL_PAUSE_MS)
+    await page.evaluate("window.scrollTo(0, 0)")
+
+
+@app.post("/render")
+async def render(request: RenderRequest) -> dict:
+    parsed = urlparse(request.url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise HTTPException(status_code=422, detail="URL must be http(s)")
+
+    timeout = max(1_000, min(request.timeout_ms or DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS))
+    browser = _state.get("browser")
+    if browser is None:
+        raise HTTPException(status_code=503, detail="Browser is not running")
+
+    # a fresh context per request: no cookie or storage bleed between sources
+    context = await browser.new_context(
+        user_agent=USER_AGENT,
+        locale="en-US",
+        viewport={"width": 1280, "height": 2000},
+    )
+    try:
+        if request.cookie:
+            await context.set_extra_http_headers({"Cookie": request.cookie})
+
+        page = await context.new_page()
+        try:
+            await page.goto(request.url, timeout=timeout, wait_until="domcontentloaded")
+            if request.wait_for:
+                await page.wait_for_selector(request.wait_for, timeout=timeout)
+            else:
+                # settle for the network going quiet, but don't fail the render
+                # when a page keeps a socket open forever (ads, analytics)
+                try:
+                    await page.wait_for_load_state("networkidle", timeout=5_000)
+                except PlaywrightError:
+                    pass
+            if request.scroll:
+                await _scroll_through(page)
+
+            return {
+                "html": await page.content(),
+                "url": page.url,
+                "title": await page.title(),
+            }
+        finally:
+            await page.close()
+    except PlaywrightError as e:
+        raise HTTPException(status_code=502, detail=str(e)[:500])
+    except Exception as e:
+        logging.exception(f"render failed for {request.url}")
+        raise HTTPException(status_code=500, detail=str(e)[:500])
+    finally:
+        await context.close()

--- a/src/render/dockerfile
+++ b/src/render/dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim AS aggy-render
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Chromium plus the system libraries it needs. This is what makes the image
+# large (~1GB); nothing else here is heavy.
+RUN playwright install --with-deps chromium
+
+COPY app.py .
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/src/render/requirements.txt
+++ b/src/render/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+playwright

--- a/src/ytdlp/app.py
+++ b/src/ytdlp/app.py
@@ -1,0 +1,231 @@
+"""Metadata-only extraction service for video sites.
+
+Wraps yt-dlp, which knows how to enumerate a channel, user, playlist, or
+search-results page on well over a thousand sites and how to get past the age
+and consent interstitials that stop a plain HTTP fetch. Two things it
+deliberately never does: download a video, or transcode one. ``/extract``
+lists a page's entries (titles, thumbnails, page URLs) and ``/resolve`` hands
+back a currently-playable URL for a single entry so the browser can stream it
+straight from the origin.
+
+The service is internal: aggy-api is the only client, and it is not exposed
+in the bundled compose file.
+"""
+
+import logging
+from typing import Optional
+from urllib.parse import urlparse
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from yt_dlp import YoutubeDL
+from yt_dlp.extractor import gen_extractor_classes
+from yt_dlp.utils import DownloadError
+
+app = FastAPI(title="aggy-ytdlp")
+
+MAX_LIMIT = 200
+DEFAULT_LIMIT = 30
+
+BASE_OPTIONS = {
+    "quiet": True,
+    "no_warnings": True,
+    "skip_download": True,
+    "noprogress": True,
+    # keep one bad entry in a listing from failing the whole page
+    "ignoreerrors": True,
+}
+
+
+class ExtractRequest(BaseModel):
+    url: str
+    limit: int = DEFAULT_LIMIT
+    cookie: Optional[str] = None
+
+
+class ResolveRequest(BaseModel):
+    url: str
+    cookie: Optional[str] = None
+
+
+def _validate(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise HTTPException(status_code=422, detail="URL must be http(s)")
+
+
+def _options(cookie: Optional[str], **extra) -> dict:
+    options = dict(BASE_OPTIONS, **extra)
+    if cookie:
+        options["http_headers"] = {"Cookie": cookie}
+    return options
+
+
+def _best_thumbnail(entry: dict) -> Optional[str]:
+    if entry.get("thumbnail"):
+        return entry["thumbnail"]
+    thumbnails = entry.get("thumbnails") or []
+    if not thumbnails:
+        return None
+    # widest wins; entries without dimensions sort last
+    best = max(
+        thumbnails, key=lambda t: (t.get("width") or 0, t.get("preference") or 0)
+    )
+    return best.get("url")
+
+
+def _entry_url(entry: dict) -> Optional[str]:
+    # flat entries carry the listing's link in `url`; a fully extracted one
+    # (a single video passed straight in) uses `webpage_url`
+    return entry.get("webpage_url") or entry.get("url")
+
+
+def _to_entry(raw: dict) -> Optional[dict]:
+    url = _entry_url(raw)
+    if not url or not str(url).startswith("http"):
+        return None
+    return {
+        "url": url,
+        "title": raw.get("title"),
+        "description": raw.get("description"),
+        "uploader": raw.get("uploader")
+        or raw.get("channel")
+        or raw.get("playlist_uploader"),
+        "thumbnail": _best_thumbnail(raw),
+        "duration": raw.get("duration"),
+        "timestamp": raw.get("timestamp"),
+        "upload_date": raw.get("upload_date"),
+        "view_count": raw.get("view_count"),
+        "extractor": raw.get("ie_key") or raw.get("extractor_key"),
+    }
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok"}
+
+
+class SupportedRequest(BaseModel):
+    url: str
+
+
+@app.post("/supported")
+def supported(request: SupportedRequest) -> dict:
+    """Whether a real extractor claims this URL.
+
+    Purely local pattern matching — no request is made to the site — so the
+    API can cheaply ask "is this a video listing?" while a user is typing a
+    URL. The catch-all "generic" extractor matches everything and is not a
+    useful answer, so it doesn't count.
+    """
+    _validate(request.url)
+
+    for extractor in gen_extractor_classes():
+        name = extractor.ie_key()
+        if name == "Generic":
+            continue
+        if extractor.suitable(request.url):
+            return {"supported": True, "extractor": name}
+    return {"supported": False, "extractor": None}
+
+
+@app.post("/extract")
+def extract(request: ExtractRequest) -> dict:
+    """List the entries of a channel / user / playlist / search page."""
+    _validate(request.url)
+    limit = max(1, min(request.limit or DEFAULT_LIMIT, MAX_LIMIT))
+
+    # extract_flat stops at the listing itself: one request per results page
+    # and no per-video extraction, which is both far faster and much lighter
+    # on the site than resolving every entry up front.
+    options = _options(
+        request.cookie,
+        extract_flat="in_playlist",
+        playlistend=limit,
+        lazy_playlist=True,
+    )
+
+    try:
+        with YoutubeDL(options) as ydl:
+            info = ydl.sanitize_info(ydl.extract_info(request.url, download=False))
+    except DownloadError as e:
+        raise HTTPException(status_code=422, detail=str(e)[:500])
+    except Exception as e:
+        logging.exception(f"extract failed for {request.url}")
+        raise HTTPException(status_code=500, detail=str(e)[:500])
+
+    if info is None:
+        raise HTTPException(status_code=422, detail="Nothing could be extracted")
+
+    raw_entries = info.get("entries")
+    if raw_entries is None:  # a single item rather than a listing
+        raw_entries = [info]
+
+    entries = [_to_entry(raw) for raw in raw_entries if raw]
+    return {
+        "title": info.get("title"),
+        "entries": [entry for entry in entries if entry][:limit],
+    }
+
+
+def _progressive_url(info: dict) -> Optional[dict]:
+    """A single URL playable in a browser `video` element.
+
+    Skips the split video-only/audio-only renditions that would need muxing,
+    and HLS/DASH manifests, neither of which a plain `video` tag can play
+    everywhere.
+    """
+    candidates = []
+    for fmt in info.get("formats") or []:
+        if not fmt.get("url"):
+            continue
+        if fmt.get("vcodec") in (None, "none") or fmt.get("acodec") in (None, "none"):
+            continue
+        if (fmt.get("protocol") or "") not in ("https", "http"):
+            continue
+        candidates.append(fmt)
+
+    if not candidates:
+        return None
+
+    best = max(candidates, key=lambda f: (f.get("height") or 0, f.get("tbr") or 0))
+    return {
+        "url": best["url"],
+        "ext": best.get("ext"),
+        "height": best.get("height"),
+        "protocol": best.get("protocol"),
+    }
+
+
+@app.post("/resolve")
+def resolve(request: ResolveRequest) -> dict:
+    """A currently-playable media URL for one page URL.
+
+    These URLs are usually signed and expire within hours, so callers are
+    expected to ask again per playback rather than store the result.
+    """
+    _validate(request.url)
+
+    try:
+        with YoutubeDL(_options(request.cookie, noplaylist=True)) as ydl:
+            info = ydl.sanitize_info(ydl.extract_info(request.url, download=False))
+    except DownloadError as e:
+        raise HTTPException(status_code=422, detail=str(e)[:500])
+    except Exception as e:
+        logging.exception(f"resolve failed for {request.url}")
+        raise HTTPException(status_code=500, detail=str(e)[:500])
+
+    if not info:
+        raise HTTPException(status_code=422, detail="Nothing could be extracted")
+
+    resolved = _progressive_url(info)
+    if resolved is None:
+        raise HTTPException(
+            status_code=422,
+            detail="No directly playable rendition is available for this item",
+        )
+
+    resolved["title"] = info.get("title")
+    resolved["duration"] = info.get("duration")
+    resolved["poster"] = _best_thumbnail(info)
+    return resolved

--- a/src/ytdlp/app.py
+++ b/src/ytdlp/app.py
@@ -34,6 +34,11 @@ BASE_OPTIONS = {
     "noprogress": True,
     # keep one bad entry in a listing from failing the whole page
     "ignoreerrors": True,
+    # Sites throttle, and a stalled TLS handshake otherwise hangs for the
+    # whole request budget and then fails the item outright.
+    "socket_timeout": 30,
+    "retries": 3,
+    "extractor_retries": 2,
 }
 
 
@@ -165,6 +170,44 @@ def extract(request: ExtractRequest) -> dict:
     return {
         "title": info.get("title"),
         "entries": [entry for entry in entries if entry][:limit],
+    }
+
+
+@app.post("/metadata")
+def metadata(request: ResolveRequest) -> dict:
+    """One item's own metadata, without resolving playable formats.
+
+    A flat listing pass is cheap precisely because it doesn't visit each
+    item, so on many sites it carries nothing but a URL and a title. This
+    fills in the rest — thumbnail above all — for an item worth the visit.
+    Format selection is skipped, so it still answers for items that have no
+    rendition a browser could play.
+    """
+    _validate(request.url)
+
+    try:
+        with YoutubeDL(_options(request.cookie, noplaylist=True)) as ydl:
+            info = ydl.extract_info(request.url, download=False, process=False)
+            info = ydl.sanitize_info(info)
+    except DownloadError as e:
+        raise HTTPException(status_code=422, detail=str(e)[:500])
+    except Exception as e:
+        logging.exception(f"metadata lookup failed for {request.url}")
+        raise HTTPException(status_code=500, detail=str(e)[:500])
+
+    if not info:
+        raise HTTPException(status_code=422, detail="Nothing could be extracted")
+
+    return {
+        "url": _entry_url(info) or request.url,
+        "title": info.get("title"),
+        "description": info.get("description"),
+        "uploader": info.get("uploader") or info.get("channel"),
+        "thumbnail": _best_thumbnail(info),
+        "duration": info.get("duration"),
+        "timestamp": info.get("timestamp"),
+        "upload_date": info.get("upload_date"),
+        "view_count": info.get("view_count"),
     }
 
 

--- a/src/ytdlp/dockerfile
+++ b/src/ytdlp/dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim AS aggy-ytdlp
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py .
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"
+
+# One worker: extraction is network-bound and FastAPI runs the sync handlers
+# in a threadpool, so a single process handles aggy's ingest volume fine.
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/src/ytdlp/requirements.txt
+++ b/src/ytdlp/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+# Extractors break whenever a site changes; this image is meant to be pulled
+# and rebuilt often, so the version is deliberately left unpinned.
+yt-dlp


### PR DESCRIPTION
## Why

Every source was, without exception, a URL that returns RSS/Atom — `ingest_source()` fetched it and handed the bytes to feedparser. Anything else had to be bent through rss-bridge, which fetches pages with a plain HTTP GET. That leaves whole categories of site unreachable:

- listings built client-side (the raw HTML has no articles in it)
- thumbnails held in `data-src` until they scroll into view
- paginated channel/search pages that aren't feed-shaped at all
- pages behind an age or consent interstitial that a plain fetch never gets past

## What changed

Sources now name the backend that reads them (`kind`), with per-source settings in `config`. Existing sources default to `rss` and behave exactly as before; dedupe, scraping, embedding, and storage stay in one shared pipeline.

| kind | reads | needs |
| --- | --- | --- |
| `rss` | fetch + feedparser (unchanged, moved as-is) | — |
| `ytdlp` | a channel / user / playlist / search-results page | `aggy-ytdlp` |
| `html` | a page, via its own CSS selectors | `aggy-render` (only when rendering) |

**`ytdlp` — metadata only.** Listings are read with yt-dlp's `extract_flat`: one request per results page, no per-item extraction, nothing downloaded. Sites hand out signed URLs that expire within hours, so an item stores its *page* URL and a `stream` media entry; `GET /item/stream_url` resolves a playable URL per playback and the browser streams it from the origin. Nothing is proxied, and no expiring URL is ever persisted.

**`html` — the same extractor for preview and ingest.** Selectors are applied in-process over HTML from the headless renderer when the source needs it, so what a user approves in the preview is what the source actually produces. The extractor also reads the lazy-loading spellings of `src`.

**RSSHub joins rss-bridge as a second bridge.** Its route catalog is imported into the source-template search every 12 hours; routes are marked so they can be cleaned up, and they disappear with the service rather than lingering as templates that could never be fetched.

**The add-a-source flow ties it together.** `/detect` recognizes a video listing (local pattern matching — the site is never contacted) and falls back to it when a page refuses to be fetched at all; selector analysis retries against rendered HTML when the raw response has no article list, and the resulting source is saved as scraped rather than as an rss-bridge template.

Both sidecars are optional: an unset host means that source kind isn't offered, and analysis falls back to a plain fetch.

## Notable details

- **Template parameter escaping** gained a policy (`strict` / `path` / `none`). A route is several path segments and must keep its slashes; a whole-URL parameter can't be escaped at all, so it is checked to be `http(s)` instead. Ordinary values still can't smuggle a `/` into the URL and escape their position in it.
- **`aggy-render` accepts `CHROMIUM_PATH`**, for hosts that ship their own browser instead of the one Playwright downloads.
- **yt-dlp is deliberately unpinned** in the sidecar's requirements: extractors break whenever a site changes, and the point of the separate image is pulling updates without rebuilding the API.

## Migration

`V14__source_ingest_backends.sql` adds `sources.kind` (default `'rss'`), `sources.config`, and `source_templates.kind`. Additive with defaults, so existing rows keep working untouched.

## Testing

- 58 new tests: backend registry and dispatch, listing→item mapping, selector extraction (lazy images, time formats, invalid selectors, missing links), RSSHub route conversion, kind/config round-trips, escaping policies, and the new endpoints.
- Full suite: **397 passed**, against 339 before. The 16 failures on this branch are the same 16 that fail on `main` in my environment (naive/aware datetime comparisons, config and network dependencies) — no change from baseline.
- Both sidecars smoke-tested live: `/supported`, `/extract`, and `/resolve` against a real channel, and the headless path end-to-end against a locally served JavaScript-built listing (rendered → extracted, with lazy thumbnails resolved to absolute URLs).
- `generate_sdk.py --check` passes; `ruff check` and `ruff format` clean on all touched files.

## Reviewer notes

- `_progressive_url` deliberately skips split video/audio renditions and HLS/DASH manifests, since a plain `<video>` can't play them everywhere. Sites offering only those will 422 on resolve — worth deciding later whether to fall back to opening the page instead of surfacing an error.
- The `html` backend is only reached for sources created *after* an analysis that needed rendering. Existing CSS-selector sources keep going through rss-bridge, so this PR doesn't move them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FRckAbSvEZ7Bn69TUNgjG

---
_Generated by [Claude Code](https://claude.ai/code/session_016FRckAbSvEZ7Bn69TUNgjG)_